### PR TITLE
feat(@schematics/angular): add skipProvidedIn option to service schem…

### DIFF
--- a/packages/schematics/angular/service/files/__name@dasherize__.__type@dasherize__.ts.template
+++ b/packages/schematics/angular/service/files/__name@dasherize__.__type@dasherize__.ts.template
@@ -1,8 +1,6 @@
 import { Injectable } from '@angular/core';
 
-@Injectable({
+<% if (!skipProvidedIn) { %>@Injectable({
   providedIn: 'root',
-})
-export class <%= classifiedName %> {
-  
-}
+})<% } else { %>@Injectable()<% } %>
+export class <%= classifiedName %> {}

--- a/packages/schematics/angular/service/index_spec.ts
+++ b/packages/schematics/angular/service/index_spec.ts
@@ -121,4 +121,22 @@ describe('Service Schematic', () => {
     expect(content).toContain('export class FooService {');
     expect(testContent).toContain("describe('FooService', () => {");
   });
+
+  it('should allow skipping providedIn when skipProvidedIn is true', async () => {
+    const options = { ...defaultOptions, skipProvidedIn: true };
+
+    const tree = await schematicRunner.runSchematic('service', options, appTree);
+    const content = tree.readContent('/projects/bar/src/app/foo/foo.ts');
+    expect(content).not.toMatch(/providedIn/);
+    expect(content).toMatch(/^@Injectable\(\)$/m);
+  });
+
+  it('should include providedIn: "root" by default', async () => {
+    const options = { ...defaultOptions };
+
+    const tree = await schematicRunner.runSchematic('service', options, appTree);
+    const content = tree.readContent('/projects/bar/src/app/foo/foo.ts');
+    expect(content).toMatch(/providedIn: 'root'/);
+    expect(content).toMatch(/^@Injectable\({$/m);
+  });
 });

--- a/packages/schematics/angular/service/schema.json
+++ b/packages/schematics/angular/service/schema.json
@@ -40,6 +40,11 @@
       "description": "Skip the generation of a unit test file `spec.ts` for the service.",
       "default": false
     },
+    "skipProvidedIn": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, does not add the providedIn property to the @Injectable decorator. The service must then be provided manually"
+    },
     "type": {
       "type": "string",
       "description": "Append a custom type to the service's filename. For example, if you set the type to `service`, the file will be named `my-service.service.ts`."


### PR DESCRIPTION
…atic

Add a new `skipProvidedIn` boolean option to the service schematic that allows developers to generate services without the `providedIn: 'root'` metadata in the @Injectable decorator. When set to true, the decorator will be rendered as `@Injectable()` instead of `@Injectable({ providedIn: 'root' })`.

This provides flexibility for developers who prefer to manually provide services in specific modules or components rather than using the default tree-shakeable pattern.

The option defaults to false to maintain backward compatibility and continue encouraging Angular's best practice of tree-shakeable services.

Fixes #31670 

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #31670


## What is the new behavior?

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
