### PR TITLE
build: update baseline date to October 2025

### DIFF
--- a/constants.bzl
+++ b/constants.bzl
@@ -13,7 +13,7 @@ NG_PACKAGR_PEER_DEP = "^21.0.0-next.0"
 # default browser set used to determine what downleveling is necessary.
 #
 # See: https://web.dev/baseline
-BASELINE_DATE = "2025-08-20"
+BASELINE_DATE = "2025-10-20"
 
 SNAPSHOT_REPOS = {
     "@angular/cli": "angular/cli-builds",


### PR DESCRIPTION
The baseline date used for determining necessary browser feature downleveling has been updated to October 20, 2025. This ensures that the build process aligns with the latest web standards and browser support.
