### PR TITLE
fix(@angular/build): builder removes @angular/localize when external packages are not inlined

### DIFF
--- a/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
@@ -654,7 +654,7 @@ function getEsBuildCommonPolyfillsOptions(
   tryToResolvePolyfillsAsRelative: boolean,
   loadResultCache: LoadResultCache | undefined,
 ): BuildOptions | undefined {
-  const { jit, workspaceRoot, i18nOptions } = options;
+  const { jit, workspaceRoot, i18nOptions, externalPackages } = options;
 
   const buildOptions = getEsBuildCommonOptions(options);
   buildOptions.splitting = false;
@@ -671,8 +671,10 @@ function getEsBuildCommonPolyfillsOptions(
   // Locale data should go first so that project provided polyfill code can augment if needed.
   let needLocaleDataPlugin = false;
   if (i18nOptions.shouldInline) {
-    // Remove localize polyfill as this is not needed for build time i18n.
-    polyfills = polyfills.filter((path) => !path.startsWith('@angular/localize'));
+    if (!externalPackages) {
+      // Remove localize polyfill when i18n inline transformation have been applied to all the packages.
+      polyfills = polyfills.filter((path) => !path.startsWith('@angular/localize'));
+    }
 
     // Add locale data for all active locales
     // TODO: Inject each individually within the inlining process itself


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

`@angular/localize` scripts are always removed when inline transformations are enabled, even though not all the scripts/dependencies might have been transformed

Issue Number: N/A

## What is the new behavior?

`@angular/localize` scripts will only be removed when inline transformations are enabled and all the scripts/dependencies are actually transformed

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->