### PR TITLE
fix(@angular-devkit/schematics): respect `--force` option when schematic contains `host.create`

### DIFF
--- a/packages/angular_devkit/schematics/src/tree/host-tree.ts
+++ b/packages/angular_devkit/schematics/src/tree/host-tree.ts
@@ -20,7 +20,6 @@ import {
 import { ParseError, parse as jsoncParse, printParseErrorCode } from 'jsonc-parser';
 import {
   ContentHasMutatedException,
-  FileAlreadyExistException,
   FileDoesNotExistException,
   InvalidUpdateRecordException,
   MergeConflictException,
@@ -407,12 +406,8 @@ export class HostTree implements Tree {
 
   // Structural methods.
   create(path: string, content: Buffer | string): void {
-    const p = this._normalizePath(path);
-    if (this._recordSync.exists(p)) {
-      throw new FileAlreadyExistException(p);
-    }
     const c = typeof content == 'string' ? Buffer.from(content) : content;
-    this._record.create(p, c as {} as virtualFs.FileBuffer).subscribe();
+    this._record.create(this._normalizePath(path), c as {} as virtualFs.FileBuffer).subscribe();
   }
   delete(path: string): void {
     this._recordSync.delete(this._normalizePath(path));

--- a/tests/legacy-cli/e2e/tests/generate/schematic-force-override.ts
+++ b/tests/legacy-cli/e2e/tests/generate/schematic-force-override.ts
@@ -1,0 +1,51 @@
+import { appendFile } from 'node:fs/promises';
+import { getGlobalVariable } from '../../utils/env';
+import { getActivePackageManager, installWorkspacePackages } from '../../utils/packages';
+import { ng } from '../../utils/process';
+import { isPrereleaseCli, updateJsonFile } from '../../utils/project';
+import { expectToFail } from '../../utils/utils';
+
+const snapshots = require('../../ng-snapshot/package.json');
+
+export default async function () {
+  const isPrerelease = await isPrereleaseCli();
+  let tag = isPrerelease ? '@next' : '';
+  if (getActivePackageManager() === 'npm') {
+    await appendFile('.npmrc', '\nlegacy-peer-deps=true');
+  }
+
+  await ng('add', `@angular/material${tag}`, '--skip-confirmation');
+
+  const isSnapshotBuild = getGlobalVariable('argv')['ng-snapshots'];
+  if (isSnapshotBuild) {
+    await updateJsonFile('package.json', (packageJson) => {
+      const dependencies = packageJson['dependencies'];
+      // Angular material adds dependencies on other Angular packages
+      // Iterate over all of the packages to update them to the snapshot version.
+      for (const [name, version] of Object.entries(snapshots.dependencies)) {
+        if (name in dependencies) {
+          dependencies[name] = version;
+        }
+      }
+    });
+    await installWorkspacePackages();
+  }
+
+  const args: string[] = [
+    'generate',
+    '@angular/material:theme-color',
+    '--primary-color=#0641e6',
+    '--tertiary-color=#994aff',
+    '--neutral-color=#313138',
+    '--error-color=#eb5757',
+    '--secondary-color=#009096',
+    '--neutral-variant-color=#b2b2b8',
+  ];
+
+  await ng(...args);
+
+  // Should fail as file exists
+  await expectToFail(() => ng(...args));
+
+  await ng(...args, '--force');
+}


### PR DESCRIPTION


Removes the `FileAlreadyExistException` check within the `create` method of `HostTree`. This change allows a schematic to create a file even if one already exists at the same path, effectively overwriting it.

This provides more flexibility for schematic authors, particularly in scenarios where files need to be replaced or updated unconditionally. It is intended to be used with schematics that have a `force` or `overwrite` option.

Closes #30578
