### PR TITLE
fix(@schematics/angular): add Vitest config generation and runner checks

### DIFF
--- a/packages/schematics/angular/config/files/vitest-base.config.ts.template
+++ b/packages/schematics/angular/config/files/vitest-base.config.ts.template
@@ -1,0 +1,9 @@
+// Learn more about Vitest configuration options at https://vitest.dev/config/
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // ...
+  },
+});

--- a/packages/schematics/angular/config/schema.json
+++ b/packages/schematics/angular/config/schema.json
@@ -16,7 +16,7 @@
     "type": {
       "type": "string",
       "description": "Specifies the type of configuration file to generate.",
-      "enum": ["karma", "browserslist"],
+      "enum": ["karma", "browserslist", "vitest"],
       "x-prompt": "Which type of configuration file would you like to create?",
       "$default": {
         "$source": "argv",


### PR DESCRIPTION
This commit expands the `config` schematic to support generating a `vitest-base.config.ts` file and includes runner checks to prevent misconfiguration.

Changes include:
- Added 'vitest' as a valid type for the `config` schematic in `schema.json`.
- Created a new `vitest-base.config.ts.template` file for generating a basic Vitest configuration.
- Implemented the `addVitestConfig` function in `packages/schematics/angular/config/index.ts`:
  - Verifies that the project's `test` target uses the `@angular/build:unit-test` builder.
  - Copies the `vitest-base.config.ts` template to the project root.
  - Sets the `runnerConfig` option to `true` in `angular.json` to enable automatic discovery.
  - Includes warning logic to notify users if the `runner` option in `angular.json` is explicitly set to `karma`, indicating that the generated Vitest config may not be used.