### PR TITLE
fix(@angular/cli): promote zoneless migration MCP tool to stable

### DIFF
--- a/packages/angular/cli/src/commands/mcp/mcp-server.ts
+++ b/packages/angular/cli/src/commands/mcp/mcp-server.ts
@@ -30,13 +30,14 @@ const STABLE_TOOLS = [
   DOC_SEARCH_TOOL,
   FIND_EXAMPLE_TOOL,
   LIST_PROJECTS_TOOL,
+  ZONELESS_MIGRATION_TOOL,
 ] as const;
 
 /**
  * The set of tools that are available but not enabled by default.
  * These tools are considered experimental and may have limitations.
  */
-export const EXPERIMENTAL_TOOLS = [MODERNIZE_TOOL, ZONELESS_MIGRATION_TOOL] as const;
+export const EXPERIMENTAL_TOOLS = [MODERNIZE_TOOL] as const;
 
 export async function createMcpServer(
   options: {


### PR DESCRIPTION
The zoneless migration tool has been moved from the experimental to the stable toolset within the MCP server, making it available by default.