### PR TITLE
fix(@angular/build): show full aggregate errors from vitest

### DIFF
--- a/packages/angular/build/src/builders/unit-test/builder.ts
+++ b/packages/angular/build/src/builders/unit-test/builder.ts
@@ -146,6 +146,13 @@ async function* runBuildAndTest(
     } catch (e) {
       assertIsError(e);
       context.logger.error(`An exception occurred during test execution:\n${e.stack ?? e.message}`);
+      if (e instanceof AggregateError) {
+        e.errors.forEach((inner) => {
+          assertIsError(inner);
+          context.logger.error(inner.stack ?? inner.message);
+        });
+      }
+
       yield { success: false };
       consecutiveErrorCount++;
     }


### PR DESCRIPTION
Vitest may throw an `AggregateError` which can contain one or more specific errors. The output console logging will now show each of these specific errors in addition to the main thrown error.