### PR TITLE
fix(@angular/build): add --ui option for Vitest runner

### DIFF
--- a/goldens/public-api/angular/build/index.api.md
+++ b/goldens/public-api/angular/build/index.api.md
@@ -237,6 +237,7 @@ export type UnitTestBuilderOptions = {
     runner?: Runner;
     setupFiles?: string[];
     tsConfig?: string;
+    ui?: boolean;
     watch?: boolean;
 };
 

--- a/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
@@ -137,6 +137,7 @@ export class VitestExecutor implements TestExecutor {
       debug,
       watch,
       browserViewport,
+      ui,
     } = this.options;
     let vitestNodeModule;
     try {
@@ -201,6 +202,7 @@ export class VitestExecutor implements TestExecutor {
         reporters: reporters ?? ['default'],
         outputFile,
         watch,
+        ui,
         coverage: await generateCoverageOption(coverage, this.projectName),
         ...debugOptions,
       },

--- a/packages/angular/build/src/builders/unit-test/schema.json
+++ b/packages/angular/build/src/builders/unit-test/schema.json
@@ -60,6 +60,11 @@
       "description": "Enables debugging mode for tests, allowing the use of the Node Inspector.",
       "default": false
     },
+    "ui": {
+      "type": "boolean",
+      "description": "Enables the Vitest UI for interactive test execution. This option is only available for the Vitest runner.",
+      "default": false
+    },
     "coverage": {
       "type": "boolean",
       "description": "Enables coverage reporting for tests.",


### PR DESCRIPTION
Adds a new `--ui` option to the `unit-test` builder to enable the Vitest UI for interactive test execution. This provides a rich, browser-based interface for viewing, filtering, and re-running tests, improving the overall developer experience.

The UI option implicitly enables watch mode to provide a live dashboard. If a user explicitly disables watch mode via `--no-watch` while the UI is enabled, a warning will be logged, and watch mode will be enforced to ensure the UI functions as expected.

This option is only available for the Vitest runner. An error will be thrown if used with the Karma runner.