### PR TITLE
fix(@angular/build): dynamically select Vitest DOM environment

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
@@ -219,6 +219,7 @@ export class VitestExecutor implements TestExecutor {
             browser: browserOptions.browser,
             coverage,
             projectName,
+            projectSourceRoot: this.options.projectSourceRoot,
             reporters,
             setupFiles: testSetupFiles,
             projectPlugins,

--- a/packages/angular/build/src/builders/unit-test/runners/vitest/index.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/index.ts
@@ -33,8 +33,11 @@ const VitestTestRunner: TestRunner = {
         );
       }
     } else {
-      // JSDOM is used when no browsers are specified
-      checker.check('jsdom');
+      // DOM emulation is used when no browsers are specified
+      checker.checkAny(
+        ['jsdom', 'happy-dom'],
+        'A DOM environment is required for non-browser tests. Please install either "jsdom" or "happy-dom".',
+      );
     }
 
     if (options.coverage.enabled) {


### PR DESCRIPTION
This change enhances the Vitest unit test builder to intelligently select the default DOM test environment (`jsdom` or `happy-dom`) based on which package is installed in the user's project.

Previously, the builder strictly defaulted to `jsdom`. With this update:
- The `validateDependencies` function now checks for the presence of either `jsdom` or `happy-dom` when browser-based tests are not configured, providing a more flexible dependency requirement.
- A new `findTestEnvironment` helper function is introduced to detect the available DOM environment (`happy-dom` is preferred if installed, otherwise `jsdom`).
- The `createVitestConfigPlugin` now uses this helper to dynamically set the `environment` in the Vitest configuration, ensuring a smart default if the user has not explicitly specified one.

This improves the out-of-the-box experience by adapting to common project setups and offering more choice in DOM emulation.

NOTE: For advanced scenarios, a custom runner config can be used to customize the environment configuration.