### PR TITLE
refactor(@angular/cli): correct package manager cache key and add barrel file

### DIFF
--- a/packages/angular/cli/src/package-managers/index.ts
+++ b/packages/angular/cli/src/package-managers/index.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+export { createPackageManager } from './factory';
+export type { PackageManagerName } from './package-manager-descriptor';
+export { PackageManager } from './package-manager';
+export type * from './package-metadata';
+export type { InstalledPackage } from './package-tree';

--- a/packages/angular/cli/src/package-managers/package-manager.ts
+++ b/packages/angular/cli/src/package-managers/package-manager.ts
@@ -35,6 +35,7 @@ const METADATA_FIELDS = ['name', 'dist-tags', 'versions', 'time'] as const;
 const MANIFEST_FIELDS = [
   'name',
   'version',
+  'deprecated',
   'dependencies',
   'peerDependencies',
   'devDependencies',
@@ -337,7 +338,7 @@ export class PackageManager {
     return this.#fetchAndParse(
       commandArgs,
       (stdout, logger) => this.descriptor.outputParsers.getRegistryMetadata(stdout, logger),
-      { ...options, cache: this.#metadataCache, cacheKey: packageName },
+      { ...options, cache: this.#metadataCache, cacheKey },
     );
   }
 
@@ -369,7 +370,7 @@ export class PackageManager {
     return this.#fetchAndParse(
       commandArgs,
       (stdout, logger) => this.descriptor.outputParsers.getPackageManifest(stdout, logger),
-      { ...options, cache: this.#manifestCache, cacheKey: specifier },
+      { ...options, cache: this.#manifestCache, cacheKey },
     );
   }
 

--- a/packages/angular/cli/src/package-managers/package-metadata.ts
+++ b/packages/angular/cli/src/package-managers/package-metadata.ts
@@ -80,6 +80,9 @@ export interface PackageManifest {
   /** The version of the package. */
   version: string;
 
+  /** A message indicating that the package version is deprecated. */
+  deprecated?: string;
+
   /** A mapping of production dependencies. */
   dependencies?: Record<string, string>;
 


### PR DESCRIPTION
The in-memory cache for the package manager abstraction did not properly include the registry URL in its cache key. This could lead to cache collisions if the same package was requested from two different registries. This commit corrects the cache key to be a composite of the package specifier and the registry URL.

Additionally, a new `index.ts` barrel file has been added to create a single, clear public entry point for the package manager feature, improving code organization.