### PR TITLE
fix(@angular/build): allow unit-test runner config with absolute path

### DIFF
--- a/packages/angular/build/src/builders/unit-test/options.ts
+++ b/packages/angular/build/src/builders/unit-test/options.ts
@@ -127,7 +127,7 @@ export async function normalizeOptions(
     dumpVirtualFiles: options.dumpVirtualFiles,
     listTests: options.listTests,
     runnerConfig:
-      typeof runnerConfig === 'string' ? path.join(workspaceRoot, runnerConfig) : runnerConfig,
+      typeof runnerConfig === 'string' ? path.resolve(workspaceRoot, runnerConfig) : runnerConfig,
   };
 }
 


### PR DESCRIPTION
The `unit-test` builder now supports passing an absolute path as the value of the `runnerConfig` option. Previously all paths were joined with the workspace root.
