### PR TITLE
build: switch to @aspect_rules_jasmine for jasmine_test

### DIFF
--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -1,6 +1,6 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", _copy_to_bin = "copy_to_bin")
+load("@aspect_rules_jasmine//jasmine:defs.bzl", _jasmine_test = "jasmine_test")
 load("@aspect_rules_js//js:defs.bzl", _js_binary = "js_binary")
-load("@devinfra//bazel/jasmine:jasmine.bzl", _jasmine_test = "jasmine_test")
 load("@devinfra//bazel/ts_project:index.bzl", "strict_deps_test")
 load("@rules_angular//src/ng_package:index.bzl", _ng_package = "ng_package")
 load("@rules_angular//src/ts_project:index.bzl", _ts_project = "ts_project")
@@ -59,15 +59,21 @@ def ng_package(deps = [], extra_substitutions = {}, **kwargs):
         **kwargs
     )
 
-def jasmine_test(args = [], tsconfig = "//:test-tsconfig", **kwargs):
+def jasmine_test(data = [], args = [], **kwargs):
+    # Create relative path to root, from current package dir. Necessary as
+    # we change the `chdir` below to the package directory.
+    relative_to_root = "/".join([".."] * len(native.package_name().split("/")))
+
     _jasmine_test(
         node_modules = "//:node_modules",
-        tsconfig = tsconfig,
         chdir = native.package_name(),
         args = [
+            "--require=%s/node_modules/source-map-support/register.js" % relative_to_root,
+            # Escape so that the `js_binary` launcher triggers Bash expansion.
             "'**/*+(.|_)spec.js'",
             "'**/*+(.|_)spec.mjs'",
             "'**/*+(.|_)spec.cjs'",
         ] + args,
+        data = data + ["//:node_modules/source-map-support"],
         **kwargs
     )


### PR DESCRIPTION
The previous `jasmine_test` rule from `@devinfra//bazel/jasmine:jasmine.bzl` was causing `ENOENT` errors locally when running tests. This was likely due to issues with path handling and the `chdir` behavior.

This change replaces the usage of `@devinfra//bazel/jasmine:jasmine.bzl` with `@aspect_rules_jasmine//jasmine:defs.bzl`. The `jasmine_test` macro in `tools/defaults.bzl` is updated to work with the new rule, including adjustments to argument passing and path handling to ensure tests can locate necessary modules like `source-map-support`.

This resolves the local `ENOENT` error and aligns with a more standard way of running jasmine tests with bazel.
