### PR TITLE
fix(@schematics/angular): correct `tsconfig.spec.json` include for spec files

### DIFF
--- a/packages/schematics/angular/application/files/common-files/tsconfig.spec.json.template
+++ b/packages/schematics/angular/application/files/common-files/tsconfig.spec.json.template
@@ -9,6 +9,7 @@
     ]
   },
   "include": [
+    "src/**/*.d.ts",
     "src/**/*<% if (standalone) { %>.spec<% } %>.ts"
   ]
 }

--- a/packages/schematics/angular/library/files/tsconfig.spec.json.template
+++ b/packages/schematics/angular/library/files/tsconfig.spec.json.template
@@ -9,6 +9,7 @@
     ]
   },
   "include": [
-     "src/**/*<% if (standalone) { %>.spec<% } %>.ts"
+    "src/**/*.d.ts",
+    "src/**/*<% if (standalone) { %>.spec<% } %>.ts"
   ]
 }


### PR DESCRIPTION


Updates the  files in both application and library schematics to specifically include  instead of . This ensures that only test specification files are processed for testing, preventing unintended inclusion of other TypeScript files.
