### PR TITLE
fix(@schematics/angular): correct spacing in application spec tsconfig

### DIFF
--- a/packages/schematics/angular/application/files/common-files/tsconfig.spec.json.template
+++ b/packages/schematics/angular/application/files/common-files/tsconfig.spec.json.template
@@ -4,9 +4,10 @@
   "extends": "<%= relativePathToWorkspaceRoot %>/tsconfig.json",
   "compilerOptions": {
     "outDir": "<%= relativePathToWorkspaceRoot %>/out-tsc/spec",
-          "types": [
-            "<%= testRunner === 'vitest' ? 'vitest/globals' : 'jasmine' %>"
-          ]  },
+    "types": [
+      "<%= testRunner === 'vitest' ? 'vitest/globals' : 'jasmine' %>"
+    ]
+  },
   "include": [
     "src/**/*.ts"
   ]


### PR DESCRIPTION
The `types` field in an application's `tsconfig.spec.json` was incorrectly indented too many places.