### PR TITLE
refactor(@angular/build): make `runner` optional in unit-test builder

### DIFF
--- a/goldens/public-api/angular/build/index.api.md
+++ b/goldens/public-api/angular/build/index.api.md
@@ -235,7 +235,7 @@ export type UnitTestBuilderOptions = {
     progress?: boolean;
     providersFile?: string;
     reporters?: SchemaReporter[];
-    runner: Runner;
+    runner?: Runner;
     setupFiles?: string[];
     tsConfig?: string;
     watch?: boolean;

--- a/packages/angular/build/src/builders/unit-test/options.ts
+++ b/packages/angular/build/src/builders/unit-test/options.ts
@@ -82,7 +82,7 @@ export async function normalizeOptions(
     include: options.include ?? ['**/*.spec.ts'],
     exclude: options.exclude,
     filter,
-    runnerName: runner,
+    runnerName: runner ?? 'vitest',
     coverage: options.coverage
       ? {
           all: options.coverageAll,

--- a/packages/angular/build/src/builders/unit-test/schema.json
+++ b/packages/angular/build/src/builders/unit-test/schema.json
@@ -16,6 +16,7 @@
     "runner": {
       "type": "string",
       "description": "Specifies the test runner to use for test execution.",
+      "default": "vitest",
       "enum": ["karma", "vitest"]
     },
     "browsers": {
@@ -267,5 +268,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["runner"]
+  "required": []
 }

--- a/tests/legacy-cli/e2e/utils/vitest.ts
+++ b/tests/legacy-cli/e2e/utils/vitest.ts
@@ -19,11 +19,7 @@ export async function applyVitestBuilder(): Promise<void> {
     // Update to Vitest builder.
     const test = project['architect']['test'];
     test['builder'] = '@angular/build:unit-test';
-    test['options'] = {
-      tsConfig: test['options']['tsConfig'],
-      buildTarget: '::development',
-      runner: 'vitest',
-    };
+    test['options'] = {};
   });
 
   await updateJsonFile('tsconfig.spec.json', (tsconfig) => {


### PR DESCRIPTION
The `runner` option in the `unit-test` builder is now optional to streamline the user configuration.

If the `runner` option is not provided, the builder now defaults to using the `vitest` value.

The builder's schema has been updated to reflect this change by removing `runner` from the required properties and updating its entry to document the new default behavior.