### PR TITLE
refactor(@angular/build): refine rolldown advanced chunking strategy

### DIFF
--- a/packages/angular/build/src/builders/application/chunk-optimizer.ts
+++ b/packages/angular/build/src/builders/application/chunk-optimizer.ts
@@ -253,7 +253,7 @@ export async function optimizeChunks(
 
     const result = await bundle.generate({
       minify: { mangle: false, compress: false },
-      advancedChunks: { minSize: 8192 },
+      advancedChunks: { groups: [{ name: 'chunks' }], minSize: 8 * 1024, maxSize: 512 * 1024 },
       sourcemap,
       chunkFileNames: (chunkInfo) => `${chunkInfo.name.replace(/-[a-zA-Z0-9]{8}$/, '')}-[hash].js`,
     });


### PR DESCRIPTION
Updates the experimental `advancedChunks` configuration for Rolldown to improve chunking behavior and web performance. This change introduces a `maxSize` of 512 KB and a named `group` to the configuration. The `maxSize` helps prevent overly large JavaScript bundles that can harm load performance by blocking the main thread.