### PR TITLE
fix(@schematics/angular): correct style guide paths for standalone components

### DIFF
--- a/packages/schematics/angular/application/files/standalone-files/src/app/app__suffix__.ts.template
+++ b/packages/schematics/angular/application/files/standalone-files/src/app/app__suffix__.ts.template
@@ -11,9 +11,9 @@ import { RouterOutlet } from '@angular/router';<% } %>
      %><router-outlet /><%
     } %>
   `,<% } else { %>
-  templateUrl: './app.html',<% } if(inlineStyle) { %>
+  templateUrl: './app<%= suffix %>.html',<% } if(inlineStyle) { %>
   styles: [],<% } else { %>
-  styleUrl: './app.<%= style %>'<% } %>
+  styleUrl: './app<%= suffix %>.<%= style %>'<% } %>
 })
 export class App {
   protected readonly title = signal('<%= name %>');

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -869,4 +869,14 @@ describe('Application Schematic', () => {
     const stylesContent = tree.readContent('/projects/foo/src/styles.css');
     expect(stylesContent).toContain('@import "tailwindcss";');
   });
+
+  describe(`fileNameStyleGuide: '2016'`, () => {
+    it('should create a component with the correct template and style urls', async () => {
+      const options = { ...defaultOptions, fileNameStyleGuide: '2016' as const };
+      const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+      const component = tree.readContent('/projects/foo/src/app/app.component.ts');
+      expect(component).toContain(`templateUrl: './app.component.html'`);
+      expect(component).toContain(`styleUrl: './app.component.css'`);
+    });
+  });
 });


### PR DESCRIPTION
This commit addresses an issue where the standalone application schematic did not correctly handle the `fileNameStyleGuide: '2016'` option. The `templateUrl` and `styleUrl` properties in the generated `app.component.ts` did not include the `.component` suffix, leading to broken links.

The key changes are:
- Updates the standalone component template to use the `suffix` variable for `templateUrl` and `styleUrl`, ensuring the correct file paths are generated.
- Adds a new test case to verify that the generated component has the correct paths when `fileNameStyleGuide: '2016'` is used.

Closes #31581