### PR TITLE
fix(@schematics/angular): remove empty i18n-extract target for new projects

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -327,9 +327,6 @@ function addAppToWorkspaceFile(options: ApplicationOptions, appDir: string): Rul
           },
         },
       },
-      'extract-i18n': {
-        builder: Builders.BuildExtractI18n,
-      },
       test: options.minimal
         ? undefined
         : {


### PR DESCRIPTION
The Angular CLI will default to using the correct builder for i18n extraction if the target definition is not present in a project. This allows for a reduced amount of preset configuration for new projects. The `i18n-extract` is only needed when using the `@angular/localize` project and can be added when it is used. Most options for the target are also command line oriented which makes the target definition unused in many cases.