### PR TITLE
build: update dependency rules_nodejs to v6.6.0

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -108,3 +108,15 @@ validate_ts_version_matching(
     module_lock_file = "MODULE.bazel.lock",
     package_json = "package.json",
 )
+
+# This is needed following https://github.com/bazel-contrib/rules_nodejs/pull/3859
+toolchain(
+    name = "node22_windows_no_exec_config_toolchain",
+    exec_compatible_with = [],
+    target_compatible_with = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
+    ],
+    toolchain = "@node22_windows_amd64//:toolchain",
+    toolchain_type = "@rules_nodejs//nodejs:toolchain_type",
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "yq.bzl", version = "0.3.1")
-bazel_dep(name = "rules_nodejs", version = "6.5.2")
+bazel_dep(name = "rules_nodejs", version = "6.6.0")
 bazel_dep(name = "aspect_rules_js", version = "2.6.2")
 bazel_dep(name = "aspect_rules_ts", version = "3.7.0")
 bazel_dep(name = "rules_pkg", version = "0.8.1")
@@ -51,33 +51,17 @@ git_override(
     remote = "https://github.com/devversion/rules_browsers.git",
 )
 
-# The below is needed until https://github.com/bazel-contrib/rules_nodejs/pull/3853 is merged and released.
-NODE_24_VERSION = "24.0.0"
-
-NODE_24_REPO = {
-    "24.0.0-darwin_arm64": ("node-v24.0.0-darwin-arm64.tar.gz", "node-v24.0.0-darwin-arm64", "194e2f3dd3ec8c2adcaa713ed40f44c5ca38467880e160974ceac1659be60121"),
-    "24.0.0-darwin_amd64": ("node-v24.0.0-darwin-x64.tar.gz", "node-v24.0.0-darwin-x64", "f716b3ce14a7e37a6cbf97c9de10d444d7da07ef833cd8da81dd944d111e6a4a"),
-    "24.0.0-linux_arm64": ("node-v24.0.0-linux-arm64.tar.xz", "node-v24.0.0-linux-arm64", "d40ec7ffe0b82b02dce94208c84351424099bd70fa3a42b65c46d95322305040"),
-    "24.0.0-linux_ppc64le": ("node-v24.0.0-linux-ppc64le.tar.xz", "node-v24.0.0-linux-ppc64le", "cfa0e8d51a2f9a446f1bfb81cdf4c7e95336ad622e2aa230e3fa1d093c63d77d"),
-    "24.0.0-linux_s390x": ("node-v24.0.0-linux-s390x.tar.xz", "node-v24.0.0-linux-s390x", "e37a04c7ee05416ec1234fd3255e05b6b81287eb0424a57441c8b69f0a155021"),
-    "24.0.0-linux_amd64": ("node-v24.0.0-linux-x64.tar.xz", "node-v24.0.0-linux-x64", "59b8af617dccd7f9f68cc8451b2aee1e86d6bd5cb92cd51dd6216a31b707efd7"),
-    "24.0.0-windows_amd64": ("node-v24.0.0-win-x64.zip", "node-v24.0.0-win-x64", "3d0fff80c87bb9a8d7f49f2f27832aa34a1477d137af46f5b14df5498be81304"),
-}
-
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
-node.toolchain(
-    name = "nodejs",
-    node_repositories = NODE_24_REPO,
-    node_version = NODE_24_VERSION,
+node.toolchain(node_version = "24.0.0")
+use_repo(
+    node,
+    "nodejs_darwin_amd64",
+    "nodejs_darwin_arm64",
+    "nodejs_linux_amd64",
+    "nodejs_linux_arm64",
+    "nodejs_toolchains",
+    "nodejs_windows_amd64",
 )
-use_repo(node, "nodejs_toolchains")
-use_repo(node, "nodejs_darwin_amd64")
-use_repo(node, "nodejs_darwin_arm64")
-use_repo(node, "nodejs_linux_amd64")
-use_repo(node, "nodejs_linux_arm64")
-use_repo(node, "nodejs_linux_ppc64le")
-use_repo(node, "nodejs_linux_s390x")
-use_repo(node, "nodejs_windows_amd64")
 
 node_dev = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node", dev_dependency = True)
 
@@ -86,40 +70,42 @@ node_dev.toolchain(
     name = "node20",
     node_version = "20.19.0",
 )
-use_repo(node_dev, "node20_darwin_arm64")
-use_repo(node_dev, "node20_darwin_amd64")
-use_repo(node_dev, "node20_linux_amd64")
-use_repo(node_dev, "node20_linux_arm64")
-use_repo(node_dev, "node20_linux_s390x")
-use_repo(node_dev, "node20_linux_ppc64le")
-use_repo(node_dev, "node20_windows_amd64")
 
 # Node.js 22
 node_dev.toolchain(
     name = "node22",
     node_version = "22.12.0",
 )
-use_repo(node_dev, "node22_darwin_arm64")
-use_repo(node_dev, "node22_darwin_amd64")
-use_repo(node_dev, "node22_linux_amd64")
-use_repo(node_dev, "node22_linux_arm64")
-use_repo(node_dev, "node22_linux_s390x")
-use_repo(node_dev, "node22_linux_ppc64le")
-use_repo(node_dev, "node22_windows_amd64")
 
 # Node.js 24
 node_dev.toolchain(
     name = "node24",
-    node_repositories = NODE_24_REPO,
-    node_version = NODE_24_VERSION,
+    node_version = "24.0.0",
 )
-use_repo(node_dev, "node24_darwin_arm64")
-use_repo(node_dev, "node24_darwin_amd64")
-use_repo(node_dev, "node24_linux_amd64")
-use_repo(node_dev, "node24_linux_arm64")
-use_repo(node_dev, "node24_linux_s390x")
-use_repo(node_dev, "node24_linux_ppc64le")
-use_repo(node_dev, "node24_windows_amd64")
+use_repo(
+    node_dev,
+    "node20_darwin_amd64",
+    "node20_darwin_arm64",
+    "node20_linux_amd64",
+    "node20_linux_arm64",
+    "node20_toolchains",
+    "node20_windows_amd64",
+    "node22_darwin_amd64",
+    "node22_darwin_arm64",
+    "node22_linux_amd64",
+    "node22_linux_arm64",
+    "node22_toolchains",
+    "node22_windows_amd64",
+    "node24_darwin_amd64",
+    "node24_darwin_arm64",
+    "node24_linux_amd64",
+    "node24_linux_arm64",
+    "node24_toolchains",
+    "node24_windows_amd64",
+)
+
+# This is needed following https://github.com/bazel-contrib/rules_nodejs/pull/3859
+register_toolchains("//:node22_windows_no_exec_config_toolchain")
 
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")
 npm.npm_translate_lock(

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -152,7 +152,8 @@
     "https://bcr.bazel.build/modules/rules_nodejs/6.3.0/MODULE.bazel": "45345e4aba35dd6e4701c1eebf5a4e67af4ed708def9ebcdc6027585b34ee52d",
     "https://bcr.bazel.build/modules/rules_nodejs/6.5.0/MODULE.bazel": "546d0cf79f36f9f6e080816045f97234b071c205f4542e3351bd4424282a8810",
     "https://bcr.bazel.build/modules/rules_nodejs/6.5.2/MODULE.bazel": "7f9ea68a0ce6d82905ce9f74e76ab8a8b4531ed4c747018c9d76424ad0b3370d",
-    "https://bcr.bazel.build/modules/rules_nodejs/6.5.2/source.json": "6a6ca0940914d55c550d1417cad13a56c9900e23f651a762d8ccc5a64adcf661",
+    "https://bcr.bazel.build/modules/rules_nodejs/6.6.0/MODULE.bazel": "49ef4cccc17a5a13c9beca2d0b3f7dea1d97381df8cb6ba4dea03943f6a81b0a",
+    "https://bcr.bazel.build/modules/rules_nodejs/6.6.0/source.json": "cbd156fa2db33707275de138110b78eb86a4cf510b979df7c4b6a8e7127484de",
     "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
     "https://bcr.bazel.build/modules/rules_pkg/0.8.1/MODULE.bazel": "7e9e7b5b26bd7ff012dfe63930db2f0176ddcd25e44a858fc72d63e995b6aab9",
     "https://bcr.bazel.build/modules/rules_pkg/0.8.1/source.json": "15dd7e13dc303f7fcde2b55300bcb8de5c0dd08a7a7269749cbbaa0fb1dfbe16",
@@ -1116,8 +1117,8 @@
     },
     "@@rules_nodejs~//nodejs:extensions.bzl%node": {
       "general": {
-        "bzlTransitiveDigest": "FmfMiNXAxRoLWw3NloQbssosE1egrSvzirbQnso7j7E=",
-        "usagesDigest": "1kpLfNSteilN9lIcsMk1OY9Ob+GrTMGxU495OOEa2cA=",
+        "bzlTransitiveDigest": "71PwVsMlLx+RWdt1SI9nSqRHX7DX/NstWwr7/XBxEMs=",
+        "usagesDigest": "GeYuTJ/owkgZEwBsWFkG3fyoxWVGCRdGtiR5b4jNj3s=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1127,43 +1128,7 @@
             "ruleClassName": "_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {
-                "24.0.0-darwin_arm64": [
-                  "node-v24.0.0-darwin-arm64.tar.gz",
-                  "node-v24.0.0-darwin-arm64",
-                  "194e2f3dd3ec8c2adcaa713ed40f44c5ca38467880e160974ceac1659be60121"
-                ],
-                "24.0.0-darwin_amd64": [
-                  "node-v24.0.0-darwin-x64.tar.gz",
-                  "node-v24.0.0-darwin-x64",
-                  "f716b3ce14a7e37a6cbf97c9de10d444d7da07ef833cd8da81dd944d111e6a4a"
-                ],
-                "24.0.0-linux_arm64": [
-                  "node-v24.0.0-linux-arm64.tar.xz",
-                  "node-v24.0.0-linux-arm64",
-                  "d40ec7ffe0b82b02dce94208c84351424099bd70fa3a42b65c46d95322305040"
-                ],
-                "24.0.0-linux_ppc64le": [
-                  "node-v24.0.0-linux-ppc64le.tar.xz",
-                  "node-v24.0.0-linux-ppc64le",
-                  "cfa0e8d51a2f9a446f1bfb81cdf4c7e95336ad622e2aa230e3fa1d093c63d77d"
-                ],
-                "24.0.0-linux_s390x": [
-                  "node-v24.0.0-linux-s390x.tar.xz",
-                  "node-v24.0.0-linux-s390x",
-                  "e37a04c7ee05416ec1234fd3255e05b6b81287eb0424a57441c8b69f0a155021"
-                ],
-                "24.0.0-linux_amd64": [
-                  "node-v24.0.0-linux-x64.tar.xz",
-                  "node-v24.0.0-linux-x64",
-                  "59b8af617dccd7f9f68cc8451b2aee1e86d6bd5cb92cd51dd6216a31b707efd7"
-                ],
-                "24.0.0-windows_amd64": [
-                  "node-v24.0.0-win-x64.zip",
-                  "node-v24.0.0-win-x64",
-                  "3d0fff80c87bb9a8d7f49f2f27832aa34a1477d137af46f5b14df5498be81304"
-                ]
-              },
+              "node_repositories": {},
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
@@ -1177,43 +1142,7 @@
             "ruleClassName": "_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {
-                "24.0.0-darwin_arm64": [
-                  "node-v24.0.0-darwin-arm64.tar.gz",
-                  "node-v24.0.0-darwin-arm64",
-                  "194e2f3dd3ec8c2adcaa713ed40f44c5ca38467880e160974ceac1659be60121"
-                ],
-                "24.0.0-darwin_amd64": [
-                  "node-v24.0.0-darwin-x64.tar.gz",
-                  "node-v24.0.0-darwin-x64",
-                  "f716b3ce14a7e37a6cbf97c9de10d444d7da07ef833cd8da81dd944d111e6a4a"
-                ],
-                "24.0.0-linux_arm64": [
-                  "node-v24.0.0-linux-arm64.tar.xz",
-                  "node-v24.0.0-linux-arm64",
-                  "d40ec7ffe0b82b02dce94208c84351424099bd70fa3a42b65c46d95322305040"
-                ],
-                "24.0.0-linux_ppc64le": [
-                  "node-v24.0.0-linux-ppc64le.tar.xz",
-                  "node-v24.0.0-linux-ppc64le",
-                  "cfa0e8d51a2f9a446f1bfb81cdf4c7e95336ad622e2aa230e3fa1d093c63d77d"
-                ],
-                "24.0.0-linux_s390x": [
-                  "node-v24.0.0-linux-s390x.tar.xz",
-                  "node-v24.0.0-linux-s390x",
-                  "e37a04c7ee05416ec1234fd3255e05b6b81287eb0424a57441c8b69f0a155021"
-                ],
-                "24.0.0-linux_amd64": [
-                  "node-v24.0.0-linux-x64.tar.xz",
-                  "node-v24.0.0-linux-x64",
-                  "59b8af617dccd7f9f68cc8451b2aee1e86d6bd5cb92cd51dd6216a31b707efd7"
-                ],
-                "24.0.0-windows_amd64": [
-                  "node-v24.0.0-win-x64.zip",
-                  "node-v24.0.0-win-x64",
-                  "3d0fff80c87bb9a8d7f49f2f27832aa34a1477d137af46f5b14df5498be81304"
-                ]
-              },
+              "node_repositories": {},
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
@@ -1227,43 +1156,7 @@
             "ruleClassName": "_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {
-                "24.0.0-darwin_arm64": [
-                  "node-v24.0.0-darwin-arm64.tar.gz",
-                  "node-v24.0.0-darwin-arm64",
-                  "194e2f3dd3ec8c2adcaa713ed40f44c5ca38467880e160974ceac1659be60121"
-                ],
-                "24.0.0-darwin_amd64": [
-                  "node-v24.0.0-darwin-x64.tar.gz",
-                  "node-v24.0.0-darwin-x64",
-                  "f716b3ce14a7e37a6cbf97c9de10d444d7da07ef833cd8da81dd944d111e6a4a"
-                ],
-                "24.0.0-linux_arm64": [
-                  "node-v24.0.0-linux-arm64.tar.xz",
-                  "node-v24.0.0-linux-arm64",
-                  "d40ec7ffe0b82b02dce94208c84351424099bd70fa3a42b65c46d95322305040"
-                ],
-                "24.0.0-linux_ppc64le": [
-                  "node-v24.0.0-linux-ppc64le.tar.xz",
-                  "node-v24.0.0-linux-ppc64le",
-                  "cfa0e8d51a2f9a446f1bfb81cdf4c7e95336ad622e2aa230e3fa1d093c63d77d"
-                ],
-                "24.0.0-linux_s390x": [
-                  "node-v24.0.0-linux-s390x.tar.xz",
-                  "node-v24.0.0-linux-s390x",
-                  "e37a04c7ee05416ec1234fd3255e05b6b81287eb0424a57441c8b69f0a155021"
-                ],
-                "24.0.0-linux_amd64": [
-                  "node-v24.0.0-linux-x64.tar.xz",
-                  "node-v24.0.0-linux-x64",
-                  "59b8af617dccd7f9f68cc8451b2aee1e86d6bd5cb92cd51dd6216a31b707efd7"
-                ],
-                "24.0.0-windows_amd64": [
-                  "node-v24.0.0-win-x64.zip",
-                  "node-v24.0.0-win-x64",
-                  "3d0fff80c87bb9a8d7f49f2f27832aa34a1477d137af46f5b14df5498be81304"
-                ]
-              },
+              "node_repositories": {},
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
@@ -1277,43 +1170,7 @@
             "ruleClassName": "_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {
-                "24.0.0-darwin_arm64": [
-                  "node-v24.0.0-darwin-arm64.tar.gz",
-                  "node-v24.0.0-darwin-arm64",
-                  "194e2f3dd3ec8c2adcaa713ed40f44c5ca38467880e160974ceac1659be60121"
-                ],
-                "24.0.0-darwin_amd64": [
-                  "node-v24.0.0-darwin-x64.tar.gz",
-                  "node-v24.0.0-darwin-x64",
-                  "f716b3ce14a7e37a6cbf97c9de10d444d7da07ef833cd8da81dd944d111e6a4a"
-                ],
-                "24.0.0-linux_arm64": [
-                  "node-v24.0.0-linux-arm64.tar.xz",
-                  "node-v24.0.0-linux-arm64",
-                  "d40ec7ffe0b82b02dce94208c84351424099bd70fa3a42b65c46d95322305040"
-                ],
-                "24.0.0-linux_ppc64le": [
-                  "node-v24.0.0-linux-ppc64le.tar.xz",
-                  "node-v24.0.0-linux-ppc64le",
-                  "cfa0e8d51a2f9a446f1bfb81cdf4c7e95336ad622e2aa230e3fa1d093c63d77d"
-                ],
-                "24.0.0-linux_s390x": [
-                  "node-v24.0.0-linux-s390x.tar.xz",
-                  "node-v24.0.0-linux-s390x",
-                  "e37a04c7ee05416ec1234fd3255e05b6b81287eb0424a57441c8b69f0a155021"
-                ],
-                "24.0.0-linux_amd64": [
-                  "node-v24.0.0-linux-x64.tar.xz",
-                  "node-v24.0.0-linux-x64",
-                  "59b8af617dccd7f9f68cc8451b2aee1e86d6bd5cb92cd51dd6216a31b707efd7"
-                ],
-                "24.0.0-windows_amd64": [
-                  "node-v24.0.0-win-x64.zip",
-                  "node-v24.0.0-win-x64",
-                  "3d0fff80c87bb9a8d7f49f2f27832aa34a1477d137af46f5b14df5498be81304"
-                ]
-              },
+              "node_repositories": {},
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
@@ -1327,43 +1184,7 @@
             "ruleClassName": "_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {
-                "24.0.0-darwin_arm64": [
-                  "node-v24.0.0-darwin-arm64.tar.gz",
-                  "node-v24.0.0-darwin-arm64",
-                  "194e2f3dd3ec8c2adcaa713ed40f44c5ca38467880e160974ceac1659be60121"
-                ],
-                "24.0.0-darwin_amd64": [
-                  "node-v24.0.0-darwin-x64.tar.gz",
-                  "node-v24.0.0-darwin-x64",
-                  "f716b3ce14a7e37a6cbf97c9de10d444d7da07ef833cd8da81dd944d111e6a4a"
-                ],
-                "24.0.0-linux_arm64": [
-                  "node-v24.0.0-linux-arm64.tar.xz",
-                  "node-v24.0.0-linux-arm64",
-                  "d40ec7ffe0b82b02dce94208c84351424099bd70fa3a42b65c46d95322305040"
-                ],
-                "24.0.0-linux_ppc64le": [
-                  "node-v24.0.0-linux-ppc64le.tar.xz",
-                  "node-v24.0.0-linux-ppc64le",
-                  "cfa0e8d51a2f9a446f1bfb81cdf4c7e95336ad622e2aa230e3fa1d093c63d77d"
-                ],
-                "24.0.0-linux_s390x": [
-                  "node-v24.0.0-linux-s390x.tar.xz",
-                  "node-v24.0.0-linux-s390x",
-                  "e37a04c7ee05416ec1234fd3255e05b6b81287eb0424a57441c8b69f0a155021"
-                ],
-                "24.0.0-linux_amd64": [
-                  "node-v24.0.0-linux-x64.tar.xz",
-                  "node-v24.0.0-linux-x64",
-                  "59b8af617dccd7f9f68cc8451b2aee1e86d6bd5cb92cd51dd6216a31b707efd7"
-                ],
-                "24.0.0-windows_amd64": [
-                  "node-v24.0.0-win-x64.zip",
-                  "node-v24.0.0-win-x64",
-                  "3d0fff80c87bb9a8d7f49f2f27832aa34a1477d137af46f5b14df5498be81304"
-                ]
-              },
+              "node_repositories": {},
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
@@ -1377,43 +1198,7 @@
             "ruleClassName": "_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {
-                "24.0.0-darwin_arm64": [
-                  "node-v24.0.0-darwin-arm64.tar.gz",
-                  "node-v24.0.0-darwin-arm64",
-                  "194e2f3dd3ec8c2adcaa713ed40f44c5ca38467880e160974ceac1659be60121"
-                ],
-                "24.0.0-darwin_amd64": [
-                  "node-v24.0.0-darwin-x64.tar.gz",
-                  "node-v24.0.0-darwin-x64",
-                  "f716b3ce14a7e37a6cbf97c9de10d444d7da07ef833cd8da81dd944d111e6a4a"
-                ],
-                "24.0.0-linux_arm64": [
-                  "node-v24.0.0-linux-arm64.tar.xz",
-                  "node-v24.0.0-linux-arm64",
-                  "d40ec7ffe0b82b02dce94208c84351424099bd70fa3a42b65c46d95322305040"
-                ],
-                "24.0.0-linux_ppc64le": [
-                  "node-v24.0.0-linux-ppc64le.tar.xz",
-                  "node-v24.0.0-linux-ppc64le",
-                  "cfa0e8d51a2f9a446f1bfb81cdf4c7e95336ad622e2aa230e3fa1d093c63d77d"
-                ],
-                "24.0.0-linux_s390x": [
-                  "node-v24.0.0-linux-s390x.tar.xz",
-                  "node-v24.0.0-linux-s390x",
-                  "e37a04c7ee05416ec1234fd3255e05b6b81287eb0424a57441c8b69f0a155021"
-                ],
-                "24.0.0-linux_amd64": [
-                  "node-v24.0.0-linux-x64.tar.xz",
-                  "node-v24.0.0-linux-x64",
-                  "59b8af617dccd7f9f68cc8451b2aee1e86d6bd5cb92cd51dd6216a31b707efd7"
-                ],
-                "24.0.0-windows_amd64": [
-                  "node-v24.0.0-win-x64.zip",
-                  "node-v24.0.0-win-x64",
-                  "3d0fff80c87bb9a8d7f49f2f27832aa34a1477d137af46f5b14df5498be81304"
-                ]
-              },
+              "node_repositories": {},
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
@@ -1427,43 +1212,7 @@
             "ruleClassName": "_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {
-                "24.0.0-darwin_arm64": [
-                  "node-v24.0.0-darwin-arm64.tar.gz",
-                  "node-v24.0.0-darwin-arm64",
-                  "194e2f3dd3ec8c2adcaa713ed40f44c5ca38467880e160974ceac1659be60121"
-                ],
-                "24.0.0-darwin_amd64": [
-                  "node-v24.0.0-darwin-x64.tar.gz",
-                  "node-v24.0.0-darwin-x64",
-                  "f716b3ce14a7e37a6cbf97c9de10d444d7da07ef833cd8da81dd944d111e6a4a"
-                ],
-                "24.0.0-linux_arm64": [
-                  "node-v24.0.0-linux-arm64.tar.xz",
-                  "node-v24.0.0-linux-arm64",
-                  "d40ec7ffe0b82b02dce94208c84351424099bd70fa3a42b65c46d95322305040"
-                ],
-                "24.0.0-linux_ppc64le": [
-                  "node-v24.0.0-linux-ppc64le.tar.xz",
-                  "node-v24.0.0-linux-ppc64le",
-                  "cfa0e8d51a2f9a446f1bfb81cdf4c7e95336ad622e2aa230e3fa1d093c63d77d"
-                ],
-                "24.0.0-linux_s390x": [
-                  "node-v24.0.0-linux-s390x.tar.xz",
-                  "node-v24.0.0-linux-s390x",
-                  "e37a04c7ee05416ec1234fd3255e05b6b81287eb0424a57441c8b69f0a155021"
-                ],
-                "24.0.0-linux_amd64": [
-                  "node-v24.0.0-linux-x64.tar.xz",
-                  "node-v24.0.0-linux-x64",
-                  "59b8af617dccd7f9f68cc8451b2aee1e86d6bd5cb92cd51dd6216a31b707efd7"
-                ],
-                "24.0.0-windows_amd64": [
-                  "node-v24.0.0-win-x64.zip",
-                  "node-v24.0.0-win-x64",
-                  "3d0fff80c87bb9a8d7f49f2f27832aa34a1477d137af46f5b14df5498be81304"
-                ]
-              },
+              "node_repositories": {},
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
@@ -1477,43 +1226,7 @@
             "ruleClassName": "_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {
-                "24.0.0-darwin_arm64": [
-                  "node-v24.0.0-darwin-arm64.tar.gz",
-                  "node-v24.0.0-darwin-arm64",
-                  "194e2f3dd3ec8c2adcaa713ed40f44c5ca38467880e160974ceac1659be60121"
-                ],
-                "24.0.0-darwin_amd64": [
-                  "node-v24.0.0-darwin-x64.tar.gz",
-                  "node-v24.0.0-darwin-x64",
-                  "f716b3ce14a7e37a6cbf97c9de10d444d7da07ef833cd8da81dd944d111e6a4a"
-                ],
-                "24.0.0-linux_arm64": [
-                  "node-v24.0.0-linux-arm64.tar.xz",
-                  "node-v24.0.0-linux-arm64",
-                  "d40ec7ffe0b82b02dce94208c84351424099bd70fa3a42b65c46d95322305040"
-                ],
-                "24.0.0-linux_ppc64le": [
-                  "node-v24.0.0-linux-ppc64le.tar.xz",
-                  "node-v24.0.0-linux-ppc64le",
-                  "cfa0e8d51a2f9a446f1bfb81cdf4c7e95336ad622e2aa230e3fa1d093c63d77d"
-                ],
-                "24.0.0-linux_s390x": [
-                  "node-v24.0.0-linux-s390x.tar.xz",
-                  "node-v24.0.0-linux-s390x",
-                  "e37a04c7ee05416ec1234fd3255e05b6b81287eb0424a57441c8b69f0a155021"
-                ],
-                "24.0.0-linux_amd64": [
-                  "node-v24.0.0-linux-x64.tar.xz",
-                  "node-v24.0.0-linux-x64",
-                  "59b8af617dccd7f9f68cc8451b2aee1e86d6bd5cb92cd51dd6216a31b707efd7"
-                ],
-                "24.0.0-windows_amd64": [
-                  "node-v24.0.0-win-x64.zip",
-                  "node-v24.0.0-win-x64",
-                  "3d0fff80c87bb9a8d7f49f2f27832aa34a1477d137af46f5b14df5498be81304"
-                ]
-              },
+              "node_repositories": {},
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
@@ -1814,43 +1527,7 @@
             "ruleClassName": "_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {
-                "24.0.0-darwin_arm64": [
-                  "node-v24.0.0-darwin-arm64.tar.gz",
-                  "node-v24.0.0-darwin-arm64",
-                  "194e2f3dd3ec8c2adcaa713ed40f44c5ca38467880e160974ceac1659be60121"
-                ],
-                "24.0.0-darwin_amd64": [
-                  "node-v24.0.0-darwin-x64.tar.gz",
-                  "node-v24.0.0-darwin-x64",
-                  "f716b3ce14a7e37a6cbf97c9de10d444d7da07ef833cd8da81dd944d111e6a4a"
-                ],
-                "24.0.0-linux_arm64": [
-                  "node-v24.0.0-linux-arm64.tar.xz",
-                  "node-v24.0.0-linux-arm64",
-                  "d40ec7ffe0b82b02dce94208c84351424099bd70fa3a42b65c46d95322305040"
-                ],
-                "24.0.0-linux_ppc64le": [
-                  "node-v24.0.0-linux-ppc64le.tar.xz",
-                  "node-v24.0.0-linux-ppc64le",
-                  "cfa0e8d51a2f9a446f1bfb81cdf4c7e95336ad622e2aa230e3fa1d093c63d77d"
-                ],
-                "24.0.0-linux_s390x": [
-                  "node-v24.0.0-linux-s390x.tar.xz",
-                  "node-v24.0.0-linux-s390x",
-                  "e37a04c7ee05416ec1234fd3255e05b6b81287eb0424a57441c8b69f0a155021"
-                ],
-                "24.0.0-linux_amd64": [
-                  "node-v24.0.0-linux-x64.tar.xz",
-                  "node-v24.0.0-linux-x64",
-                  "59b8af617dccd7f9f68cc8451b2aee1e86d6bd5cb92cd51dd6216a31b707efd7"
-                ],
-                "24.0.0-windows_amd64": [
-                  "node-v24.0.0-win-x64.zip",
-                  "node-v24.0.0-win-x64",
-                  "3d0fff80c87bb9a8d7f49f2f27832aa34a1477d137af46f5b14df5498be81304"
-                ]
-              },
+              "node_repositories": {},
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
@@ -1864,43 +1541,7 @@
             "ruleClassName": "_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {
-                "24.0.0-darwin_arm64": [
-                  "node-v24.0.0-darwin-arm64.tar.gz",
-                  "node-v24.0.0-darwin-arm64",
-                  "194e2f3dd3ec8c2adcaa713ed40f44c5ca38467880e160974ceac1659be60121"
-                ],
-                "24.0.0-darwin_amd64": [
-                  "node-v24.0.0-darwin-x64.tar.gz",
-                  "node-v24.0.0-darwin-x64",
-                  "f716b3ce14a7e37a6cbf97c9de10d444d7da07ef833cd8da81dd944d111e6a4a"
-                ],
-                "24.0.0-linux_arm64": [
-                  "node-v24.0.0-linux-arm64.tar.xz",
-                  "node-v24.0.0-linux-arm64",
-                  "d40ec7ffe0b82b02dce94208c84351424099bd70fa3a42b65c46d95322305040"
-                ],
-                "24.0.0-linux_ppc64le": [
-                  "node-v24.0.0-linux-ppc64le.tar.xz",
-                  "node-v24.0.0-linux-ppc64le",
-                  "cfa0e8d51a2f9a446f1bfb81cdf4c7e95336ad622e2aa230e3fa1d093c63d77d"
-                ],
-                "24.0.0-linux_s390x": [
-                  "node-v24.0.0-linux-s390x.tar.xz",
-                  "node-v24.0.0-linux-s390x",
-                  "e37a04c7ee05416ec1234fd3255e05b6b81287eb0424a57441c8b69f0a155021"
-                ],
-                "24.0.0-linux_amd64": [
-                  "node-v24.0.0-linux-x64.tar.xz",
-                  "node-v24.0.0-linux-x64",
-                  "59b8af617dccd7f9f68cc8451b2aee1e86d6bd5cb92cd51dd6216a31b707efd7"
-                ],
-                "24.0.0-windows_amd64": [
-                  "node-v24.0.0-win-x64.zip",
-                  "node-v24.0.0-win-x64",
-                  "3d0fff80c87bb9a8d7f49f2f27832aa34a1477d137af46f5b14df5498be81304"
-                ]
-              },
+              "node_repositories": {},
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
@@ -1914,43 +1555,7 @@
             "ruleClassName": "_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {
-                "24.0.0-darwin_arm64": [
-                  "node-v24.0.0-darwin-arm64.tar.gz",
-                  "node-v24.0.0-darwin-arm64",
-                  "194e2f3dd3ec8c2adcaa713ed40f44c5ca38467880e160974ceac1659be60121"
-                ],
-                "24.0.0-darwin_amd64": [
-                  "node-v24.0.0-darwin-x64.tar.gz",
-                  "node-v24.0.0-darwin-x64",
-                  "f716b3ce14a7e37a6cbf97c9de10d444d7da07ef833cd8da81dd944d111e6a4a"
-                ],
-                "24.0.0-linux_arm64": [
-                  "node-v24.0.0-linux-arm64.tar.xz",
-                  "node-v24.0.0-linux-arm64",
-                  "d40ec7ffe0b82b02dce94208c84351424099bd70fa3a42b65c46d95322305040"
-                ],
-                "24.0.0-linux_ppc64le": [
-                  "node-v24.0.0-linux-ppc64le.tar.xz",
-                  "node-v24.0.0-linux-ppc64le",
-                  "cfa0e8d51a2f9a446f1bfb81cdf4c7e95336ad622e2aa230e3fa1d093c63d77d"
-                ],
-                "24.0.0-linux_s390x": [
-                  "node-v24.0.0-linux-s390x.tar.xz",
-                  "node-v24.0.0-linux-s390x",
-                  "e37a04c7ee05416ec1234fd3255e05b6b81287eb0424a57441c8b69f0a155021"
-                ],
-                "24.0.0-linux_amd64": [
-                  "node-v24.0.0-linux-x64.tar.xz",
-                  "node-v24.0.0-linux-x64",
-                  "59b8af617dccd7f9f68cc8451b2aee1e86d6bd5cb92cd51dd6216a31b707efd7"
-                ],
-                "24.0.0-windows_amd64": [
-                  "node-v24.0.0-win-x64.zip",
-                  "node-v24.0.0-win-x64",
-                  "3d0fff80c87bb9a8d7f49f2f27832aa34a1477d137af46f5b14df5498be81304"
-                ]
-              },
+              "node_repositories": {},
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
@@ -1964,43 +1569,7 @@
             "ruleClassName": "_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {
-                "24.0.0-darwin_arm64": [
-                  "node-v24.0.0-darwin-arm64.tar.gz",
-                  "node-v24.0.0-darwin-arm64",
-                  "194e2f3dd3ec8c2adcaa713ed40f44c5ca38467880e160974ceac1659be60121"
-                ],
-                "24.0.0-darwin_amd64": [
-                  "node-v24.0.0-darwin-x64.tar.gz",
-                  "node-v24.0.0-darwin-x64",
-                  "f716b3ce14a7e37a6cbf97c9de10d444d7da07ef833cd8da81dd944d111e6a4a"
-                ],
-                "24.0.0-linux_arm64": [
-                  "node-v24.0.0-linux-arm64.tar.xz",
-                  "node-v24.0.0-linux-arm64",
-                  "d40ec7ffe0b82b02dce94208c84351424099bd70fa3a42b65c46d95322305040"
-                ],
-                "24.0.0-linux_ppc64le": [
-                  "node-v24.0.0-linux-ppc64le.tar.xz",
-                  "node-v24.0.0-linux-ppc64le",
-                  "cfa0e8d51a2f9a446f1bfb81cdf4c7e95336ad622e2aa230e3fa1d093c63d77d"
-                ],
-                "24.0.0-linux_s390x": [
-                  "node-v24.0.0-linux-s390x.tar.xz",
-                  "node-v24.0.0-linux-s390x",
-                  "e37a04c7ee05416ec1234fd3255e05b6b81287eb0424a57441c8b69f0a155021"
-                ],
-                "24.0.0-linux_amd64": [
-                  "node-v24.0.0-linux-x64.tar.xz",
-                  "node-v24.0.0-linux-x64",
-                  "59b8af617dccd7f9f68cc8451b2aee1e86d6bd5cb92cd51dd6216a31b707efd7"
-                ],
-                "24.0.0-windows_amd64": [
-                  "node-v24.0.0-win-x64.zip",
-                  "node-v24.0.0-win-x64",
-                  "3d0fff80c87bb9a8d7f49f2f27832aa34a1477d137af46f5b14df5498be81304"
-                ]
-              },
+              "node_repositories": {},
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
@@ -2014,43 +1583,7 @@
             "ruleClassName": "_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {
-                "24.0.0-darwin_arm64": [
-                  "node-v24.0.0-darwin-arm64.tar.gz",
-                  "node-v24.0.0-darwin-arm64",
-                  "194e2f3dd3ec8c2adcaa713ed40f44c5ca38467880e160974ceac1659be60121"
-                ],
-                "24.0.0-darwin_amd64": [
-                  "node-v24.0.0-darwin-x64.tar.gz",
-                  "node-v24.0.0-darwin-x64",
-                  "f716b3ce14a7e37a6cbf97c9de10d444d7da07ef833cd8da81dd944d111e6a4a"
-                ],
-                "24.0.0-linux_arm64": [
-                  "node-v24.0.0-linux-arm64.tar.xz",
-                  "node-v24.0.0-linux-arm64",
-                  "d40ec7ffe0b82b02dce94208c84351424099bd70fa3a42b65c46d95322305040"
-                ],
-                "24.0.0-linux_ppc64le": [
-                  "node-v24.0.0-linux-ppc64le.tar.xz",
-                  "node-v24.0.0-linux-ppc64le",
-                  "cfa0e8d51a2f9a446f1bfb81cdf4c7e95336ad622e2aa230e3fa1d093c63d77d"
-                ],
-                "24.0.0-linux_s390x": [
-                  "node-v24.0.0-linux-s390x.tar.xz",
-                  "node-v24.0.0-linux-s390x",
-                  "e37a04c7ee05416ec1234fd3255e05b6b81287eb0424a57441c8b69f0a155021"
-                ],
-                "24.0.0-linux_amd64": [
-                  "node-v24.0.0-linux-x64.tar.xz",
-                  "node-v24.0.0-linux-x64",
-                  "59b8af617dccd7f9f68cc8451b2aee1e86d6bd5cb92cd51dd6216a31b707efd7"
-                ],
-                "24.0.0-windows_amd64": [
-                  "node-v24.0.0-win-x64.zip",
-                  "node-v24.0.0-win-x64",
-                  "3d0fff80c87bb9a8d7f49f2f27832aa34a1477d137af46f5b14df5498be81304"
-                ]
-              },
+              "node_repositories": {},
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
@@ -2064,43 +1597,7 @@
             "ruleClassName": "_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {
-                "24.0.0-darwin_arm64": [
-                  "node-v24.0.0-darwin-arm64.tar.gz",
-                  "node-v24.0.0-darwin-arm64",
-                  "194e2f3dd3ec8c2adcaa713ed40f44c5ca38467880e160974ceac1659be60121"
-                ],
-                "24.0.0-darwin_amd64": [
-                  "node-v24.0.0-darwin-x64.tar.gz",
-                  "node-v24.0.0-darwin-x64",
-                  "f716b3ce14a7e37a6cbf97c9de10d444d7da07ef833cd8da81dd944d111e6a4a"
-                ],
-                "24.0.0-linux_arm64": [
-                  "node-v24.0.0-linux-arm64.tar.xz",
-                  "node-v24.0.0-linux-arm64",
-                  "d40ec7ffe0b82b02dce94208c84351424099bd70fa3a42b65c46d95322305040"
-                ],
-                "24.0.0-linux_ppc64le": [
-                  "node-v24.0.0-linux-ppc64le.tar.xz",
-                  "node-v24.0.0-linux-ppc64le",
-                  "cfa0e8d51a2f9a446f1bfb81cdf4c7e95336ad622e2aa230e3fa1d093c63d77d"
-                ],
-                "24.0.0-linux_s390x": [
-                  "node-v24.0.0-linux-s390x.tar.xz",
-                  "node-v24.0.0-linux-s390x",
-                  "e37a04c7ee05416ec1234fd3255e05b6b81287eb0424a57441c8b69f0a155021"
-                ],
-                "24.0.0-linux_amd64": [
-                  "node-v24.0.0-linux-x64.tar.xz",
-                  "node-v24.0.0-linux-x64",
-                  "59b8af617dccd7f9f68cc8451b2aee1e86d6bd5cb92cd51dd6216a31b707efd7"
-                ],
-                "24.0.0-windows_amd64": [
-                  "node-v24.0.0-win-x64.zip",
-                  "node-v24.0.0-win-x64",
-                  "3d0fff80c87bb9a8d7f49f2f27832aa34a1477d137af46f5b14df5498be81304"
-                ]
-              },
+              "node_repositories": {},
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
@@ -2114,43 +1611,7 @@
             "ruleClassName": "_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {
-                "24.0.0-darwin_arm64": [
-                  "node-v24.0.0-darwin-arm64.tar.gz",
-                  "node-v24.0.0-darwin-arm64",
-                  "194e2f3dd3ec8c2adcaa713ed40f44c5ca38467880e160974ceac1659be60121"
-                ],
-                "24.0.0-darwin_amd64": [
-                  "node-v24.0.0-darwin-x64.tar.gz",
-                  "node-v24.0.0-darwin-x64",
-                  "f716b3ce14a7e37a6cbf97c9de10d444d7da07ef833cd8da81dd944d111e6a4a"
-                ],
-                "24.0.0-linux_arm64": [
-                  "node-v24.0.0-linux-arm64.tar.xz",
-                  "node-v24.0.0-linux-arm64",
-                  "d40ec7ffe0b82b02dce94208c84351424099bd70fa3a42b65c46d95322305040"
-                ],
-                "24.0.0-linux_ppc64le": [
-                  "node-v24.0.0-linux-ppc64le.tar.xz",
-                  "node-v24.0.0-linux-ppc64le",
-                  "cfa0e8d51a2f9a446f1bfb81cdf4c7e95336ad622e2aa230e3fa1d093c63d77d"
-                ],
-                "24.0.0-linux_s390x": [
-                  "node-v24.0.0-linux-s390x.tar.xz",
-                  "node-v24.0.0-linux-s390x",
-                  "e37a04c7ee05416ec1234fd3255e05b6b81287eb0424a57441c8b69f0a155021"
-                ],
-                "24.0.0-linux_amd64": [
-                  "node-v24.0.0-linux-x64.tar.xz",
-                  "node-v24.0.0-linux-x64",
-                  "59b8af617dccd7f9f68cc8451b2aee1e86d6bd5cb92cd51dd6216a31b707efd7"
-                ],
-                "24.0.0-windows_amd64": [
-                  "node-v24.0.0-win-x64.zip",
-                  "node-v24.0.0-win-x64",
-                  "3d0fff80c87bb9a8d7f49f2f27832aa34a1477d137af46f5b14df5498be81304"
-                ]
-              },
+              "node_repositories": {},
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
@@ -2164,43 +1625,7 @@
             "ruleClassName": "_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {
-                "24.0.0-darwin_arm64": [
-                  "node-v24.0.0-darwin-arm64.tar.gz",
-                  "node-v24.0.0-darwin-arm64",
-                  "194e2f3dd3ec8c2adcaa713ed40f44c5ca38467880e160974ceac1659be60121"
-                ],
-                "24.0.0-darwin_amd64": [
-                  "node-v24.0.0-darwin-x64.tar.gz",
-                  "node-v24.0.0-darwin-x64",
-                  "f716b3ce14a7e37a6cbf97c9de10d444d7da07ef833cd8da81dd944d111e6a4a"
-                ],
-                "24.0.0-linux_arm64": [
-                  "node-v24.0.0-linux-arm64.tar.xz",
-                  "node-v24.0.0-linux-arm64",
-                  "d40ec7ffe0b82b02dce94208c84351424099bd70fa3a42b65c46d95322305040"
-                ],
-                "24.0.0-linux_ppc64le": [
-                  "node-v24.0.0-linux-ppc64le.tar.xz",
-                  "node-v24.0.0-linux-ppc64le",
-                  "cfa0e8d51a2f9a446f1bfb81cdf4c7e95336ad622e2aa230e3fa1d093c63d77d"
-                ],
-                "24.0.0-linux_s390x": [
-                  "node-v24.0.0-linux-s390x.tar.xz",
-                  "node-v24.0.0-linux-s390x",
-                  "e37a04c7ee05416ec1234fd3255e05b6b81287eb0424a57441c8b69f0a155021"
-                ],
-                "24.0.0-linux_amd64": [
-                  "node-v24.0.0-linux-x64.tar.xz",
-                  "node-v24.0.0-linux-x64",
-                  "59b8af617dccd7f9f68cc8451b2aee1e86d6bd5cb92cd51dd6216a31b707efd7"
-                ],
-                "24.0.0-windows_amd64": [
-                  "node-v24.0.0-win-x64.zip",
-                  "node-v24.0.0-win-x64",
-                  "3d0fff80c87bb9a8d7f49f2f27832aa34a1477d137af46f5b14df5498be81304"
-                ]
-              },
+              "node_repositories": {},
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],


### PR DESCRIPTION
See associated pull request for more information.

Closes #31552 as a pr takeover
