### PR TITLE
refactor(@angular/build): improve Vitest configuration merging

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
@@ -226,7 +226,7 @@ export class VitestExecutor implements TestExecutor {
           watch: null,
         },
         plugins: [
-          createVitestConfigPlugin({
+          await createVitestConfigPlugin({
             browser: browserOptions.browser,
             coverage,
             projectName,

--- a/packages/angular/build/src/builders/unit-test/tests/options/browsers_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/browsers_spec.ts
@@ -16,53 +16,33 @@ import {
 } from '../setup';
 
 describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
-  xdescribe('Option: "browsers"', () => {
+  describe('Option: "browsers"', () => {
     beforeEach(async () => {
       setupApplicationTarget(harness);
     });
 
-    it('should use jsdom when browsers is not provided', async () => {
+    it('should use DOM emulation when browsers is not provided', async () => {
       harness.useTarget('test', {
         ...BASE_OPTIONS,
         browsers: undefined,
       });
 
-      const { result, logs } = await harness.executeOnce();
+      const { result } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
-      expectLog(logs, 'Using jsdom in Node.js for test execution.');
     });
 
-    it('should fail when browsers is empty', async () => {
-      harness.useTarget('test', {
-        ...BASE_OPTIONS,
-        browsers: [],
-      });
-
-      await expectAsync(harness.executeOnce()).toBeRejectedWithError(
-        /must NOT have fewer than 1 items/,
-      );
-    });
-
-    it('should launch a browser when provided', async () => {
+    it('should fail when a browser is requested but no provider is installed', async () => {
       harness.useTarget('test', {
         ...BASE_OPTIONS,
         browsers: ['chrome'],
       });
 
       const { result, logs } = await harness.executeOnce();
-      expect(result?.success).toBeTrue();
-      expectLog(logs, /Starting browser "chrome"/);
-    });
-
-    it('should launch a browser in headless mode when specified', async () => {
-      harness.useTarget('test', {
-        ...BASE_OPTIONS,
-        browsers: ['chromeheadless'],
-      });
-
-      const { result, logs } = await harness.executeOnce();
-      expect(result?.success).toBeTrue();
-      expectLog(logs, /Starting browser "chrome" in headless mode/);
+      expect(result?.success).toBeFalse();
+      expectLog(
+        logs,
+        `The "browsers" option requires either "@vitest/browser-playwright", "@vitest/browser-webdriverio", or "@vitest/browser-preview" to be installed`,
+      );
     });
   });
 });


### PR DESCRIPTION
This commit refactors the Vitest configuration handling within the unit test builder to more reliably merge the CLI-generated configuration with a user's `vitest-base.config.ts` file.

The new implementation uses Vitest's `mergeConfig` utility to create a layered configuration, ensuring that essential CLI settings (such as test entry points and in-memory file providers) are preserved while still allowing users to customize other options. This prevents user configurations from inadvertently overriding critical builder settings, leading to a more stable and predictable testing experience.