### PR TITLE
feat(@schematics/angular): configure Vitest for new projects and libraries

### DIFF
--- a/packages/schematics/angular/application/files/common-files/tsconfig.spec.json.template
+++ b/packages/schematics/angular/application/files/common-files/tsconfig.spec.json.template
@@ -4,10 +4,9 @@
   "extends": "<%= relativePathToWorkspaceRoot %>/tsconfig.json",
   "compilerOptions": {
     "outDir": "<%= relativePathToWorkspaceRoot %>/out-tsc/spec",
-    "types": [
-      "jasmine"
-    ]
-  },
+          "types": [
+            "<%= testRunner === 'vitest' ? 'vitest/globals' : 'jasmine' %>"
+          ]  },
   "include": [
     "src/**/*.ts"
   ]

--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -132,6 +132,7 @@ export default function (options: ApplicationOptions): Rule {
             appName: options.name,
             folderName,
             suffix,
+            testRunner: options.testRunner,
           }),
           move(appDir),
         ]),
@@ -181,6 +182,65 @@ function addDependenciesToPackageJson(options: ApplicationOptions): Rule {
         install: options.skipInstall ? InstallBehavior.None : InstallBehavior.Auto,
       }),
     );
+  }
+
+  if (!options.skipTests) {
+    if (options.testRunner === 'vitest') {
+      rules.push(
+        addDependency('vitest', latestVersions['vitest'], {
+          type: DependencyType.Dev,
+          existing: ExistingBehavior.Skip,
+          install: options.skipInstall ? InstallBehavior.None : InstallBehavior.Auto,
+        }),
+        addDependency('jsdom', latestVersions['jsdom'], {
+          type: DependencyType.Dev,
+          existing: ExistingBehavior.Skip,
+          install: options.skipInstall ? InstallBehavior.None : InstallBehavior.Auto,
+        }),
+      );
+    } else {
+      rules.push(
+        addDependency('karma', latestVersions['karma'], {
+          type: DependencyType.Dev,
+          existing: ExistingBehavior.Skip,
+          install: options.skipInstall ? InstallBehavior.None : InstallBehavior.Auto,
+        }),
+        addDependency('karma-chrome-launcher', latestVersions['karma-chrome-launcher'], {
+          type: DependencyType.Dev,
+          existing: ExistingBehavior.Skip,
+          install: options.skipInstall ? InstallBehavior.None : InstallBehavior.Auto,
+        }),
+        addDependency('karma-coverage', latestVersions['karma-coverage'], {
+          type: DependencyType.Dev,
+          existing: ExistingBehavior.Skip,
+          install: options.skipInstall ? InstallBehavior.None : InstallBehavior.Auto,
+        }),
+        addDependency('karma-jasmine', latestVersions['karma-jasmine'], {
+          type: DependencyType.Dev,
+          existing: ExistingBehavior.Skip,
+          install: options.skipInstall ? InstallBehavior.None : InstallBehavior.Auto,
+        }),
+        addDependency(
+          'karma-jasmine-html-reporter',
+          latestVersions['karma-jasmine-html-reporter'],
+          {
+            type: DependencyType.Dev,
+            existing: ExistingBehavior.Skip,
+            install: options.skipInstall ? InstallBehavior.None : InstallBehavior.Auto,
+          },
+        ),
+        addDependency('jasmine-core', latestVersions['jasmine-core'], {
+          type: DependencyType.Dev,
+          existing: ExistingBehavior.Skip,
+          install: options.skipInstall ? InstallBehavior.None : InstallBehavior.Auto,
+        }),
+        addDependency('@types/jasmine', latestVersions['@types/jasmine'], {
+          type: DependencyType.Dev,
+          existing: ExistingBehavior.Skip,
+          install: options.skipInstall ? InstallBehavior.None : InstallBehavior.Auto,
+        }),
+      );
+    }
   }
 
   return chain(rules);
@@ -327,18 +387,24 @@ function addAppToWorkspaceFile(options: ApplicationOptions, appDir: string): Rul
           },
         },
       },
-      test: options.minimal
-        ? undefined
-        : {
-            builder: Builders.BuildKarma,
-            options: {
-              polyfills: options.zoneless ? undefined : ['zone.js', 'zone.js/testing'],
-              tsConfig: `${projectRoot}tsconfig.spec.json`,
-              inlineStyleLanguage,
-              assets: [{ 'glob': '**/*', 'input': `${projectRoot}public` }],
-              styles: [`${sourceRoot}/styles.${options.style}`],
-            },
-          },
+      test:
+        options.skipTests || options.minimal
+          ? undefined
+          : options.testRunner === 'vitest'
+            ? {
+                builder: Builders.BuildUnitTest,
+                options: {},
+              }
+            : {
+                builder: Builders.BuildKarma,
+                options: {
+                  polyfills: options.zoneless ? undefined : ['zone.js', 'zone.js/testing'],
+                  tsConfig: `${projectRoot}tsconfig.spec.json`,
+                  inlineStyleLanguage,
+                  assets: [{ 'glob': '**/*', 'input': `${projectRoot}public` }],
+                  styles: [`${sourceRoot}/styles.${options.style}`],
+                },
+              },
     },
   };
 

--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -89,6 +89,12 @@
       "default": false,
       "alias": "S"
     },
+    "testRunner": {
+      "description": "The unit testing runner to use.",
+      "type": "string",
+      "enum": ["vitest", "karma"],
+      "default": "vitest"
+    },
     "skipPackageJson": {
       "type": "boolean",
       "default": false,

--- a/packages/schematics/angular/config/index_spec.ts
+++ b/packages/schematics/angular/config/index_spec.ts
@@ -50,6 +50,12 @@ describe('Config Schematic', () => {
       defaultAppOptions,
       workspaceTree,
     );
+
+    // Set builder to a karma builder for testing purposes
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const angularJson = applicationTree.readJson('angular.json') as any;
+    angularJson['projects']['foo']['architect']['test']['builder'] = '@angular/build:karma';
+    applicationTree.overwrite('angular.json', JSON.stringify(angularJson));
   });
 
   describe(`when 'type' is 'karma'`, () => {

--- a/packages/schematics/angular/library/files/tsconfig.spec.json.template
+++ b/packages/schematics/angular/library/files/tsconfig.spec.json.template
@@ -5,7 +5,7 @@
   "compilerOptions": {
     "outDir": "<%= relativePathToWorkspaceRoot %>/out-tsc/spec",
     "types": [
-      "jasmine"
+      "<%= testTypesPackage %>"
     ]
   },
   "include": [

--- a/packages/schematics/angular/library/index_spec.ts
+++ b/packages/schematics/angular/library/index_spec.ts
@@ -414,6 +414,17 @@ describe('Library Schematic', () => {
     expect(workspace.projects.foo.architect.test.builder).toBe('@angular/build:karma');
   });
 
+  it(`should add 'unit-test' test builder`, async () => {
+    const packageJson = getJsonFileContent(workspaceTree, 'package.json');
+    packageJson['devDependencies']['vitest'] = '^4.0.0';
+    workspaceTree.overwrite('package.json', JSON.stringify(packageJson));
+
+    const tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
+
+    const workspace = JSON.parse(tree.readContent('/angular.json'));
+    expect(workspace.projects.foo.architect.test.builder).toBe('@angular/build:unit-test');
+  });
+
   describe('standalone=false', () => {
     const defaultNonStandaloneOptions = { ...defaultOptions, standalone: false };
 

--- a/packages/schematics/angular/ng-new/index.ts
+++ b/packages/schematics/angular/ng-new/index.ts
@@ -23,6 +23,7 @@ import {
   RepositoryInitializerTask,
 } from '@angular-devkit/schematics/tasks';
 import { Schema as ApplicationOptions } from '../application/schema';
+import { JSONFile } from '../utility/json-file';
 import { Schema as WorkspaceOptions } from '../workspace/schema';
 import { Schema as NgNewOptions } from './schema';
 
@@ -50,6 +51,7 @@ export default function (options: NgNewOptions): Rule {
     routing: options.routing,
     style: options.style,
     skipTests: options.skipTests,
+    testRunner: options.testRunner,
     skipPackageJson: false,
     // always 'skipInstall' here, so that we do it after the move
     skipInstall: true,
@@ -69,6 +71,12 @@ export default function (options: NgNewOptions): Rule {
         schematic('ai-config', {
           tool: options.aiConfig?.length ? options.aiConfig : undefined,
         }),
+        (tree: Tree) => {
+          if (options.testRunner === 'karma') {
+            const file = new JSONFile(tree, 'angular.json');
+            file.modify(['schematics', '@schematics/angular:application', 'testRunner'], 'karma');
+          }
+        },
         move(options.directory),
       ]),
     ),

--- a/packages/schematics/angular/ng-new/index_spec.ts
+++ b/packages/schematics/angular/ng-new/index_spec.ts
@@ -158,6 +158,32 @@ describe('Ng New Schematic', () => {
     expect(schematics['@schematics/angular:resolver'].typeSeparator).toBe('.');
   });
 
+  it(`should set 'testRunner' to 'karma'`, async () => {
+    const options = { ...defaultOptions, testRunner: 'karma' as const };
+    const tree = await schematicRunner.runSchematic('ng-new', options);
+
+    const {
+      projects: {
+        'foo': {
+          architect: { test },
+        },
+      },
+    } = JSON.parse(tree.readContent('/bar/angular.json'));
+    expect(test.builder).toBe('@angular/build:karma');
+
+    const { devDependencies } = JSON.parse(tree.readContent('/bar/package.json'));
+    expect(devDependencies['karma']).toBeDefined();
+    expect(devDependencies['jasmine-core']).toBeDefined();
+  });
+
+  it(`should set 'testRunner' to 'karma' in workspace schematic options`, async () => {
+    const options = { ...defaultOptions, testRunner: 'karma' as const };
+    const tree = await schematicRunner.runSchematic('ng-new', options);
+
+    const { schematics } = JSON.parse(tree.readContent('/bar/angular.json'));
+    expect(schematics['@schematics/angular:application'].testRunner).toBe('karma');
+  });
+
   it(`should not add type to class name when file name style guide is '2016'`, async () => {
     const options = { ...defaultOptions, fileNameStyleGuide: '2016' };
 

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -108,6 +108,12 @@
       "default": false,
       "alias": "S"
     },
+    "testRunner": {
+      "description": "The unit testing runner to use.",
+      "type": "string",
+      "enum": ["vitest", "karma"],
+      "default": "vitest"
+    },
     "createApplication": {
       "description": "Create a new initial application project in the new workspace. When false, creates an empty workspace with no initial application. You can then use the `ng generate application` command to create applications in the `projects` directory.",
       "type": "boolean",

--- a/packages/schematics/angular/utility/latest-versions/package.json
+++ b/packages/schematics/angular/utility/latest-versions/package.json
@@ -15,6 +15,7 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "karma-jasmine": "~5.1.0",
     "karma": "~6.4.0",
+    "jsdom": "^27.0.0",
     "less": "^4.2.0",
     "postcss": "^8.5.3",
     "protractor": "~7.0.0",
@@ -24,6 +25,7 @@
     "tslib": "^2.3.0",
     "ts-node": "~10.9.0",
     "typescript": "~5.9.2",
+    "vitest": "^4.0.0",
     "zone.js": "~0.15.0"
   }
 }

--- a/packages/schematics/angular/utility/workspace-models.ts
+++ b/packages/schematics/angular/utility/workspace-models.ts
@@ -27,6 +27,7 @@ export enum Builders {
   BrowserEsbuild = '@angular-devkit/build-angular:browser-esbuild',
   Karma = '@angular-devkit/build-angular:karma',
   BuildKarma = '@angular/build:karma',
+  BuildUnitTest = '@angular/build:unit-test',
   TsLint = '@angular-devkit/build-angular:tslint',
   NgPackagr = '@angular-devkit/build-angular:ng-packagr',
   BuildNgPackagr = '@angular/build:ng-packagr',

--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -34,14 +34,7 @@
   },
   "devDependencies": {
     "@angular/cli": "<%= '^' + version %>",
-    "@angular/compiler-cli": "<%= latestVersions.Angular %>",<% if (!minimal) { %>
-    "@types/jasmine": "<%= latestVersions['@types/jasmine'] %>",
-    "jasmine-core": "<%= latestVersions['jasmine-core'] %>",
-    "karma": "<%= latestVersions['karma'] %>",
-    "karma-chrome-launcher": "<%= latestVersions['karma-chrome-launcher'] %>",
-    "karma-coverage": "<%= latestVersions['karma-coverage'] %>",
-    "karma-jasmine": "<%= latestVersions['karma-jasmine'] %>",
-    "karma-jasmine-html-reporter": "<%= latestVersions['karma-jasmine-html-reporter'] %>",<% } %>
+    "@angular/compiler-cli": "<%= latestVersions.Angular %>",
     "typescript": "<%= latestVersions['typescript'] %>"
   }
 }

--- a/tests/legacy-cli/e2e/initialize/500-create-project.ts
+++ b/tests/legacy-cli/e2e/initialize/500-create-project.ts
@@ -24,6 +24,8 @@ export default async function () {
       'new',
       'test-project',
       '--skip-install',
+      '--test-runner',
+      'karma',
       '--package-manager',
       getActivePackageManager(),
     );

--- a/tests/legacy-cli/e2e/tests/generate/directive/directive-prefix.ts
+++ b/tests/legacy-cli/e2e/tests/generate/directive/directive-prefix.ts
@@ -17,7 +17,9 @@ export default function () {
       )
       .then(() => ng('generate', 'directive', 'test2-directive'))
       .then(() => expectFileToMatch(join(directiveDir, 'test2-directive.ts'), /selector: '\[preW/))
-      .then(() => ng('generate', 'application', 'app-two', '--skip-install'))
+      .then(() =>
+        ng('generate', 'application', 'app-two', '--skip-install', '--test-runner', 'karma'),
+      )
       .then(() => useCIDefaults('app-two'))
       .then(() => useCIChrome('app-two', './projects/app-two'))
       .then(() =>

--- a/tests/legacy-cli/e2e/tests/misc/update-git-clean-subdirectory.ts
+++ b/tests/legacy-cli/e2e/tests/misc/update-git-clean-subdirectory.ts
@@ -11,7 +11,7 @@ export default async function () {
 
   await silentGit('init', '.');
 
-  await ng('new', 'subdirectory-test-project', '--skip-install');
+  await ng('new', 'subdirectory-test-project', '--skip-install', '--test-runner', 'karma');
   process.chdir('./subdirectory-test-project');
   await prepareProjectForE2e('subdirectory-test-project');
 


### PR DESCRIPTION
This commit updates the application, ng-new, and library schematics to configure Vitest as the default unit testing runner, replacing Karma and Jasmine. It also introduces a `testRunner` option to allow users to choose between `vitest` and `karma`.

Application & `ng new` Schematics:
- Adds a `testRunner` option to allow choosing between `vitest` (default) and `karma`.
- Sets "@angular/build:unit-test" as the builder for the "test" target when `vitest` is chosen, and "@angular/build:karma" for `karma`.
- Conditionally adds dependencies based on the selected runner.
- Updates "tsconfig.spec.json" to include "vitest/globals" or "jasmine" for type support.

Library Schematic:
- Conditionally configures the "test" target with the "@angular/build:unit-test" builder if Vitest is detected in the workspace.
- Dynamically sets the "types" in "tsconfig.spec.json" to "vitest/globals" or "jasmine" based on the presence of Vitest.