### PR TITLE
fix(@angular/build): ensure locale data plugin runs before other plugins

### DIFF
--- a/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
@@ -686,7 +686,7 @@ function getEsBuildCommonPolyfillsOptions(
     needLocaleDataPlugin = true;
   }
   if (needLocaleDataPlugin) {
-    buildOptions.plugins.push(createAngularLocaleDataPlugin());
+    buildOptions.plugins.unshift(createAngularLocaleDataPlugin());
   }
 
   if (polyfills.length === 0) {


### PR DESCRIPTION
The Angular locale data plugin is responsible for resolving  imports. In some cases, other plugins would attempt to resolve these imports first, leading to a 'Failed to resolve import' error.

By ensuring that the Angular locale data plugin is prepended to the esbuild plugin list, we guarantee that it runs before other plugins, allowing it to correctly resolve the locale data imports.

Closes #31579
