### PR TITLE
test(@schematics/angular): add additional test coverage for jasmine-to-vitest schematic

### DIFF
--- a/packages/schematics/angular/refactor/jasmine-vitest/index_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/index_spec.ts
@@ -1,0 +1,149 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+import { Schema as ApplicationOptions } from '../../application/schema';
+import { Schema as WorkspaceOptions } from '../../workspace/schema';
+
+describe('Jasmine to Vitest Schematic', () => {
+  const schematicRunner = new SchematicTestRunner(
+    '@schematics/angular',
+    require.resolve('../../collection.json'),
+  );
+
+  let appTree: UnitTestTree;
+
+  const workspaceOptions: WorkspaceOptions = {
+    name: 'workspace',
+    newProjectRoot: 'projects',
+    version: '20.0.0',
+  };
+
+  const appOptions: ApplicationOptions = {
+    name: 'bar',
+    inlineStyle: false,
+    inlineTemplate: false,
+    routing: false,
+    skipTests: false,
+    skipPackageJson: false,
+  };
+
+  beforeEach(async () => {
+    appTree = await schematicRunner.runSchematic('workspace', workspaceOptions);
+    appTree = await schematicRunner.runSchematic('application', appOptions, appTree);
+  });
+
+  it('should transform a basic Jasmine test file', async () => {
+    const specFilePath = 'projects/bar/src/app/app.spec.ts';
+    const content = `
+      describe('AppComponent', () => {
+        it('should create the app', () => {
+          const service = { myMethod: () => {} };
+          spyOn(service, 'myMethod');
+          service.myMethod();
+          expect(service.myMethod).toHaveBeenCalled();
+        });
+      });
+    `;
+    appTree.overwrite(specFilePath, content);
+
+    const tree = await schematicRunner.runSchematic(
+      'jasmine-to-vitest',
+      { project: 'bar' },
+      appTree,
+    );
+
+    const newContent = tree.readContent(specFilePath);
+    expect(newContent).toContain(`vi.spyOn(service, 'myMethod');`);
+  });
+
+  it('should only transform files matching the fileSuffix option', async () => {
+    const specFilePath = 'projects/bar/src/app/app.spec.ts';
+    const specFileContent = `
+      describe('AppComponent', () => {
+        it('should test something', () => {
+          spyOn(window, 'alert');
+        });
+      });
+    `;
+    appTree.overwrite(specFilePath, specFileContent);
+
+    const testFilePath = 'projects/bar/src/app/app.test.ts';
+    const testFileContent = `
+      describe('AppComponent Test', () => {
+        it('should test another thing', () => {
+          spyOn(window, 'confirm');
+        });
+      });
+    `;
+    appTree.create(testFilePath, testFileContent);
+
+    const tree = await schematicRunner.runSchematic(
+      'jasmine-to-vitest',
+      { project: 'bar', fileSuffix: '.test.ts' },
+      appTree,
+    );
+
+    const unchangedContent = tree.readContent(specFilePath);
+    expect(unchangedContent).toContain(`spyOn(window, 'alert');`);
+    expect(unchangedContent).not.toContain(`vi.spyOn(window, 'alert');`);
+
+    const changedContent = tree.readContent(testFilePath);
+    expect(changedContent).toContain(`vi.spyOn(window, 'confirm');`);
+  });
+
+  it('should print verbose logs when the verbose option is true', async () => {
+    const specFilePath = 'projects/bar/src/app/app.spec.ts';
+    const content = `
+      describe('AppComponent', () => {
+        it('should create the app', () => {
+          const service = { myMethod: () => {} };
+          spyOn(service, 'myMethod');
+        });
+      });
+    `;
+    appTree.overwrite(specFilePath, content);
+
+    const logs: string[] = [];
+    schematicRunner.logger.subscribe((entry) => logs.push(entry.message));
+
+    await schematicRunner.runSchematic(
+      'jasmine-to-vitest',
+      { project: 'bar', verbose: true },
+      appTree,
+    );
+
+    expect(logs).toContain('Detailed Transformation Log:');
+    expect(logs).toContain(`Processing: /${specFilePath}`);
+    expect(logs.some((log) => log.includes('Transformed `spyOn` to `vi.spyOn`'))).toBe(true);
+  });
+
+  it('should print a summary report after running', async () => {
+    const specFilePath = 'projects/bar/src/app/app.spec.ts';
+    const content = `
+      describe('AppComponent', () => {
+        it('should create the app', () => {
+          const service = { myMethod: () => {} };
+          jasmine.spyOnAllFunctions(service);
+        });
+      });
+    `;
+    appTree.overwrite(specFilePath, content);
+
+    const logs: string[] = [];
+    schematicRunner.logger.subscribe((entry) => logs.push(entry.message));
+
+    await schematicRunner.runSchematic('jasmine-to-vitest', { include: specFilePath }, appTree);
+
+    expect(logs).toContain('Jasmine to Vitest Refactoring Summary:');
+    expect(logs).toContain('- 1 test file(s) scanned.');
+    expect(logs).toContain('- 1 file(s) transformed.');
+    expect(logs).toContain('- 1 TODO(s) added for manual review:');
+    expect(logs).toContain('  - 1x spyOnAllFunctions');
+  });
+});

--- a/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.integration_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.integration_spec.ts
@@ -1,0 +1,457 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { logging } from '@angular-devkit/core';
+import { format } from 'prettier';
+import { transformJasmineToVitest } from './test-file-transformer';
+import { RefactorReporter } from './utils/refactor-reporter';
+
+async function expectTransformation(input: string, expected: string): Promise<void> {
+  const logger = new logging.NullLogger();
+  const reporter = new RefactorReporter(logger);
+  const transformed = transformJasmineToVitest('spec.ts', input, reporter);
+  const formattedTransformed = await format(transformed, { parser: 'typescript' });
+  let formattedExpected = await format(expected, { parser: 'typescript' });
+  // Strip blank lines to avoid test failures due to cosmetic differences.
+  formattedExpected = formattedExpected.replace(/\n\s*\n/g, '\n');
+
+  expect(formattedTransformed).toBe(formattedExpected);
+}
+
+describe('Jasmine to Vitest Transformer - Integration Tests', () => {
+  it('should transform a basic component test file', async () => {
+    const jasmineCode = `
+      import { ComponentFixture, TestBed } from '@angular/core/testing';
+      import { MyComponent } from './my.component';
+      import { MyService } from './my.service';
+
+      describe('MyComponent', () => {
+        let component: MyComponent;
+        let fixture: ComponentFixture<MyComponent>;
+        let myService: MyService;
+
+        beforeEach(() => {
+          TestBed.configureTestingModule({
+            declarations: [MyComponent],
+            providers: [MyService],
+          });
+
+          fixture = TestBed.createComponent(MyComponent);
+          component = fixture.componentInstance;
+          myService = TestBed.inject(MyService);
+          spyOn(myService, 'getValue').and.returnValue('mock value');
+        });
+
+        it('should create', () => {
+          expect(component).toBeTruthy();
+        });
+
+        it('should get value from service on init', () => {
+          fixture.detectChanges();
+          expect(myService.getValue).toHaveBeenCalled();
+          expect(component.value).toBe('mock value');
+        });
+
+        it('should handle user click', () => {
+          spyOn(window, 'alert');
+          const button = fixture.nativeElement.querySelector('button');
+          button.click();
+          fixture.detectChanges();
+          expect(window.alert).toHaveBeenCalledWith('button clicked');
+        });
+
+        xit('a skipped test', () => {
+          // This test is skipped
+        });
+      });
+    `;
+
+    const vitestCode = `
+      import { ComponentFixture, TestBed } from '@angular/core/testing';
+      import { MyComponent } from './my.component';
+      import { MyService } from './my.service';
+
+      describe('MyComponent', () => {
+        let component: MyComponent;
+        let fixture: ComponentFixture<MyComponent>;
+        let myService: MyService;
+
+        beforeEach(() => {
+          TestBed.configureTestingModule({
+            declarations: [MyComponent],
+            providers: [MyService],
+          });
+
+          fixture = TestBed.createComponent(MyComponent);
+          component = fixture.componentInstance;
+          myService = TestBed.inject(MyService);
+          vi.spyOn(myService, 'getValue').mockReturnValue('mock value');
+        });
+
+        it('should create', () => {
+          expect(component).toBeTruthy();
+        });
+
+        it('should get value from service on init', () => {
+          fixture.detectChanges();
+          expect(myService.getValue).toHaveBeenCalled();
+          expect(component.value).toBe('mock value');
+        });
+
+        it('should handle user click', () => {
+          vi.spyOn(window, 'alert');
+          const button = fixture.nativeElement.querySelector('button');
+          button.click();
+          fixture.detectChanges();
+          expect(window.alert).toHaveBeenCalledWith('button clicked');
+        });
+
+        it.skip('a skipped test', () => {
+          // This test is skipped
+        });
+      });
+    `;
+
+    await expectTransformation(jasmineCode, vitestCode);
+  });
+
+  it('should transform a service test with async operations and timer mocks', async () => {
+    const jasmineCode = `
+      import { TestBed } from '@angular/core/testing';
+      import { MyService } from './my.service';
+
+      describe('MyService', () => {
+        let service: MyService;
+
+        beforeEach(() => {
+          TestBed.configureTestingModule({
+            providers: [MyService],
+          });
+          service = TestBed.inject(MyService);
+          jasmine.clock().install();
+        });
+
+        afterEach(() => {
+          jasmine.clock().uninstall();
+        });
+
+        it('should do something async with done', (done) => {
+          service.fetchData().then(data => {
+            expect(data).toEqual({ value: 'real data' });
+            done();
+          });
+        });
+
+        it('should handle timeouts', () => {
+          let value = '';
+          setTimeout(() => {
+            value = 'done';
+          }, 1000);
+
+          jasmine.clock().tick(500);
+          expect(value).toBe('');
+          jasmine.clock().tick(500);
+          expect(value).toBe('done');
+        });
+
+        fit('a focused test for async behavior', async () => {
+          const promise = Promise.resolve('resolved');
+          await expectAsync(promise).toBeResolvedTo('resolved');
+        });
+      });
+    `;
+
+    const vitestCode = `
+      import { TestBed } from '@angular/core/testing';
+      import { MyService } from './my.service';
+
+      describe('MyService', () => {
+        let service: MyService;
+
+        beforeEach(() => {
+          TestBed.configureTestingModule({
+            providers: [MyService],
+          });
+          service = TestBed.inject(MyService);
+          vi.useFakeTimers();
+        });
+
+        afterEach(() => {
+          vi.useRealTimers();
+        });
+
+        it('should do something async with done', async () => {
+          await service.fetchData().then(data => {
+            expect(data).toEqual({ value: 'real data' });
+          });
+        });
+
+        it('should handle timeouts', () => {
+          let value = '';
+          setTimeout(() => {
+            value = 'done';
+          }, 1000);
+
+          vi.advanceTimersByTime(500);
+          expect(value).toBe('');
+          vi.advanceTimersByTime(500);
+          expect(value).toBe('done');
+        });
+
+        it.only('a focused test for async behavior', async () => {
+          const promise = Promise.resolve('resolved');
+          await expect(promise).resolves.toEqual('resolved');
+        });
+      });
+    `;
+
+    await expectTransformation(jasmineCode, vitestCode);
+  });
+
+  it('should transform a file with complex spies and matchers', async () => {
+    const jasmineCode = `
+      describe('Complex Scenarios', () => {
+        let serviceMock;
+
+        beforeEach(() => {
+          serviceMock = jasmine.createSpyObj('MyService', {
+            getData: jasmine.any(String),
+            process: undefined,
+          });
+        });
+
+        it('should use asymmetric matchers correctly', () => {
+          const result = serviceMock.getData();
+          expect(result).toEqual(jasmine.any(String));
+          expect({ foo: 'bar', baz: 'qux' }).toEqual(jasmine.objectContaining({ foo: 'bar' }));
+        });
+
+        it('should handle array contents checking', () => {
+          const arr = [1, 2, 3];
+          expect(arr).toEqual(jasmine.arrayWithExactContents([3, 2, 1]));
+        });
+
+        it('should handle spy call order', () => {
+          const spyA = jasmine.createSpy('spyA');
+          const spyB = jasmine.createSpy('spyB');
+          spyA();
+          spyB();
+          expect(spyA).toHaveBeenCalledBefore(spyB);
+        });
+
+        it('should handle called once with', () => {
+          serviceMock.process('data');
+          expect(serviceMock.process).toHaveBeenCalledOnceWith('data');
+        });
+
+        it('should handle spy inspection', () => {
+            serviceMock.process('arg1', 'arg2');
+            expect(serviceMock.process.calls.mostRecent().args).toEqual(['arg1', 'arg2']);
+            expect(serviceMock.process.calls.count()).toBe(1);
+        });
+      });
+    `;
+
+    const vitestCode = `
+      describe('Complex Scenarios', () => {
+        let serviceMock;
+
+        beforeEach(() => {
+          serviceMock = {
+            getData: vi.fn().mockReturnValue(expect.any(String)),
+            process: vi.fn().mockReturnValue(undefined),
+          };
+        });
+
+        it('should use asymmetric matchers correctly', () => {
+          const result = serviceMock.getData();
+          expect(result).toEqual(expect.any(String));
+          expect({ foo: 'bar', baz: 'qux' }).toEqual(expect.objectContaining({ foo: 'bar' }));
+        });
+
+        it('should handle array contents checking', () => {
+          const arr = [1, 2, 3];
+          expect(arr).toHaveLength(3);
+          expect(arr).toEqual(expect.arrayContaining([3, 2, 1]));
+        });
+
+        it('should handle spy call order', () => {
+          const spyA = vi.fn();
+          const spyB = vi.fn();
+          spyA();
+          spyB();
+          expect(Math.min(...vi.mocked(spyA).mock.invocationCallOrder)).toBeLessThan(Math.min(...vi.mocked(spyB).mock.invocationCallOrder));
+        });
+
+        it('should handle called once with', () => {
+          serviceMock.process('data');
+          expect(serviceMock.process).toHaveBeenCalledTimes(1);
+          expect(serviceMock.process).toHaveBeenCalledWith('data');
+        });
+
+        it('should handle spy inspection', () => {
+            serviceMock.process('arg1', 'arg2');
+            expect(vi.mocked(serviceMock.process).mock.lastCall).toEqual(['arg1', 'arg2']);
+            expect(vi.mocked(serviceMock.process).mock.calls.length).toBe(1);
+        });
+      });
+    `;
+
+    await expectTransformation(jasmineCode, vitestCode);
+  });
+
+  it('should handle various other Jasmine APIs', async () => {
+    const jasmineCode = `
+      describe('Miscellaneous APIs', () => {
+        let el: HTMLElement;
+
+        beforeEach(() => {
+          el = document.createElement('div');
+          jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+        });
+
+        it('should handle DOM matchers like toHaveClass', () => {
+          el.classList.add('my-class');
+          expect(el).withContext('element should have my-class').toHaveClass('my-class');
+          el.classList.remove('my-class');
+          expect(el).not.toHaveClass('my-class');
+        });
+
+        it('should handle pending tests', () => {
+          pending('This test is not yet implemented.');
+        });
+
+        it('should handle fail()', () => {
+          if (true) {
+            fail('This should not have happened');
+          }
+        });
+
+        it('should handle spyOnProperty', () => {
+          const obj = { get myProp() { return 'original'; } };
+          spyOnProperty(obj, 'myProp', 'get').and.returnValue('mocked');
+          expect(obj.myProp).toBe('mocked');
+        });
+
+        it('should handle spies throwing errors', () => {
+          const spy = jasmine.createSpy('mySpy').and.throwError('Test Error');
+          expect(() => spy()).toThrowError('Test Error');
+        });
+      });
+    `;
+
+    const vitestCode = `
+      describe('Miscellaneous APIs', () => {
+        let el: HTMLElement;
+
+        beforeEach(() => {
+          el = document.createElement('div');
+          vi.setConfig({ testTimeout: 10000 });
+        });
+
+        it('should handle DOM matchers like toHaveClass', () => {
+          el.classList.add('my-class');
+          expect(el.classList.contains('my-class'), 'element should have my-class').toBe(true);
+          el.classList.remove('my-class');
+          expect(el.classList.contains('my-class')).toBe(false);
+        });
+
+        it.skip('should handle pending tests', () => {
+          // TODO: vitest-migration: The pending() function was converted to a skipped test (\`it.skip\`).
+          // pending('This test is not yet implemented.');
+        });
+
+        it('should handle fail()', () => {
+          if (true) {
+            throw new Error('This should not have happened');
+          }
+        });
+
+        it('should handle spyOnProperty', () => {
+          const obj = { get myProp() { return 'original'; } };
+          vi.spyOn(obj, 'myProp', 'get').mockReturnValue('mocked');
+          expect(obj.myProp).toBe('mocked');
+        });
+
+        it('should handle spies throwing errors', () => {
+          const spy = vi.fn().mockImplementation(() => { throw new Error('Test Error') });
+          expect(() => spy()).toThrowError('Test Error');
+        });
+      });
+    `;
+
+    await expectTransformation(jasmineCode, vitestCode);
+  });
+
+  it('should add TODOs for unsupported Jasmine features', async () => {
+    const jasmineCode = `
+      describe('Unsupported Features', () => {
+        beforeAll(() => {
+          jasmine.addMatchers({
+            toBeAwesome: () => ({
+              compare: (actual) => ({ pass: actual === 'awesome' })
+            })
+          });
+        });
+
+        it('should use a custom matcher', () => {
+          // This will not be transformed, but a TODO should be present.
+          expect('awesome').toBeAwesome();
+        });
+
+        it('should handle spyOnAllFunctions', () => {
+          const myObj = { func1: () => {}, func2: () => {} };
+          jasmine.spyOnAllFunctions(myObj);
+          myObj.func1();
+          expect(myObj.func1).toHaveBeenCalled();
+        });
+
+        it('should handle unknown jasmine properties', () => {
+          const env = jasmine.getEnv();
+          env.configure({ random: false });
+        });
+      });
+    `;
+
+    /* eslint-disable max-len */
+    const vitestCode = `
+      describe('Unsupported Features', () => {
+        beforeAll(() => {
+          // TODO: vitest-migration: jasmine.addMatchers is not supported. Please manually migrate to expect.extend().
+          jasmine.addMatchers({
+            toBeAwesome: () => ({
+              compare: (actual) => ({ pass: actual === 'awesome' })
+            })
+          });
+        });
+
+        it('should use a custom matcher', () => {
+          // This will not be transformed, but a TODO should be present.
+          expect('awesome').toBeAwesome();
+        });
+
+        it('should handle spyOnAllFunctions', () => {
+          const myObj = { func1: () => {}, func2: () => {} };
+          // TODO: vitest-migration: Vitest does not have a direct equivalent for jasmine.spyOnAllFunctions(). Please spy on individual methods manually using vi.spyOn().
+          jasmine.spyOnAllFunctions(myObj);
+          myObj.func1();
+          expect(myObj.func1).toHaveBeenCalled();
+        });
+
+        it('should handle unknown jasmine properties', () => {
+          // TODO: vitest-migration: Unsupported jasmine property "getEnv" found. Please migrate this manually.
+          const env = jasmine.getEnv();
+          env.configure({ random: false });
+        });
+      });
+    `;
+    /* eslint-enable max-len */
+
+    await expectTransformation(jasmineCode, vitestCode);
+  });
+});

--- a/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer_spec.ts
@@ -1,0 +1,219 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { logging } from '@angular-devkit/core';
+import { format } from 'prettier';
+import { transformJasmineToVitest } from './test-file-transformer';
+import { RefactorReporter } from './utils/refactor-reporter';
+
+async function expectTransformation(input: string, expected: string): Promise<void> {
+  const logger = new logging.NullLogger();
+  const reporter = new RefactorReporter(logger);
+  const transformed = transformJasmineToVitest('spec.ts', input, reporter);
+  const formattedTransformed = await format(transformed, { parser: 'typescript' });
+  const formattedExpected = await format(expected, { parser: 'typescript' });
+
+  expect(formattedTransformed).toBe(formattedExpected);
+}
+
+describe('Jasmine to Vitest Transformer', () => {
+  describe('Nested Transformations', () => {
+    const testCases = [
+      {
+        description: 'should handle nested transforms like a spy returning an asymmetric matcher',
+        input: `spyOn(service, 'getValue').and.returnValue(jasmine.any(Number));`,
+        expected: `vi.spyOn(service, 'getValue').mockReturnValue(expect.any(Number));`,
+      },
+      {
+        description: 'should handle expectAsync resolving to an asymmetric matcher',
+        input: `await expectAsync(myPromise).toBeResolvedTo(jasmine.any(Number));`,
+        expected: `await expect(myPromise).resolves.toEqual(expect.any(Number));`,
+      },
+      {
+        description:
+          'should handle spying on a property that returns a promise and using expectAsync',
+        input: `
+          spyOnProperty(service, 'myProp', 'get').and.returnValue(Promise.resolve(42));
+          await expectAsync(service.myProp).toBeResolvedTo(42);
+        `,
+        expected: `
+          vi.spyOn(service, 'myProp', 'get').mockReturnValue(Promise.resolve(42));
+          await expect(service.myProp).resolves.toEqual(42);
+        `,
+      },
+      {
+        description: 'should handle a done callback that also uses timer mocks',
+        input: `
+          it('should handle timers and async', (done) => {
+            jasmine.clock().install();
+            setTimeout(() => {
+              expect(true).toBe(true);
+              jasmine.clock().uninstall();
+              done();
+            }, 100);
+            jasmine.clock().tick(100);
+          });
+        `,
+        expected: `
+          it('should handle timers and async', async () => {
+            vi.useFakeTimers();
+            setTimeout(() => {
+              expect(true).toBe(true);
+              vi.useRealTimers();
+            }, 100);
+            vi.advanceTimersByTime(100);
+          });
+        `,
+      },
+      {
+        description: 'should handle toHaveBeenCalledOnceWith using an asymmetric matcher',
+        input: `expect(mySpy).toHaveBeenCalledOnceWith(jasmine.objectContaining({ id: 1 }));`,
+        expected: `
+          expect(mySpy).toHaveBeenCalledTimes(1);
+          expect(mySpy).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }));
+        `,
+      },
+      {
+        description: 'should handle withContext combined with a multi-statement matcher',
+        input: `expect(mySpy).withContext('custom message').toHaveBeenCalledOnceWith('foo');`,
+        expected: `
+          expect(mySpy, 'custom message').toHaveBeenCalledTimes(1);
+          expect(mySpy, 'custom message').toHaveBeenCalledWith('foo');
+        `,
+      },
+      {
+        description: 'should handle createSpyObj with complex return values',
+        input: `const spy = jasmine.createSpyObj('MyService', { getPromise: Promise.resolve(jasmine.any(String)) });`,
+        expected: `
+          const spy = {
+            getPromise: vi.fn().mockReturnValue(Promise.resolve(expect.any(String))),
+          };
+        `,
+      },
+      {
+        description: 'should handle arrayWithExactContents containing nested asymmetric matchers',
+        input: `expect(myArray).toEqual(jasmine.arrayWithExactContents([jasmine.objectContaining({ id: 1 })]));`,
+        expected: `
+          expect(myArray).toHaveLength(1);
+          expect(myArray).toEqual(expect.arrayContaining([expect.objectContaining({ id: 1 })]));
+        `,
+      },
+      {
+        description: 'should handle a spy rejecting with an asymmetric matcher',
+        input: `spyOn(service, 'myMethod').and.rejectWith(jasmine.objectContaining({ code: 'ERROR' }));`,
+        expected: `vi.spyOn(service, 'myMethod').mockRejectedValue(expect.objectContaining({ code: 'ERROR' }));`,
+      },
+      {
+        description: 'should handle a complex spy object with a property map and subsequent spyOn',
+        input: `
+          const myService = jasmine.createSpyObj('MyService', ['methodA'], { propA: 'valueA' });
+          spyOn(myService, 'methodA').and.returnValue('mocked value');
+          myService.methodA('test');
+          expect(myService.methodA).toHaveBeenCalledWith('test');
+        `,
+        expected: `
+          const myService = {
+            methodA: vi.fn(),
+            propA: 'valueA'
+          };
+          vi.spyOn(myService, 'methodA').mockReturnValue('mocked value');
+          myService.methodA('test');
+          expect(myService.methodA).toHaveBeenCalledWith('test');
+        `,
+      },
+    ];
+
+    testCases.forEach(({ description, input, expected }) => {
+      it(description, async () => {
+        await expectTransformation(input, expected);
+      });
+    });
+  });
+
+  describe('Comment Preservation', () => {
+    const testCases = [
+      {
+        description: 'should preserve a comment before a spy',
+        input: `
+          // This is an important spy
+          spyOn(service, 'myMethod').and.returnValue(true);
+        `,
+        expected: `
+          // This is an important spy
+          vi.spyOn(service, 'myMethod').mockReturnValue(true);
+        `,
+      },
+      {
+        description: 'should preserve a multi-line comment between chained calls',
+        input: `
+          spyOn(service, 'myMethod')
+            /*
+             * This spy needs to return a specific value.
+             */
+            .and.returnValue(true);
+        `,
+        expected: `
+          vi.spyOn(service, 'myMethod')
+            /*
+             * This spy needs to return a specific value.
+             */
+            .mockReturnValue(true);
+        `,
+        skipped: true,
+      },
+      {
+        description: 'should preserve a trailing comment on a matcher line',
+        input: `
+          expect(mySpy).toHaveBeenCalledWith('foo'); // Trailing comment
+        `,
+        expected: `
+          expect(mySpy).toHaveBeenCalledWith('foo'); // Trailing comment
+        `,
+      },
+      {
+        description: 'should preserve comments inside a done callback function',
+        input: `
+          it('should do something async', (done) => {
+            // Start the async operation
+            setTimeout(() => {
+              // It's done now
+              done();
+            }, 100);
+          });
+        `,
+        expected: `
+          it('should do something async', async () => {
+            // Start the async operation
+            setTimeout(() => {
+              // It's done now
+            }, 100);
+          });
+        `,
+      },
+      {
+        description: 'should preserve comments around a multi-statement transformation',
+        input: `
+          // Check if the spy was called correctly
+          expect(mySpy).toHaveBeenCalledOnceWith('foo');
+        `,
+        expected: `
+          // Check if the spy was called correctly
+          expect(mySpy).toHaveBeenCalledTimes(1);
+          expect(mySpy).toHaveBeenCalledWith('foo');
+        `,
+        skipped: true,
+      },
+    ];
+
+    testCases.forEach(({ description, input, expected, skipped }) => {
+      (skipped ? xit : it)(description, async () => {
+        await expectTransformation(input, expected);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This commit adds new tests for the `jasmine-to-vitest` refactoring schematic to increase test coverage and better validate its behavior during complex transformations.

The new tests include:
- **Integration Tests:** A new `test-file-transformer.integration_spec.ts` file validates the end-to-end transformation of various realistic test file scenarios, such as component tests, service tests with async operations, and complex spies and matchers.
- **Unit Tests:** A new `test-file-transformer_spec.ts` file focuses on unit-testing specific transformation capabilities, including nested transformations and the preservation of comments during refactoring.
- **Schematic Runner Tests:** A new `index_spec.ts` file provides tests for the schematic runner itself, verifying options like `fileSuffix` and `verbose` logging, and the generation of the summary report.