### PR TITLE
fix(@schematics/angular): add `addImports` option to jasmine-vitest schematic

### DIFF
--- a/packages/schematics/angular/refactor/jasmine-vitest/index.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/index.ts
@@ -119,7 +119,9 @@ export default function (options: Schema): Rule {
     for (const file of files) {
       reporter.incrementScannedFiles();
       const content = tree.readText(file);
-      const newContent = transformJasmineToVitest(file, content, reporter);
+      const newContent = transformJasmineToVitest(file, content, reporter, {
+        addImports: !!options.addImports,
+      });
 
       if (content !== newContent) {
         tree.overwrite(file, newContent);

--- a/packages/schematics/angular/refactor/jasmine-vitest/schema.json
+++ b/packages/schematics/angular/refactor/jasmine-vitest/schema.json
@@ -25,6 +25,11 @@
       "type": "boolean",
       "description": "Enable verbose logging to see detailed information about the transformations being applied.",
       "default": false
+    },
+    "addImports": {
+      "type": "boolean",
+      "description": "Whether to add imports for the Vitest API. The Angular `unit-test` system automatically uses the Vitest globals option, which means explicit imports for global APIs like `describe`, `it`, `expect`, and `vi` are often not strictly necessary unless Vitest has been configured not to use globals.",
+      "default": false
     }
   }
 }

--- a/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.integration_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.integration_spec.ts
@@ -14,7 +14,7 @@ import { RefactorReporter } from './utils/refactor-reporter';
 async function expectTransformation(input: string, expected: string): Promise<void> {
   const logger = new logging.NullLogger();
   const reporter = new RefactorReporter(logger);
-  const transformed = transformJasmineToVitest('spec.ts', input, reporter);
+  const transformed = transformJasmineToVitest('spec.ts', input, reporter, { addImports: false });
   const formattedTransformed = await format(transformed, { parser: 'typescript' });
   const formattedExpected = await format(expected, { parser: 'typescript' });
 

--- a/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer_add-imports_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer_add-imports_spec.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { expectTransformation } from './test-helpers';
+
+describe('Jasmine to Vitest Transformer', () => {
+  describe('addImports option', () => {
+    it('should add value imports when addImports is true', async () => {
+      const input = `spyOn(foo, 'bar');`;
+      const expected = `
+        import { vi } from 'vitest';
+        vi.spyOn(foo, 'bar');
+      `;
+      await expectTransformation(input, expected, true);
+    });
+
+    it('should generate a single, combined import for value and type imports when addImports is true', async () => {
+      const input = `
+        let mySpy: jasmine.Spy;
+        spyOn(foo, 'bar');
+      `;
+      const expected = `
+        import { type Mock, vi } from 'vitest';
+
+        let mySpy: Mock;
+        vi.spyOn(foo, 'bar');
+      `;
+      await expectTransformation(input, expected, true);
+    });
+
+    it('should only add type imports when addImports is false', async () => {
+      const input = `
+        let mySpy: jasmine.Spy;
+        spyOn(foo, 'bar');
+      `;
+      const expected = `
+        import type { Mock } from 'vitest';
+
+        let mySpy: Mock;
+        vi.spyOn(foo, 'bar');
+      `;
+      await expectTransformation(input, expected, false);
+    });
+
+    it('should not add an import if no Vitest APIs are used, even when addImports is true', async () => {
+      const input = `const a = 1;`;
+      const expected = `const a = 1;`;
+      await expectTransformation(input, expected, true);
+    });
+  });
+});

--- a/packages/schematics/angular/refactor/jasmine-vitest/test-helpers.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/test-helpers.ts
@@ -23,10 +23,14 @@ import { RefactorReporter } from './utils/refactor-reporter';
  * @param input The Jasmine code snippet to be transformed.
  * @param expected The expected Vitest code snippet after transformation.
  */
-export async function expectTransformation(input: string, expected: string): Promise<void> {
+export async function expectTransformation(
+  input: string,
+  expected: string,
+  addImports = false,
+): Promise<void> {
   const logger = new logging.NullLogger();
   const reporter = new RefactorReporter(logger);
-  const transformed = transformJasmineToVitest('spec.ts', input, reporter);
+  const transformed = transformJasmineToVitest('spec.ts', input, reporter, { addImports });
   const formattedTransformed = await format(transformed, { parser: 'typescript' });
   const formattedExpected = await format(expected, { parser: 'typescript' });
 

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-matcher.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-matcher.ts
@@ -15,7 +15,11 @@
  */
 
 import ts from '../../../third_party/github.com/Microsoft/TypeScript/lib/typescript';
-import { createExpectCallExpression, createPropertyAccess } from '../utils/ast-helpers';
+import {
+  addVitestValueImport,
+  createExpectCallExpression,
+  createPropertyAccess,
+} from '../utils/ast-helpers';
 import { getJasmineMethodName, isJasmineCallExpression } from '../utils/ast-validation';
 import { addTodoComment } from '../utils/comment-helpers';
 import { RefactorContext } from '../utils/refactor-context';
@@ -94,7 +98,7 @@ const ASYMMETRIC_MATCHER_NAMES: ReadonlyArray<string> = [
 
 export function transformAsymmetricMatchers(
   node: ts.Node,
-  { sourceFile, reporter }: RefactorContext,
+  { sourceFile, reporter, pendingVitestValueImports }: RefactorContext,
 ): ts.Node {
   if (
     ts.isPropertyAccessExpression(node) &&
@@ -103,6 +107,7 @@ export function transformAsymmetricMatchers(
   ) {
     const matcherName = node.name.text;
     if (ASYMMETRIC_MATCHER_NAMES.includes(matcherName)) {
+      addVitestValueImport(pendingVitestValueImports, 'expect');
       reporter.reportTransformation(
         sourceFile,
         node,

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-misc.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-misc.ts
@@ -14,7 +14,7 @@
  */
 
 import ts from '../../../third_party/github.com/Microsoft/TypeScript/lib/typescript';
-import { createViCallExpression } from '../utils/ast-helpers';
+import { addVitestValueImport, createViCallExpression } from '../utils/ast-helpers';
 import { getJasmineMethodName, isJasmineCallExpression } from '../utils/ast-validation';
 import { addTodoComment } from '../utils/comment-helpers';
 import { RefactorContext } from '../utils/refactor-context';
@@ -22,7 +22,7 @@ import { TodoCategory } from '../utils/todo-notes';
 
 export function transformTimerMocks(
   node: ts.Node,
-  { sourceFile, reporter }: RefactorContext,
+  { sourceFile, reporter, pendingVitestValueImports }: RefactorContext,
 ): ts.Node {
   if (
     !ts.isCallExpression(node) ||
@@ -55,6 +55,7 @@ export function transformTimerMocks(
   }
 
   if (newMethodName) {
+    addVitestValueImport(pendingVitestValueImports, 'vi');
     reporter.reportTransformation(
       sourceFile,
       node,
@@ -94,7 +95,7 @@ export function transformFail(node: ts.Node, { sourceFile, reporter }: RefactorC
 
 export function transformDefaultTimeoutInterval(
   node: ts.Node,
-  { sourceFile, reporter }: RefactorContext,
+  { sourceFile, reporter, pendingVitestValueImports }: RefactorContext,
 ): ts.Node {
   if (
     ts.isExpressionStatement(node) &&
@@ -108,6 +109,7 @@ export function transformDefaultTimeoutInterval(
       assignment.left.expression.text === 'jasmine' &&
       assignment.left.name.text === 'DEFAULT_TIMEOUT_INTERVAL'
     ) {
+      addVitestValueImport(pendingVitestValueImports, 'vi');
       reporter.reportTransformation(
         sourceFile,
         node,

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-type.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-type.ts
@@ -14,12 +14,12 @@
  */
 
 import ts from '../../../third_party/github.com/Microsoft/TypeScript/lib/typescript';
-import { addVitestAutoImport } from '../utils/ast-helpers';
+import { addVitestTypeImport } from '../utils/ast-helpers';
 import { RefactorContext } from '../utils/refactor-context';
 
 export function transformJasmineTypes(
   node: ts.Node,
-  { sourceFile, reporter, pendingVitestImports }: RefactorContext,
+  { sourceFile, reporter, pendingVitestTypeImports }: RefactorContext,
 ): ts.Node {
   const typeNameNode = ts.isTypeReferenceNode(node) ? node.typeName : node;
   if (
@@ -40,7 +40,7 @@ export function transformJasmineTypes(
         node,
         `Transformed type \`jasmine.Spy\` to \`${vitestTypeName}\`.`,
       );
-      addVitestAutoImport(pendingVitestImports, vitestTypeName);
+      addVitestTypeImport(pendingVitestTypeImports, vitestTypeName);
 
       return ts.factory.createIdentifier(vitestTypeName);
     }
@@ -51,7 +51,7 @@ export function transformJasmineTypes(
         node,
         `Transformed type \`jasmine.SpyObj\` to \`${vitestTypeName}\`.`,
       );
-      addVitestAutoImport(pendingVitestImports, vitestTypeName);
+      addVitestTypeImport(pendingVitestTypeImports, vitestTypeName);
 
       if (ts.isTypeReferenceNode(node)) {
         return ts.factory.updateTypeReferenceNode(

--- a/packages/schematics/angular/refactor/jasmine-vitest/utils/refactor-context.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/utils/refactor-context.ts
@@ -23,8 +23,11 @@ export interface RefactorContext {
   /** The official context from the TypeScript Transformer API. */
   readonly tsContext: ts.TransformationContext;
 
+  /** A set of Vitest value imports to be added to the file. */
+  readonly pendingVitestValueImports: Set<string>;
+
   /** A set of Vitest type imports to be added to the file. */
-  readonly pendingVitestImports: Set<string>;
+  readonly pendingVitestTypeImports: Set<string>;
 }
 
 /**


### PR DESCRIPTION
Introduces a new `--add-imports` boolean option to the Jasmine to Vitest refactoring schematic.

When this option is set to `true`, the schematic will automatically add a single, consolidated `import { ... } from 'vitest';` statement at the top of the transformed file for any Vitest APIs that are used.

Key changes:
- Type-only imports (e.g., `Mock`, `MockedObject`) are now always added to ensure the refactored code remains type-correct.
- Value imports (e.g., `vi`, `describe`, `it`, `expect`) are only added when `--add-imports` is `true`.
- The import generation logic correctly handles all scenarios, including type-only imports (`import type {...}`), value-only imports, and combined imports with inline `type` keywords.
- A new test suite has been added to validate the import generation logic under various conditions.