### PR TITLE
fix(@angular/build): add adapters to new reporter

### DIFF
--- a/packages/angular/build/src/builders/karma/application_builder.ts
+++ b/packages/angular/build/src/builders/karma/application_builder.ts
@@ -215,6 +215,8 @@ function injectKarmaReporter(
 
   class ProgressNotifierReporter {
     static $inject = ['emitter', LATEST_BUILD_FILES_TOKEN];
+    // Needed for the karma reporter interface, see https://github.com/angular/angular-cli/issues/31629
+    adapters = [];
 
     constructor(
       private readonly emitter: KarmaEmitter,


### PR DESCRIPTION
This commit add `adapters` field to the `ProgressNotifierReporter`.

Closes #31629

Cherry-pick of https://github.com/angular/angular-cli/pull/31630