### PR TITLE
build: enable auto merge strategy for pull requests

### DIFF
--- a/.ng-dev/commit-message.mjs
+++ b/.ng-dev/commit-message.mjs
@@ -9,7 +9,6 @@ export const commitMessage = {
   maxLineLength: Infinity,
   minBodyLength: 0,
   minBodyLengthTypeExcludes: ['docs'],
-  disallowFixup: true,
   // Note: When changing this logic, also change the `contributing.ejs` file.
   scopes: packages.map(({ name }) => name),
 };

--- a/.ng-dev/pull-request.mjs
+++ b/.ng-dev/pull-request.mjs
@@ -1,12 +1,12 @@
 /**
  * Configuration for the merge tool in `ng-dev`. This sets up the labels which
  * are respected by the merge script (e.g. the target labels).
- * 
+ *
  * @type { import("@angular/ng-dev").PullRequestConfig }
  */
 export const pullRequest = {
   githubApiMerge: {
-    default: 'rebase',
+    default: 'auto',
     labels: [{ pattern: 'merge: squash commits', method: 'squash' }],
   },
 };


### PR DESCRIPTION
This commit enables the 'auto' merge strategy for pull requests. This strategy automatically determines the best merge method based on the pull request's commits.

The auto merge strategy can:
- Delegate to the autosquash merge strategy if the PR has fixup/squash commits against multiple normal commits.
- Squash commits if the PR has only one normal commit and some fixup/squash commits.
- Rebase commits if the PR has no fixup/squash commits.

This improves the developer experience by automating the merge process. A key benefit is that PRs that can be cleanly rebased will now appear as 'merged' in GitHub's UI, providing a clearer history than the previous 'unmerged' status that could occur with squashing.
