### PR TITLE
fix(@angular/cli): add schema versioning and metadata to example database

### DIFF
--- a/tools/example_db_generator.js
+++ b/tools/example_db_generator.js
@@ -89,6 +89,20 @@ function generate(inPath, outPath) {
   }
   const db = new DatabaseSync(dbPath);
 
+  // Create a table to store metadata.
+  db.exec(`
+    CREATE TABLE metadata (
+      key TEXT PRIMARY KEY NOT NULL,
+      value TEXT NOT NULL
+    );
+  `);
+
+  db.exec(`
+    INSERT INTO metadata (key, value) VALUES
+      ('schema_version', '1'),
+      ('created_at', '${new Date().toISOString()}');
+  `);
+
   // Create a relational table to store the structured example data.
   db.exec(`
     CREATE TABLE examples (


### PR DESCRIPTION
This commit introduces schema versioning and metadata to the Angular CLI's example database.

A new `metadata` table has been added to both the runtime and build-time example databases. This table stores key-value pairs, initially including `schema_version` and `created_at`.

The `find_examples` tool now validates the `schema_version` of the loaded database. If a schema mismatch is detected, the tool throws a descriptive error message that guides the user on how to resolve the incompatibility (e.g., by updating their CLI or project's `@angular/core` package).

This change improves the robustness and maintainability of the example database by:
- Ensuring compatibility between the CLI and the example database schema.
- Providing actionable feedback to users when schema versions are incompatible.
- Laying the groundwork for future metadata additions and database evolution.