### PR TITLE
feat(@angular/cli): make find_examples tool version-aware

### DIFF
--- a/packages/angular/cli/src/commands/mcp/tools/examples.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/examples.ts
@@ -546,7 +546,15 @@ function parseFrontmatter(content: string): Record<string, unknown> {
     } else {
       const arrayItemMatch = line.match(/^\s*-\s*(.*)/);
       if (arrayItemMatch && currentKey && isArray) {
-        arrayValues.push(arrayItemMatch[1].trim());
+        let value = arrayItemMatch[1].trim();
+        // Unquote if the value is quoted.
+        if (
+          (value.startsWith("'") && value.endsWith("'")) ||
+          (value.startsWith('"') && value.endsWith('"'))
+        ) {
+          value = value.slice(1, -1);
+        }
+        arrayValues.push(value);
       }
     }
   }

--- a/tools/example_db_generator.js
+++ b/tools/example_db_generator.js
@@ -60,7 +60,15 @@ function parseFrontmatter(content) {
     } else {
       const arrayItemMatch = line.match(/^\s*-\s*(.*)/);
       if (arrayItemMatch && currentKey && isArray) {
-        arrayValues.push(arrayItemMatch[1].trim());
+        let value = arrayItemMatch[1].trim();
+        // Unquote if the value is quoted.
+        if (
+          (value.startsWith("'") && value.endsWith("'")) ||
+          (value.startsWith('"') && value.endsWith('"'))
+        ) {
+          value = value.slice(1, -1);
+        }
+        arrayValues.push(value);
       }
     }
   }


### PR DESCRIPTION
This commit refactors the `find_examples` MCP tool to be version-aware, aligning its behavior with the `get_best_practices` tool. The tool now dynamically resolves the code examples database from the user's installed version of `@angular/core`, ensuring that the provided examples are accurate for their specific project version.

Key changes:
- The input schema is updated to accept a `workspacePath`.
- New logic reads the `angular.examples` metadata from `@angular/core/package.json` to locate the version-specific SQLite database.
- If the version-specific database cannot be resolved, the tool gracefully falls back to the generic database bundled with the CLI.
- The database querying logic has been extracted into a separate helper function for better code organization.