### PR TITLE
refactor(@angular/build): update private exports to allow external cache usage

### DIFF
--- a/packages/angular/build/src/private.ts
+++ b/packages/angular/build/src/private.ts
@@ -36,7 +36,7 @@ export { SassWorkerImplementation } from './tools/sass/sass-service';
 
 export { SourceFileCache } from './tools/esbuild/angular/source-file-cache';
 export { Cache } from './tools/esbuild/cache';
-export { LmbdCacheStore } from './tools/esbuild/lmdb-cache-store';
+export { LmdbCacheStore } from './tools/esbuild/lmdb-cache-store';
 export { createJitResourceTransformer } from './tools/angular/transformers/jit-resource-transformer';
 export { JavaScriptTransformer } from './tools/esbuild/javascript-transformer';
 

--- a/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
@@ -73,11 +73,11 @@ export function createCompilerPlugin(
 
       // Initialize a worker pool for JavaScript transformations.
       // Webcontainers currently do not support this persistent cache store.
-      let cacheStore: import('../lmdb-cache-store').LmbdCacheStore | undefined;
+      let cacheStore: import('../lmdb-cache-store').LmdbCacheStore | undefined;
       if (pluginOptions.sourceFileCache?.persistentCachePath && !process.versions.webcontainer) {
         try {
-          const { LmbdCacheStore } = await import('../lmdb-cache-store');
-          cacheStore = new LmbdCacheStore(
+          const { LmdbCacheStore } = await import('../lmdb-cache-store');
+          cacheStore = new LmdbCacheStore(
             path.join(pluginOptions.sourceFileCache.persistentCachePath, 'angular-compiler.db'),
           );
         } catch (e) {

--- a/packages/angular/build/src/tools/esbuild/i18n-inliner.ts
+++ b/packages/angular/build/src/tools/esbuild/i18n-inliner.ts
@@ -11,7 +11,7 @@ import { createHash } from 'node:crypto';
 import { extname, join } from 'node:path';
 import { WorkerPool } from '../../utils/worker-pool';
 import { BuildOutputFile, BuildOutputFileType } from './bundler-context';
-import type { LmbdCacheStore } from './lmdb-cache-store';
+import type { LmdbCacheStore } from './lmdb-cache-store';
 import { createOutputFile } from './utils';
 
 /**
@@ -39,7 +39,7 @@ export interface I18nInlinerOptions {
 export class I18nInliner {
   #cacheInitFailed = false;
   #workerPool: WorkerPool;
-  #cache: LmbdCacheStore | undefined;
+  #cache: LmdbCacheStore | undefined;
   readonly #localizeFiles: ReadonlyMap<string, BuildOutputFile>;
   readonly #unmodifiedFiles: Array<BuildOutputFile>;
 
@@ -274,9 +274,9 @@ export class I18nInliner {
 
     // Initialize a persistent cache for i18n transformations.
     try {
-      const { LmbdCacheStore } = await import('./lmdb-cache-store');
+      const { LmdbCacheStore } = await import('./lmdb-cache-store');
 
-      this.#cache = new LmbdCacheStore(join(persistentCachePath, 'angular-i18n.db'));
+      this.#cache = new LmdbCacheStore(join(persistentCachePath, 'angular-i18n.db'));
     } catch {
       this.#cacheInitFailed = true;
 

--- a/packages/angular/build/src/tools/esbuild/lmdb-cache-store.ts
+++ b/packages/angular/build/src/tools/esbuild/lmdb-cache-store.ts
@@ -9,7 +9,7 @@
 import { RootDatabase, open } from 'lmdb';
 import { Cache, CacheStore } from './cache';
 
-export class LmbdCacheStore implements CacheStore<unknown> {
+export class LmdbCacheStore implements CacheStore<unknown> {
   readonly #cacheFileUrl;
   #db: RootDatabase | undefined;
 


### PR DESCRIPTION
This change allows using cache feature in `JavaScriptTransformer` from the private exports of `@angular/build`.
