### PR TITLE
fix(@angular/cli): add vitest to version command output

### DIFF
--- a/packages/angular/cli/src/commands/version/version-info.ts
+++ b/packages/angular/cli/src/commands/version/version-info.ts
@@ -72,6 +72,7 @@ const PACKAGE_PATTERNS = [
   /^rxjs$/,
   /^typescript$/,
   /^ng-packagr$/,
+  /^vitest$/,
   /^webpack$/,
   /^zone\.js$/,
 ];


### PR DESCRIPTION
Adds `vitest` to the list of packages displayed in the output of the `ng version` command. This provides better visibility into the testing setup of a project, aiding in diagnostics and issue reporting.