### PR TITLE
refactor(@angular/cli): use command default for unspecified target builders

### DIFF
--- a/packages/angular/cli/src/command-builder/architect-command-module.ts
+++ b/packages/angular/cli/src/command-builder/architect-command-module.ts
@@ -41,7 +41,8 @@ export abstract class ArchitectCommandModule
     // Add default builder if target is not in project and a command default is provided
     if (this.findDefaultBuilderName && this.context.workspace) {
       for (const [project, projectDefinition] of this.context.workspace.projects) {
-        if (projectDefinition.targets.has(target)) {
+        const targetDefinition = projectDefinition.targets.get(target);
+        if (targetDefinition?.builder) {
           continue;
         }
 
@@ -49,7 +50,13 @@ export abstract class ArchitectCommandModule
           project,
           target,
         });
-        if (defaultBuilder) {
+        if (!defaultBuilder) {
+          continue;
+        }
+
+        if (targetDefinition) {
+          targetDefinition.builder = defaultBuilder;
+        } else {
           projectDefinition.targets.set(target, {
             builder: defaultBuilder,
           });


### PR DESCRIPTION
If a target definition from a project's configuration does not contain a `builder` field and the CLI command provides a default, the default will now be used for the command execution. This is in addition to the existing case where the command will use a synthetic target definition for commands that provide default builders.