### PR TITLE
fix(@angular-devkit/build-angular): ensure vitest code coverage handles virtual files correctly

### DIFF
--- a/packages/angular/build/src/builders/unit-test/tests/options/code-coverage_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/code-coverage_spec.ts
@@ -28,7 +28,7 @@ describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
 
       const { result } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
-      expect(harness.hasFile('coverage/test/index.html')).toBeFalse();
+      harness.expectFile('coverage/test/index.html').toNotExist();
     });
 
     it('should generate a code coverage report when coverage is true', async () => {
@@ -39,7 +39,19 @@ describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
 
       const { result } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
-      expect(harness.hasFile('coverage/test/index.html')).toBeTrue();
+      harness.expectFile('coverage/test/index.html').toExist();
+    });
+
+    it('should generate a code coverage report when coverage is true', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        coverage: true,
+        coverageReporters: ['json'] as any,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      harness.expectFile('coverage/test/coverage-final.json').content.toContain('app.component.ts');
     });
   });
 });


### PR DESCRIPTION
Vitest's default coverage provider checks for the physical existence of files to determine inclusion in the coverage report. This behavior excludes in-memory files generated by the build process from the final report. This change patches the `isIncluded` method of Vitest's `BaseCoverageProvider` to correctly account for these virtual files, ensuring they are included in the coverage analysis.

Additionally, bundler-generated helper code chunks without any original source code can have empty sourcemaps. Vitest includes files with such sourcemaps in the coverage report, which is incorrect. This change adds a virtual source to these sourcemaps to prevent them from being included in the final coverage output.

Closes #31601
