### PR TITLE
refactor(@angular/build): create shared utility for external metadata

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
@@ -99,11 +99,8 @@ export async function getVitestBuildOptions(
   entryPoints.set('init-testbed', 'angular:test-bed-init');
 
   const externalDependencies = new Set(['vitest']);
-  if (!options.browsers?.length) {
-    // Only add for non-browser setups.
-    // Comprehensive browser prebundling will be handled separately.
-    ANGULAR_PACKAGES_TO_EXTERNALIZE.forEach((dep) => externalDependencies.add(dep));
-  }
+  ANGULAR_PACKAGES_TO_EXTERNALIZE.forEach((dep) => externalDependencies.add(dep));
+
   if (baseBuildOptions.externalDependencies) {
     baseBuildOptions.externalDependencies.forEach((dep) => externalDependencies.add(dep));
   }

--- a/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
@@ -42,6 +42,7 @@ interface VitestConfigPluginOptions {
   setupFiles: string[];
   projectPlugins: Exclude<UserWorkspaceConfig['plugins'], undefined>;
   include: string[];
+  optimizeDepsInclude: string[];
 }
 
 async function findTestEnvironment(
@@ -133,6 +134,7 @@ export function createVitestConfigPlugin(options: VitestConfigPluginOptions): Vi
         },
         optimizeDeps: {
           noDiscovery: true,
+          include: options.optimizeDepsInclude,
         },
         plugins: projectPlugins,
       };


### PR DESCRIPTION
The logic to process external metadata from build results was previously implemented directly within the dev-server.

This commit extracts this logic into a shared utility function, `updateExternalMetadata`, and moves it to a common location. The dev-server is updated to use this new function.

Additionally, the Vitest unit test builder is modified to leverage this utility, allowing it to correctly track external dependencies for Vite's dependency optimization.