### PR TITLE
fix(@angular/build): ensure `ɵgetOrCreateAngularServerApp`  is always defined after errors

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite/hmr.ts
+++ b/packages/angular/build/src/builders/dev-server/vite/hmr.ts
@@ -57,9 +57,12 @@ export async function invalidateUpdatedFiles(
   }
 
   if (serverApplicationChanged) {
-    // Clear the server app cache and
-    // trigger module evaluation before reload to initiate dependency optimization.
-    const { ɵdestroyAngularServerApp } = (await server.ssrLoadModule('/main.server.mjs')) as {
+    // Clear the server app cache and trigger module evaluation before reload to initiate dependency optimization.
+    // The querystring is needed as a workaround for:
+    // `ɵgetOrCreateAngularServerApp` can be undefined right after an error.
+    const { ɵdestroyAngularServerApp } = (await server.ssrLoadModule(
+      `/main.server.mjs?timestamp=${Date.now()}`,
+    )) as {
       ɵdestroyAngularServerApp: typeof destroyAngularServerApp;
     };
 

--- a/packages/angular/build/src/tools/vite/middlewares/ssr-middleware.ts
+++ b/packages/angular/build/src/tools/vite/middlewares/ssr-middleware.ts
@@ -45,12 +45,6 @@ export function createAngularSsrInternalMiddleware(
         ɵgetOrCreateAngularServerApp: typeof getOrCreateAngularServerApp;
       };
 
-      // `ɵgetOrCreateAngularServerApp` can be undefined right after an error.
-      // See: https://github.com/angular/angular-cli/issues/29907
-      if (!ɵgetOrCreateAngularServerApp) {
-        return next();
-      }
-
       const angularServerApp = ɵgetOrCreateAngularServerApp({
         allowStaticRouteRender: true,
       });


### PR DESCRIPTION

Addresses an issue where  could become `ɵgetOrCreateAngularServerApp` undefined after an error, leading to subsequent rendering failures.

This change modifies the HMR process to include a timestamp when loading. This ensures the server application is always re-evaluated, preventing stale application states.
