### PR TITLE
build: remove `minimumReleaseAgeExclude` for `vitest`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,5 +26,3 @@ minimumReleaseAgeExclude:
   - '@ngtools/webpack'
   - '@schematics/*'
   - 'ng-packagr'
-  - 'vitest' # temporary to support v21
-  - '@vitest/*' # temporary to support v21


### PR DESCRIPTION
This is no longer required.
