### PR TITLE
Add build/serve MCP tools

### DIFF
--- a/packages/angular/cli/BUILD.bazel
+++ b/packages/angular/cli/BUILD.bazel
@@ -38,6 +38,7 @@ ts_project(
         ],
         exclude = [
             "**/*_spec.ts",
+            "**/testing/**",
         ],
     ) + [
         # These files are generated from the JSON schema
@@ -116,7 +117,10 @@ ts_project(
     name = "angular-cli_test_lib",
     testonly = True,
     srcs = glob(
-        include = ["**/*_spec.ts"],
+        include = [
+            "**/*_spec.ts",
+            "**/testing/**",
+        ],
         exclude = [
             # NB: we need to exclude the nested node_modules that is laid out by yarn workspaces
             "node_modules/**",

--- a/packages/angular/cli/src/commands/mcp/dev-server.ts
+++ b/packages/angular/cli/src/commands/mcp/dev-server.ts
@@ -1,0 +1,148 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { ChildProcess } from 'child_process';
+import { Host } from './host';
+
+// Log messages that we want to catch to identify the build status.
+
+const BUILD_SUCCEEDED_MESSAGE = 'Application bundle generation complete.';
+const BUILD_FAILED_MESSAGE = 'Application bundle generation failed.';
+const WAITING_FOR_CHANGES_MESSAGE = 'Watch mode enabled. Watching for file changes...';
+const CHANGES_DETECTED_START_MESSAGE = '❯ Changes detected. Rebuilding...';
+const CHANGES_DETECTED_SUCCESS_MESSAGE = '✔ Changes detected. Rebuilding...';
+
+const BUILD_START_MESSAGES = [CHANGES_DETECTED_START_MESSAGE];
+const BUILD_END_MESSAGES = [
+  BUILD_SUCCEEDED_MESSAGE,
+  BUILD_FAILED_MESSAGE,
+  WAITING_FOR_CHANGES_MESSAGE,
+  CHANGES_DETECTED_SUCCESS_MESSAGE,
+];
+
+export type BuildStatus = 'success' | 'failure' | 'unknown';
+
+/**
+ * An Angular development server managed by the MCP server.
+ */
+export interface DevServer {
+  /**
+   * Launches the dev server and returns immediately.
+   *
+   * Throws if this server is already running.
+   */
+  start(): void;
+
+  /**
+   * If the dev server is running, stops it.
+   */
+  stop(): void;
+
+  /**
+   * Gets all the server logs so far (stdout + stderr).
+   */
+  getServerLogs(): string[];
+
+  /**
+   * Gets all the server logs from the latest build.
+   */
+  getMostRecentBuild(): { status: BuildStatus; logs: string[] };
+
+  /**
+   * Whether the dev server is currently being built, or is awaiting further changes.
+   */
+  isBuilding(): boolean;
+
+  /**
+   * `ng serve` port to use.
+   */
+  port: number;
+}
+
+export function devServerKey(project?: string) {
+  return project ?? '<default>';
+}
+
+/**
+ * A local Angular development server managed by the MCP server.
+ */
+export class LocalDevServer implements DevServer {
+  readonly host: Host;
+  readonly port: number;
+  readonly project?: string;
+
+  private devServerProcess: ChildProcess | null = null;
+  private serverLogs: string[] = [];
+  private buildInProgress = false;
+  private latestBuildLogStartIndex?: number = undefined;
+  private latestBuildStatus: BuildStatus = 'unknown';
+
+  constructor({ host, port, project }: { host: Host; port: number; project?: string }) {
+    this.host = host;
+    this.project = project;
+    this.port = port;
+  }
+
+  start() {
+    if (this.devServerProcess) {
+      throw Error('Dev server already started.');
+    }
+
+    const args = ['serve'];
+    if (this.project) {
+      args.push(this.project);
+    }
+
+    args.push(`--port=${this.port}`);
+
+    this.devServerProcess = this.host.spawn('ng', args, { stdio: 'pipe' });
+    this.devServerProcess.stdout?.on('data', (data) => {
+      this.addLog(data.toString());
+    });
+    this.devServerProcess.stderr?.on('data', (data) => {
+      this.addLog(data.toString());
+    });
+    this.devServerProcess.stderr?.on('close', () => {
+      this.stop();
+    });
+    this.buildInProgress = true;
+  }
+
+  private addLog(log: string) {
+    this.serverLogs.push(log);
+
+    if (BUILD_START_MESSAGES.some((message) => log.startsWith(message))) {
+      this.buildInProgress = true;
+      this.latestBuildLogStartIndex = this.serverLogs.length - 1;
+    } else if (BUILD_END_MESSAGES.some((message) => log.startsWith(message))) {
+      this.buildInProgress = false;
+      // We consider everything except a specific failure message to be a success.
+      this.latestBuildStatus = log.startsWith(BUILD_FAILED_MESSAGE) ? 'failure' : 'success';
+    }
+  }
+
+  stop() {
+    this.devServerProcess?.kill();
+    this.devServerProcess = null;
+  }
+
+  getServerLogs(): string[] {
+    return [...this.serverLogs];
+  }
+
+  getMostRecentBuild() {
+    return {
+      status: this.latestBuildStatus,
+      logs: this.serverLogs.slice(this.latestBuildLogStartIndex),
+    };
+  }
+
+  isBuilding() {
+    return this.buildInProgress;
+  }
+}

--- a/packages/angular/cli/src/commands/mcp/mcp-server.ts
+++ b/packages/angular/cli/src/commands/mcp/mcp-server.ts
@@ -10,15 +10,25 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import path from 'node:path';
 import type { AngularWorkspace } from '../../utilities/config';
 import { VERSION } from '../../utilities/version';
+import { DevServer } from './dev-server';
 import { registerInstructionsResource } from './resources/instructions';
 import { AI_TUTOR_TOOL } from './tools/ai-tutor';
 import { BEST_PRACTICES_TOOL } from './tools/best-practices';
+import { BUILD_TOOL } from './tools/build';
+import { START_DEVSERVER_TOOL } from './tools/devserver/start-devserver';
+import { STOP_DEVSERVER_TOOL } from './tools/devserver/stop-devserver';
+import { WAIT_FOR_DEVSERVER_BUILD_TOOL } from './tools/devserver/wait-for-devserver-build';
 import { DOC_SEARCH_TOOL } from './tools/doc-search';
 import { FIND_EXAMPLE_TOOL } from './tools/examples';
 import { MODERNIZE_TOOL } from './tools/modernize';
 import { ZONELESS_MIGRATION_TOOL } from './tools/onpush-zoneless-migration/zoneless-migration';
 import { LIST_PROJECTS_TOOL } from './tools/projects';
 import { AnyMcpToolDeclaration, registerTools } from './tools/tool-registry';
+
+/**
+ * Tools to manage devservers. Should be bundled together, then added to experimental or stable as a group.
+ */
+const SERVE_TOOLS = [START_DEVSERVER_TOOL, STOP_DEVSERVER_TOOL, WAIT_FOR_DEVSERVER_BUILD_TOOL];
 
 /**
  * The set of tools that are enabled by default for the MCP server.
@@ -37,7 +47,7 @@ const STABLE_TOOLS = [
  * The set of tools that are available but not enabled by default.
  * These tools are considered experimental and may have limitations.
  */
-export const EXPERIMENTAL_TOOLS = [MODERNIZE_TOOL] as const;
+export const EXPERIMENTAL_TOOLS = [BUILD_TOOL, MODERNIZE_TOOL, ...SERVE_TOOLS] as const;
 
 export async function createMcpServer(
   options: {
@@ -104,6 +114,7 @@ equivalent actions.
       workspace: options.workspace,
       logger,
       exampleDatabasePath: path.join(__dirname, '../../../lib/code-examples.db'),
+      devServers: new Map<string, DevServer>(),
     },
     toolDeclarations,
   );

--- a/packages/angular/cli/src/commands/mcp/testing/mock-host.ts
+++ b/packages/angular/cli/src/commands/mcp/testing/mock-host.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { Host } from '../host';
+
+/**
+ * A mock implementation of the `Host` interface for testing purposes.
+ * This class allows spying on host methods and controlling their return values.
+ */
+export class MockHost implements Host {
+  runCommand = jasmine.createSpy('runCommand').and.resolveTo({ stdout: '', stderr: '' });
+  stat = jasmine.createSpy('stat');
+  existsSync = jasmine.createSpy('existsSync');
+  spawn = jasmine.createSpy('spawn');
+  getAvailablePort = jasmine.createSpy('getAvailablePort');
+}

--- a/packages/angular/cli/src/commands/mcp/tools/build.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/build.ts
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { z } from 'zod';
+import { CommandError, Host, LocalWorkspaceHost } from '../host';
+import { createStructuredContentOutput } from '../utils';
+import { McpToolDeclaration, declareTool } from './tool-registry';
+
+const DEFAULT_CONFIGURATION = 'development';
+
+const buildStatusSchema = z.enum(['success', 'failure']);
+type BuildStatus = z.infer<typeof buildStatusSchema>;
+
+const buildToolInputSchema = z.object({
+  project: z
+    .string()
+    .optional()
+    .describe(
+      'Which project to build in a monorepo context. If not provided, builds the default project.',
+    ),
+  configuration: z
+    .string()
+    .optional()
+    .describe('Which build configuration to use. Defaults to "development".'),
+});
+
+export type BuildToolInput = z.infer<typeof buildToolInputSchema>;
+
+const buildToolOutputSchema = z.object({
+  status: buildStatusSchema.describe('Build status.'),
+  logs: z.array(z.string()).optional().describe('Output logs from `ng build`.'),
+  path: z.string().optional().describe('The output location for the build, if successful.'),
+});
+
+export type BuildToolOutput = z.infer<typeof buildToolOutputSchema>;
+
+export async function runBuild(input: BuildToolInput, host: Host) {
+  // Build "ng"'s command line.
+  const args = ['build'];
+  if (input.project) {
+    args.push(input.project);
+  }
+  args.push('-c', input.configuration ?? DEFAULT_CONFIGURATION);
+
+  let status: BuildStatus = 'success';
+  let logs: string[] = [];
+  let outputPath: string | undefined;
+
+  try {
+    logs = (await host.runCommand('ng', args)).logs;
+  } catch (e) {
+    status = 'failure';
+    if (e instanceof CommandError) {
+      logs = e.logs;
+    } else if (e instanceof Error) {
+      logs = [e.message];
+    } else {
+      logs = [String(e)];
+    }
+  }
+
+  for (const line of logs) {
+    const match = line.match(/Output location: (.*)/);
+    if (match) {
+      outputPath = match[1].trim();
+      break;
+    }
+  }
+
+  const structuredContent: BuildToolOutput = {
+    status,
+    logs,
+    path: outputPath,
+  };
+
+  return createStructuredContentOutput(structuredContent);
+}
+
+export const BUILD_TOOL: McpToolDeclaration<
+  typeof buildToolInputSchema.shape,
+  typeof buildToolOutputSchema.shape
+> = declareTool({
+  name: 'build',
+  title: 'Build Tool',
+  description: `
+<Purpose>
+Perform a one-off, non-watched build using "ng build". Use this tool whenever the user wants to build an Angular project; this is similar to
+"ng build", but the tool is smarter about using the right configuration and collecting the output logs.
+</Purpose>
+<Use Cases>
+* Building an Angular project and getting build logs back.
+</Use Cases>
+<Operational Notes>
+* This tool runs "ng build" so it expects to run within an Angular workspace.
+* If you want a watched build which updates as files are changed, use "start_devserver" instead, which also serves the app.
+* You can provide a project instead of building the root one. The "list_projects" MCP tool could be used to obtain the list of projects.
+* This tool defaults to a development environment while a regular "ng build" defaults to a production environment. An unexpected build
+  failure might suggest the project is not configured for the requested environment.
+</Operational Notes>
+`,
+  isReadOnly: false,
+  isLocalOnly: true,
+  inputSchema: buildToolInputSchema.shape,
+  outputSchema: buildToolOutputSchema.shape,
+  factory: () => (input) => runBuild(input, LocalWorkspaceHost),
+});

--- a/packages/angular/cli/src/commands/mcp/tools/build_spec.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/build_spec.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { CommandError, Host } from '../host';
+import { MockHost } from '../testing/mock-host';
+import { runBuild } from './build';
+
+describe('Build Tool', () => {
+  let mockHost: MockHost;
+
+  beforeEach(() => {
+    mockHost = {
+      runCommand: jasmine.createSpy<Host['runCommand']>('runCommand').and.resolveTo({ logs: [] }),
+      stat: jasmine.createSpy<Host['stat']>('stat'),
+      existsSync: jasmine.createSpy<Host['existsSync']>('existsSync'),
+    } as Partial<MockHost> as MockHost;
+  });
+
+  it('should construct the command correctly with default configuration', async () => {
+    await runBuild({}, mockHost);
+    expect(mockHost.runCommand).toHaveBeenCalledWith('ng', ['build', '-c', 'development']);
+  });
+
+  it('should construct the command correctly with a specified project', async () => {
+    await runBuild({ project: 'another-app' }, mockHost);
+    expect(mockHost.runCommand).toHaveBeenCalledWith('ng', [
+      'build',
+      'another-app',
+      '-c',
+      'development',
+    ]);
+  });
+
+  it('should construct the command correctly for a custom configuration', async () => {
+    await runBuild({ configuration: 'myconfig' }, mockHost);
+    expect(mockHost.runCommand).toHaveBeenCalledWith('ng', ['build', '-c', 'myconfig']);
+  });
+
+  it('should handle a successful build and extract the output path and logs', async () => {
+    const buildLogs = [
+      'Build successful!',
+      'Some other log lines...',
+      'some warning',
+      'Output location: dist/my-app',
+    ];
+    mockHost.runCommand.and.resolveTo({
+      logs: buildLogs,
+    });
+
+    const { structuredContent } = await runBuild({ project: 'my-app' }, mockHost);
+
+    expect(mockHost.runCommand).toHaveBeenCalledWith('ng', [
+      'build',
+      'my-app',
+      '-c',
+      'development',
+    ]);
+    expect(structuredContent.status).toBe('success');
+    expect(structuredContent.logs).toEqual(buildLogs);
+    expect(structuredContent.path).toBe('dist/my-app');
+  });
+
+  it('should handle a failed build and capture logs', async () => {
+    const buildLogs = ['Some output before the crash.', 'Error: Something went wrong!'];
+    const error = new CommandError('Build failed', buildLogs, 1);
+    mockHost.runCommand.and.rejectWith(error);
+
+    const { structuredContent } = await runBuild(
+      { project: 'my-failed-app', configuration: 'production' },
+      mockHost,
+    );
+
+    expect(mockHost.runCommand).toHaveBeenCalledWith('ng', [
+      'build',
+      'my-failed-app',
+      '-c',
+      'production',
+    ]);
+    expect(structuredContent.status).toBe('failure');
+    expect(structuredContent.logs).toEqual(buildLogs);
+    expect(structuredContent.path).toBeUndefined();
+  });
+
+  it('should handle builds where the output path is not found in logs', async () => {
+    const buildLogs = ["Some logs that don't match any output path."];
+    mockHost.runCommand.and.resolveTo({ logs: buildLogs });
+
+    const { structuredContent } = await runBuild({}, mockHost);
+
+    expect(structuredContent.status).toBe('success');
+    expect(structuredContent.logs).toEqual(buildLogs);
+    expect(structuredContent.path).toBeUndefined();
+  });
+});

--- a/packages/angular/cli/src/commands/mcp/tools/devserver/serve_spec.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/devserver/serve_spec.ts
@@ -1,0 +1,172 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { EventEmitter } from 'events';
+import { ChildProcess } from 'node:child_process';
+import { MockHost } from '../../testing/mock-host';
+import { McpToolContext } from '../tool-registry';
+import { startDevServer } from './start-devserver';
+import { stopDevserver } from './stop-devserver';
+import { WATCH_DELAY, waitForDevserverBuild } from './wait-for-devserver-build';
+
+class MockChildProcess extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  kill = jasmine.createSpy('kill');
+}
+
+describe('Serve Tools', () => {
+  let mockHost: MockHost;
+  let mockContext: McpToolContext;
+  let mockProcess: MockChildProcess;
+  let portCounter: number;
+
+  beforeEach(() => {
+    portCounter = 12345;
+    mockProcess = new MockChildProcess();
+    mockHost = {
+      spawn: jasmine.createSpy('spawn').and.returnValue(mockProcess as unknown as ChildProcess),
+      getAvailablePort: jasmine.createSpy('getAvailablePort').and.callFake(() => {
+        return Promise.resolve(portCounter++);
+      }),
+    } as Partial<MockHost> as MockHost;
+
+    mockContext = {
+      devServers: new Map(),
+    } as Partial<McpToolContext> as McpToolContext;
+  });
+
+  it('should start and stop a dev server', async () => {
+    const startResult = await startDevServer({}, mockContext, mockHost);
+    expect(startResult.structuredContent.message).toBe(
+      `Development server for project '<default>' started and watching for workspace changes.`,
+    );
+    expect(mockHost.spawn).toHaveBeenCalledWith('ng', ['serve', '--port=12345'], { stdio: 'pipe' });
+
+    const stopResult = stopDevserver({}, mockContext);
+    expect(stopResult.structuredContent.message).toBe(
+      `Development server for project '<default>' stopped.`,
+    );
+    expect(mockProcess.kill).toHaveBeenCalled();
+  });
+
+  it('should wait for a build to complete', async () => {
+    await startDevServer({}, mockContext, mockHost);
+
+    const waitPromise = waitForDevserverBuild({ timeout: 10 }, mockContext);
+
+    // Simulate build logs.
+    mockProcess.stdout.emit('data', '... building ...');
+    mockProcess.stdout.emit('data', '✔ Changes detected. Rebuilding...');
+    mockProcess.stdout.emit('data', '... more logs ...');
+    mockProcess.stdout.emit('data', 'Application bundle generation complete.');
+
+    const waitResult = await waitPromise;
+    expect(waitResult.structuredContent.status).toBe('success');
+    expect(waitResult.structuredContent.logs).toEqual([
+      '... building ...',
+      '✔ Changes detected. Rebuilding...',
+      '... more logs ...',
+      'Application bundle generation complete.',
+    ]);
+  });
+
+  it('should handle multiple dev servers', async () => {
+    // Start server for project 1. This uses the basic mockProcess created for the tests.
+    const startResult1 = await startDevServer({ project: 'app-one' }, mockContext, mockHost);
+    expect(startResult1.structuredContent.message).toBe(
+      `Development server for project 'app-one' started and watching for workspace changes.`,
+    );
+    const process1 = mockProcess;
+
+    // Start server for project 2, returning a new mock process.
+    const process2 = new MockChildProcess();
+    mockHost.spawn.and.returnValue(process2 as unknown as ChildProcess);
+    const startResult2 = await startDevServer({ project: 'app-two' }, mockContext, mockHost);
+    expect(startResult2.structuredContent.message).toBe(
+      `Development server for project 'app-two' started and watching for workspace changes.`,
+    );
+
+    expect(mockHost.spawn).toHaveBeenCalledWith('ng', ['serve', 'app-one', '--port=12345'], {
+      stdio: 'pipe',
+    });
+    expect(mockHost.spawn).toHaveBeenCalledWith('ng', ['serve', 'app-two', '--port=12346'], {
+      stdio: 'pipe',
+    });
+
+    // Stop server for project 1
+    const stopResult1 = stopDevserver({ project: 'app-one' }, mockContext);
+    expect(stopResult1.structuredContent.message).toBe(
+      `Development server for project 'app-one' stopped.`,
+    );
+    expect(process1.kill).toHaveBeenCalled();
+    expect(process2.kill).not.toHaveBeenCalled();
+
+    // Stop server for project 2
+    const stopResult2 = stopDevserver({ project: 'app-two' }, mockContext);
+    expect(stopResult2.structuredContent.message).toBe(
+      `Development server for project 'app-two' stopped.`,
+    );
+    expect(process2.kill).toHaveBeenCalled();
+  });
+
+  it('should handle server crash', async () => {
+    await startDevServer({ project: 'crash-app' }, mockContext, mockHost);
+
+    // Simulate a crash with exit code 1
+    mockProcess.stdout.emit('data', 'Fatal error.');
+    mockProcess.emit('close', 1);
+
+    const stopResult = stopDevserver({ project: 'crash-app' }, mockContext);
+    expect(stopResult.structuredContent.message).toContain('stopped');
+    expect(stopResult.structuredContent.logs).toEqual(['Fatal error.']);
+  });
+
+  it('wait should timeout if build takes too long', async () => {
+    await startDevServer({ project: 'timeout-app' }, mockContext, mockHost);
+    const waitResult = await waitForDevserverBuild(
+      { project: 'timeout-app', timeout: 10 },
+      mockContext,
+    );
+    expect(waitResult.structuredContent.status).toBe('timeout');
+  });
+
+  it('should wait through multiple cycles for a build to complete', async () => {
+    jasmine.clock().install();
+    try {
+      await startDevServer({}, mockContext, mockHost);
+
+      // Immediately simulate a build starting so isBuilding() is true.
+      mockProcess.stdout.emit('data', '❯ Changes detected. Rebuilding...');
+
+      const waitPromise = waitForDevserverBuild({ timeout: 5 * WATCH_DELAY }, mockContext);
+
+      // Tick past the first debounce. The while loop will be entered.
+      jasmine.clock().tick(WATCH_DELAY + 1);
+
+      // Tick past the second debounce (inside the loop).
+      jasmine.clock().tick(WATCH_DELAY + 1);
+
+      // Now finish the build.
+      mockProcess.stdout.emit('data', 'Application bundle generation complete.');
+
+      // Tick past another debounce to exit the loop.
+      jasmine.clock().tick(WATCH_DELAY + 1);
+
+      const waitResult = await waitPromise;
+
+      expect(waitResult.structuredContent.status).toBe('success');
+      expect(waitResult.structuredContent.logs).toEqual([
+        '❯ Changes detected. Rebuilding...',
+        'Application bundle generation complete.',
+      ]);
+    } finally {
+      jasmine.clock().uninstall();
+    }
+  });
+});

--- a/packages/angular/cli/src/commands/mcp/tools/devserver/start-devserver.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/devserver/start-devserver.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { z } from 'zod';
+import { LocalDevServer, devServerKey } from '../../dev-server';
+import { Host, LocalWorkspaceHost } from '../../host';
+import { createStructuredContentOutput } from '../../utils';
+import { McpToolContext, McpToolDeclaration, declareTool } from '../tool-registry';
+
+const startDevServerToolInputSchema = z.object({
+  project: z
+    .string()
+    .optional()
+    .describe(
+      'Which project to serve in a monorepo context. If not provided, serves the default project.',
+    ),
+});
+
+export type StartDevserverToolInput = z.infer<typeof startDevServerToolInputSchema>;
+
+const startDevServerToolOutputSchema = z.object({
+  message: z.string().describe('A message indicating the result of the operation.'),
+  address: z
+    .string()
+    .optional()
+    .describe(
+      'If the operation was successful, this is the HTTP address that the server can be found at.',
+    ),
+});
+
+export type StartDevserverToolOutput = z.infer<typeof startDevServerToolOutputSchema>;
+
+function localhostAddress(port: number) {
+  return `http://localhost:${port}/`;
+}
+
+export async function startDevServer(
+  input: StartDevserverToolInput,
+  context: McpToolContext,
+  host: Host,
+) {
+  const projectKey = devServerKey(input.project);
+
+  let devServer = context.devServers.get(projectKey);
+  if (devServer) {
+    return createStructuredContentOutput({
+      message: `Development server for project '${projectKey}' is already running.`,
+      address: localhostAddress(devServer.port),
+    });
+  }
+
+  const port = await host.getAvailablePort();
+
+  devServer = new LocalDevServer({ host, project: input.project, port });
+  devServer.start();
+
+  context.devServers.set(projectKey, devServer);
+
+  return createStructuredContentOutput({
+    message: `Development server for project '${projectKey}' started and watching for workspace changes.`,
+    address: localhostAddress(port),
+  });
+}
+
+export const START_DEVSERVER_TOOL: McpToolDeclaration<
+  typeof startDevServerToolInputSchema.shape,
+  typeof startDevServerToolOutputSchema.shape
+> = declareTool({
+  name: 'start_devserver',
+  title: 'Start Development Server',
+  description: `
+<Purpose>
+Starts the Angular development server ("ng serve") as a background process. Follow this up with "wait_for_devserver_build" to wait until
+the first build completes.
+</Purpose>
+<Use Cases>
+* **Starting the Server:** Use this tool to begin serving the application. The tool will return immediately while the server runs in the
+  background.
+* **Get Initial Build Logs:** Once a dev server has started, use the "wait_for_devserver_build" tool to ensure it's alive. If there are any
+  build errors, "wait_for_devserver_build" would provide them back and you can give them to the user or rely on them to propose a fix.
+* **Get Updated Build Logs:** Important: as long as a devserver is alive (i.e. "stop_devserver" wasn't called), after every time you make a
+  change to the workspace, re-run "wait_for_devserver_build" to see whether the change was successfully built and wait for the devserver to
+  be updated.
+</Use Cases>
+<Operational Notes>
+* This tool manages development servers by itself. It maintains at most a single dev server instance for each project in the monorepo.
+* This is an asynchronous operation. Subsequent commands can be ran while the server is active.
+* Use 'stop_devserver' to gracefully shut down the server and access the full log output.
+</Operational Notes>
+`,
+  isReadOnly: true,
+  isLocalOnly: true,
+  inputSchema: startDevServerToolInputSchema.shape,
+  outputSchema: startDevServerToolOutputSchema.shape,
+  factory: (context) => (input) => {
+    return startDevServer(input, context, LocalWorkspaceHost);
+  },
+});

--- a/packages/angular/cli/src/commands/mcp/tools/devserver/stop-devserver.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/devserver/stop-devserver.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { z } from 'zod';
+import { devServerKey } from '../../dev-server';
+import { createStructuredContentOutput } from '../../utils';
+import { McpToolContext, McpToolDeclaration, declareTool } from '../tool-registry';
+
+const stopDevserverToolInputSchema = z.object({
+  project: z
+    .string()
+    .optional()
+    .describe(
+      'Which project to stop serving in a monorepo context. If not provided, stops the default project server.',
+    ),
+});
+
+export type StopDevserverToolInput = z.infer<typeof stopDevserverToolInputSchema>;
+
+const stopDevserverToolOutputSchema = z.object({
+  message: z.string().describe('A message indicating the result of the operation.'),
+  logs: z.array(z.string()).optional().describe('The full logs from the dev server.'),
+});
+
+export type StopDevserverToolOutput = z.infer<typeof stopDevserverToolOutputSchema>;
+
+export function stopDevserver(input: StopDevserverToolInput, context: McpToolContext) {
+  const projectKey = devServerKey(input.project);
+  const devServer = context.devServers.get(projectKey);
+
+  if (!devServer) {
+    return createStructuredContentOutput({
+      message: `Development server for project '${projectKey}' was not running.`,
+      logs: undefined,
+    });
+  }
+
+  devServer.stop();
+  context.devServers.delete(projectKey);
+
+  return createStructuredContentOutput({
+    message: `Development server for project '${projectKey}' stopped.`,
+    logs: devServer.getServerLogs(),
+  });
+}
+
+export const STOP_DEVSERVER_TOOL: McpToolDeclaration<
+  typeof stopDevserverToolInputSchema.shape,
+  typeof stopDevserverToolOutputSchema.shape
+> = declareTool({
+  name: 'stop_devserver',
+  title: 'Stop Development Server',
+  description: `
+<Purpose>
+Stops a running Angular development server ("ng serve") that was started with the "start_devserver" tool.
+</Purpose>
+<Use Cases>
+* **Stopping the Server:** Use this tool to terminate a running development server and retrieve the logs.
+</Use Cases>
+<Operational Notes>
+* This should be called to gracefully shut down the server and access the full log output.
+* This just sends a SIGTERM to the server and returns immediately; so the server might still be functional for a short
+  time after this is called. However note that this is not a blocker for starting a new devserver.
+</Operational Notes>
+`,
+  isReadOnly: true,
+  isLocalOnly: true,
+  inputSchema: stopDevserverToolInputSchema.shape,
+  outputSchema: stopDevserverToolOutputSchema.shape,
+  factory: (context) => (input) => {
+    return stopDevserver(input, context);
+  },
+});

--- a/packages/angular/cli/src/commands/mcp/tools/devserver/wait-for-devserver-build.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/devserver/wait-for-devserver-build.ts
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { z } from 'zod';
+import { devServerKey } from '../../dev-server';
+import { createStructuredContentOutput } from '../../utils';
+import { McpToolContext, McpToolDeclaration, declareTool } from '../tool-registry';
+
+/**
+ * How long to wait to give "ng serve" time to identify whether the watched workspace has changed.
+ */
+export const WATCH_DELAY = 1000;
+
+/**
+ * Default timeout for waiting for the build to complete.
+ */
+const DEFAULT_TIMEOUT = 180_000; // In milliseconds
+
+const waitForDevserverBuildToolInputSchema = z.object({
+  project: z
+    .string()
+    .optional()
+    .describe(
+      'Which project to wait for in a monorepo context. If not provided, waits for the default project server.',
+    ),
+  timeout: z
+    .number()
+    .default(DEFAULT_TIMEOUT)
+    .describe(
+      `The maximum time to wait for the build to complete, in milliseconds. This can't be lower than ${WATCH_DELAY}.`,
+    ),
+});
+
+export type WaitForDevserverBuildToolInput = z.infer<typeof waitForDevserverBuildToolInputSchema>;
+
+const waitForDevserverBuildToolOutputSchema = z.object({
+  status: z
+    .enum(['success', 'failure', 'unknown', 'timeout', 'no_devserver_found'])
+    .describe(
+      "The status of the build if it's complete, or a status indicating why the wait operation failed.",
+    ),
+  logs: z
+    .array(z.string())
+    .optional()
+    .describe('The logs from the most recent build, if one exists.'),
+});
+
+export type WaitForDevserverBuildToolOutput = z.infer<typeof waitForDevserverBuildToolOutputSchema>;
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function waitForDevserverBuild(
+  input: WaitForDevserverBuildToolInput,
+  context: McpToolContext,
+) {
+  const projectKey = devServerKey(input.project);
+  const devServer = context.devServers.get(projectKey);
+  const deadline = Date.now() + input.timeout;
+
+  if (!devServer) {
+    return createStructuredContentOutput<WaitForDevserverBuildToolOutput>({
+      status: 'no_devserver_found',
+    });
+  }
+
+  await wait(WATCH_DELAY);
+  while (devServer.isBuilding()) {
+    if (Date.now() > deadline) {
+      return createStructuredContentOutput<WaitForDevserverBuildToolOutput>({
+        status: 'timeout',
+      });
+    }
+    await wait(WATCH_DELAY);
+  }
+
+  return createStructuredContentOutput<WaitForDevserverBuildToolOutput>({
+    ...devServer.getMostRecentBuild(),
+  });
+}
+
+export const WAIT_FOR_DEVSERVER_BUILD_TOOL: McpToolDeclaration<
+  typeof waitForDevserverBuildToolInputSchema.shape,
+  typeof waitForDevserverBuildToolOutputSchema.shape
+> = declareTool({
+  name: 'wait_for_devserver_build',
+  title: 'Wait for Devserver Build',
+  description: `
+<Purpose>
+Waits for a dev server that was started with the "start_devserver" tool to complete its build, then reports the build logs from its most
+recent build.
+</Purpose>
+<Use Cases>
+* **Waiting for a build:** As long as a devserver is alive ("start_devserver" was called for this project and "stop_devserver" wasn't
+  called yet), then if you're making a file change and want to ensure it was successfully built, call this tool instead of any other build
+  tool or command. When it retuns you'll get build logs back **and** you'll know the user's devserver is up-to-date with the latest changes.
+</Use Cases>
+<Operational Notes>
+* This tool expects that a dev server was launched on the same project with the "start_devserver" tool, otherwise a "no_devserver_found"
+  status will be returned.
+* This tool will block until the build is complete or the timeout is reached. If you expect a long build process, consider increasing the
+  timeout. Timeouts on initial run (right after "start_devserver" calls) or after a big change are not necessarily indicative of an error.
+* If you encountered a timeout and it might be reasonable, just call this tool again.
+* If the dev server is not building, it will return quickly, with the logs from the last build.
+* A 'no_devserver_found' status can indicate the underlying server was stopped for some reason. Try first to call the "start_devserver"
+  tool again, before giving up.
+</Operational Notes>
+`,
+  isReadOnly: true,
+  isLocalOnly: true,
+  inputSchema: waitForDevserverBuildToolInputSchema.shape,
+  outputSchema: waitForDevserverBuildToolOutputSchema.shape,
+  factory: (context) => (input) => {
+    return waitForDevserverBuild(input, context);
+  },
+});

--- a/packages/angular/cli/src/commands/mcp/tools/tool-registry.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/tool-registry.ts
@@ -9,6 +9,7 @@
 import type { McpServer, ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ZodRawShape } from 'zod';
 import type { AngularWorkspace } from '../../../utilities/config';
+import { DevServer } from '../dev-server';
 
 type ToolConfig = Parameters<McpServer['registerTool']>[1];
 
@@ -17,6 +18,7 @@ export interface McpToolContext {
   workspace?: AngularWorkspace;
   logger: { warn(text: string): void };
   exampleDatabasePath?: string;
+  devServers: Map<string, DevServer>;
 }
 
 export type McpToolFactory<TInput extends ZodRawShape> = (

--- a/packages/angular/cli/src/commands/mcp/utils.ts
+++ b/packages/angular/cli/src/commands/mcp/utils.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+/**
+ * @fileoverview
+ * Utility functions shared across MCP tools.
+ */
+
+/**
+ * Returns simple structured content output from an MCP tool.
+ *
+ * @returns A structure with both `content` and `structuredContent` for maximum compatibility.
+ */
+export function createStructuredContentOutput<OutputType>(structuredContent: OutputType) {
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(structuredContent, null, 2) }],
+    structuredContent,
+  };
+}


### PR DESCRIPTION
New MCP experimental tools:

* "build" tool: A new MCP tool that allows for one-off, non-watched builds of Angular projects, similar to
      `ng build`.
* "serve" tools: A group of new MCP tools to manage the development server:
  * "start_devserver": Starts the Angular development server as a background process.
  * "stop_devserver": Stops a running development server.
  * "wait_for_devserver_build": Waits for a build to complete and reports the logs.

Notes:

* Implementation mostly follows the design doc for build/serve/test workflow.
* The currently-alive devservers are stored as part of the MCP context, and so are maintained across tool invocations.
* Build progress detection relies on hardcoding expected strings to match - see "dev-server.ts".
* Beyond the unit tests, also tested manually in Gemini CLI.
* A bunch of tools, included these new ones, just return basic unweighted structured content, so added a utility function in a "utils.ts" file for that functionality.

