### PR TITLE
fix(@angular/build): externalize Angular dependencies in Vitest runner

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
@@ -14,6 +14,21 @@ import { NormalizedUnitTestBuilderOptions, injectTestingPolyfills } from '../../
 import { findTests, getTestEntrypoints } from '../../test-discovery';
 import { RunnerOptions } from '../api';
 
+/**
+ * A list of Angular related packages that should be marked as external.
+ * This allows Vite to pre-bundle them, improving performance.
+ */
+const ANGULAR_PACKAGES_TO_EXTERNALIZE = [
+  '@angular/core',
+  '@angular/common',
+  '@angular/platform-browser',
+  '@angular/compiler',
+  '@angular/router',
+  '@angular/forms',
+  '@angular/animations',
+  'rxjs',
+];
+
 function createTestBedInitVirtualFile(
   providersFile: string | undefined,
   projectSourceRoot: string,
@@ -83,6 +98,11 @@ export async function getVitestBuildOptions(
   });
   entryPoints.set('init-testbed', 'angular:test-bed-init');
 
+  const externalDependencies = new Set(['vitest', ...ANGULAR_PACKAGES_TO_EXTERNALIZE]);
+  if (baseBuildOptions.externalDependencies) {
+    baseBuildOptions.externalDependencies.forEach((dep) => externalDependencies.add(dep));
+  }
+
   const buildOptions: Partial<ApplicationBuilderInternalOptions> = {
     ...baseBuildOptions,
     watch,
@@ -101,7 +121,7 @@ export async function getVitestBuildOptions(
     outputHashing: adjustOutputHashing(baseBuildOptions.outputHashing),
     optimization: false,
     entryPoints,
-    externalDependencies: ['vitest', '@vitest/browser/context'],
+    externalDependencies: [...externalDependencies],
   };
 
   buildOptions.polyfills = injectTestingPolyfills(buildOptions.polyfills);


### PR DESCRIPTION
Marks common Angular packages and RxJS as external within the Vitest test runner's build configuration. This allows Vite to perform dependency pre-bundling on these libraries, which can significantly improve build and rebuild performance during test execution.

The implementation introduces a constant to hold the list of packages and merges them with any externalDependencies that may already exist in the base build options, preserving user configuration.