### PR TITLE
fix(@angular/build): direct check include file exists in unit-test discovery

### DIFF
--- a/packages/angular/build/src/builders/unit-test/test-discovery.ts
+++ b/packages/angular/build/src/builders/unit-test/test-discovery.ts
@@ -232,18 +232,18 @@ async function resolveStaticPattern(
     return { resolved: [], unresolved: [`${pattern}/**/*.@(${infixes}).@(ts|tsx)`] };
   }
 
-  const fileExt = extname(pattern);
-  const baseName = basename(pattern, fileExt);
+  const fileExt = extname(fullPath);
+  const baseName = basename(fullPath, fileExt);
 
   for (const infix of TEST_FILE_INFIXES) {
-    const potentialSpec = join(
-      projectSourceRoot,
-      dirname(pattern),
-      `${baseName}${infix}${fileExt}`,
-    );
+    const potentialSpec = join(dirname(fullPath), `${baseName}${infix}${fileExt}`);
     if (await exists(potentialSpec)) {
       return { resolved: [potentialSpec], unresolved: [] };
     }
+  }
+
+  if (await exists(fullPath)) {
+    return { resolved: [fullPath], unresolved: [] };
   }
 
   return { resolved: [], unresolved: [pattern] };


### PR DESCRIPTION
When discovering unit-test files, the `include` option values that are not dynamic patterns will now be checked directly if they exist on the file system. This avoids glob calls for specific files and helps avoid Windows pathing issues with glob syntax.