### PR TITLE
fix(@angular/ssr): improve route matching for wildcard routes

### DIFF
--- a/packages/angular/ssr/test/routes/ng-routes_spec.ts
+++ b/packages/angular/ssr/test/routes/ng-routes_spec.ts
@@ -428,6 +428,45 @@ describe('extractRoutesAndCreateRouteTree', () => {
     ]);
   });
 
+  it('should extract routes with a route level matcher captured by "**"', async () => {
+    setAngularAppTestingManifest(
+      [
+        {
+          path: '',
+          component: DummyComponent,
+        },
+        {
+          path: 'list',
+          component: DummyComponent,
+        },
+        {
+          path: 'product',
+          component: DummyComponent,
+          children: [
+            {
+              matcher: () => null,
+              component: DummyComponent,
+            },
+          ],
+        },
+      ],
+      [
+        { path: 'list', renderMode: RenderMode.Client },
+        { path: '', renderMode: RenderMode.Client },
+        { path: '**', renderMode: RenderMode.Server },
+      ],
+    );
+
+    const { routeTree, errors } = await extractRoutesAndCreateRouteTree({ url });
+    expect(errors).toHaveSize(0);
+    expect(routeTree.toObject()).toEqual([
+      { route: '/', renderMode: RenderMode.Client },
+      { route: '/list', renderMode: RenderMode.Client },
+      { route: '/product', renderMode: RenderMode.Server },
+      { route: '/**', renderMode: RenderMode.Server },
+    ]);
+  });
+
   it('should extract nested redirects that are not explicitly defined.', async () => {
     setAngularAppTestingManifest(
       [


### PR DESCRIPTION
Enhance the route traversal logic to correctly identify and process wildcard route matchers (e.g., '**'). This ensures that routes with matchers are properly marked as present in the client router and handled according to their render mode.

closes #31666