### PR TITLE
refactor(@angular/build): provide file dependencies map on compilation initialize result

### DIFF
--- a/packages/angular/build/src/tools/angular/compilation/angular-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/angular-compilation.ts
@@ -76,6 +76,7 @@ export abstract class AngularCompilation {
     referencedFiles: readonly string[];
     externalStylesheets?: ReadonlyMap<string, string>;
     templateUpdates?: ReadonlyMap<string, string>;
+    componentResourcesDependencies?: ReadonlyMap<string, readonly string[]>;
   }>;
 
   abstract emitAffectedFiles(): Iterable<EmitFileResult> | Promise<Iterable<EmitFileResult>>;


### PR DESCRIPTION
I am writing a rsbuild plugin that compiles angular, it uses the compilation classes underneath and thanks to the exposure of [createAngularCompilation](https://github.com/angular/angular-cli/blob/53bdbf1dc056ad8a3c29000b66dc780217b4d28c/packages/angular/build/src/private.ts#L62) its been fairly smooth to implement. 

however I’ve encountered a blocker when wiring up a dev server that correctly associates component TypeScript files with their html template resources. for this a dependency map is needed and that's what [getResourceDependencies](https://github.com/angular/angular-cli/blob/main/packages/angular/build/src/tools/angular/compilation/aot-compilation.ts#L183) provides. but it isn’t publicly accessible from the compilation which is fair.

so right now, the only option seems to be creating a second Angular compiler instance in my plugin solely to access that API, which isn’t ideal. (i could be missing something?)

the PR change stores the dependencies map and returns it in initialization result which worked well in my case, but i am not sure if this is the right approach or what overhead it could introduce.