### PR TITLE
refactor(@angular/build): remove advanced chunking option in experimental chunk optimizer

### DIFF
--- a/packages/angular/build/src/builders/application/chunk-optimizer.ts
+++ b/packages/angular/build/src/builders/application/chunk-optimizer.ts
@@ -253,7 +253,6 @@ export async function optimizeChunks(
 
     const result = await bundle.generate({
       minify: { mangle: false, compress: false },
-      advancedChunks: { minSize: 8192 },
       sourcemap,
       chunkFileNames: (chunkInfo) => `${chunkInfo.name.replace(/-[a-zA-Z0-9]{8}$/, '')}-[hash].js`,
     });

--- a/tests/legacy-cli/e2e.bzl
+++ b/tests/legacy-cli/e2e.bzl
@@ -56,6 +56,7 @@ WEBPACK_IGNORE_TESTS = [
     "tests/build/auto-csp*",
     "tests/build/incremental-watch.js",
     "tests/build/chunk-optimizer.js",
+    "tests/build/chunk-optimizer-lazy.js",
 ]
 
 def _to_glob(patterns):

--- a/tests/legacy-cli/e2e/tests/build/chunk-optimizer-lazy.ts
+++ b/tests/legacy-cli/e2e/tests/build/chunk-optimizer-lazy.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { readdir } from 'node:fs/promises';
+import { replaceInFile } from '../../utils/fs';
+import { execWithEnv, ng } from '../../utils/process';
+
+export default async function () {
+  // Add lazy routes.
+  await ng('generate', 'component', 'lazy-a');
+  await ng('generate', 'component', 'lazy-b');
+  await ng('generate', 'component', 'lazy-c');
+  await replaceInFile(
+    'src/app/app.routes.ts',
+    'routes: Routes = [];',
+    `routes: Routes = [
+      {
+        path: 'lazy-a',
+        loadComponent: () => import('./lazy-a/lazy-a').then(m => m.LazyA),
+      },
+      {
+        path: 'lazy-b',
+        loadComponent: () => import('./lazy-b/lazy-b').then(m => m.LazyB),
+      },
+      {
+        path: 'lazy-c',
+        loadComponent: () => import('./lazy-c/lazy-c').then(m => m.LazyC),
+      },
+    ];`,
+  );
+
+  // Build without chunk optimization
+  await ng('build', '--output-hashing=none');
+  const unoptimizedFiles = await readdir('dist/test-project/browser');
+  const unoptimizedJsFiles = unoptimizedFiles.filter((f) => f.endsWith('.js'));
+
+  // Build with chunk optimization
+  await execWithEnv('ng', ['build', '--output-hashing=none'], {
+    ...process.env,
+    NG_BUILD_OPTIMIZE_CHUNKS: '1',
+  });
+  const optimizedFiles = await readdir('dist/test-project/browser');
+  const optimizedJsFiles = optimizedFiles.filter((f) => f.endsWith('.js'));
+
+  // Check that the number of chunks is reduced but not all combined
+  assert.ok(
+    optimizedJsFiles.length < unoptimizedJsFiles.length,
+    `Expected chunk count to be less than ${unoptimizedJsFiles.length}, but was ${optimizedJsFiles.length}.`,
+  );
+  assert.ok(
+    optimizedJsFiles.length > 1,
+    `Expected more than one chunk, but found ${optimizedJsFiles.length}.`,
+  );
+}


### PR DESCRIPTION
Removes the experimental `advancedChunks` configuration from the Rolldown-based chunk optimizer. This experimental feature is being temporarily removed to allow for further refinement and testing of the chunking strategy.

A new E2E test (`chunk-optimizer-lazy`) has been added to validate the default chunking behavior with multiple lazy-loaded routes, ensuring that the optimizer still produces a reasonable number of output files without the advanced configuration.