### PR TITLE
fix(@schematics/angular): preserve blank lines in jasmine-to-vitest schematic

### DIFF
--- a/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.integration_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.integration_spec.ts
@@ -16,9 +16,7 @@ async function expectTransformation(input: string, expected: string): Promise<vo
   const reporter = new RefactorReporter(logger);
   const transformed = transformJasmineToVitest('spec.ts', input, reporter);
   const formattedTransformed = await format(transformed, { parser: 'typescript' });
-  let formattedExpected = await format(expected, { parser: 'typescript' });
-  // Strip blank lines to avoid test failures due to cosmetic differences.
-  formattedExpected = formattedExpected.replace(/\n\s*\n/g, '\n');
+  const formattedExpected = await format(expected, { parser: 'typescript' });
 
   expect(formattedTransformed).toBe(formattedExpected);
 }


### PR DESCRIPTION
The TypeScript printer, by design, does not retain blank lines. This caused the jasmine-to-vitest refactoring schematic to produce code that lost the original file's vertical spacing, harming readability.

This commit introduces a pre- and post-processing step within the main transformation function. Before parsing, blank lines are converted into unique placeholder comments. After the TypeScript printer generates the new code, these placeholders are converted back into blank lines, ensuring that the vertical formatting of the original file is preserved in the transformed output.