### PR TITLE
docs: clarify `outputMode` description in application schema

### DIFF
--- a/packages/angular/build/src/builders/application/schema.json
+++ b/packages/angular/build/src/builders/application/schema.json
@@ -611,7 +611,7 @@
     },
     "outputMode": {
       "type": "string",
-      "description": "Defines the build output target. 'static': Generates a static site build artifact for deployment on any static hosting service. 'server': Generates a server application build artifact, required for applications using hybrid rendering or APIs.",
+      "description": "Defines the type of build output artifact. 'static': Generates a static site build artifact for deployment on any static hosting service. 'server': Generates a server application build artifact, required for applications using hybrid rendering or APIs.",
       "enum": ["static", "server"]
     }
   },


### PR DESCRIPTION
Updates the description for the  property in the application builder's schema. This change clarifies that both 'static' and 'server' modes generate build artifacts, and specifies that the 'server' mode is required for applications using hybrid rendering or APIs.

closes #31666