### PR TITLE
refactor(@angular/build): remove Angular packages from externals for browser tests

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
@@ -98,7 +98,12 @@ export async function getVitestBuildOptions(
   });
   entryPoints.set('init-testbed', 'angular:test-bed-init');
 
-  const externalDependencies = new Set(['vitest', ...ANGULAR_PACKAGES_TO_EXTERNALIZE]);
+  const externalDependencies = new Set(['vitest']);
+  if (!options.browsers?.length) {
+    // Only add for non-browser setups.
+    // Comprehensive browser prebundling will be handled separately.
+    ANGULAR_PACKAGES_TO_EXTERNALIZE.forEach((dep) => externalDependencies.add(dep));
+  }
   if (baseBuildOptions.externalDependencies) {
     baseBuildOptions.externalDependencies.forEach((dep) => externalDependencies.add(dep));
   }


### PR DESCRIPTION
To facilitate the future implementation of more comprehensive Vite-based prebundling for browser-based unit tests, this change removes Angular packages from the list of external dependencies when a browser is configured.