### PR TITLE
refactor(@angular/cli): use streaming HTML parser in search documentation tool

### DIFF
--- a/packages/angular/cli/BUILD.bazel
+++ b/packages/angular/cli/BUILD.bazel
@@ -58,6 +58,7 @@ ts_project(
         ":node_modules/jsonc-parser",
         ":node_modules/npm-package-arg",
         ":node_modules/pacote",
+        ":node_modules/parse5-html-rewriting-stream",
         ":node_modules/resolve",
         ":node_modules/yargs",
         ":node_modules/zod",

--- a/packages/angular/cli/package.json
+++ b/packages/angular/cli/package.json
@@ -36,6 +36,7 @@
     "listr2": "9.0.4",
     "npm-package-arg": "13.0.1",
     "pacote": "21.0.3",
+    "parse5-html-rewriting-stream": "8.0.0",
     "resolve": "1.22.10",
     "semver": "7.7.3",
     "yargs": "18.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -504,6 +504,9 @@ importers:
       pacote:
         specifier: 21.0.3
         version: 21.0.3
+      parse5-html-rewriting-stream:
+        specifier: 8.0.0
+        version: 8.0.0
       resolve:
         specifier: 1.22.10
         version: 1.22.10


### PR DESCRIPTION
The `search_documentation` MCP tool previously used a regular expression and string searching to extract and clean documentation content from fetched HTML. This approach was not robust and could produce incorrect results. It also buffered the entire HTML response in memory before processing.

This commit refactors the implementation to use `parse5-html-rewriting-stream`, which is already a dependency in the workspace. The new implementation streams the `fetch` response directly into a single-pass parser that simultaneously extracts the `<main>` element's content and strips all HTML tags.

This change makes the parsing more reliable, efficient, and memory-friendly.