### PR TITLE
fix(@angular/build): enhance Vitest dependency externalization and pre-bundling

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
@@ -231,7 +231,7 @@ export class VitestExecutor implements TestExecutor {
             coverage,
             projectName,
             projectSourceRoot: this.options.projectSourceRoot,
-            optimizeDepsInclude: this.externalMetadata.explicitBrowser,
+            optimizeDepsInclude: this.externalMetadata.implicitBrowser,
             reporters,
             setupFiles: testSetupFiles,
             projectPlugins,


### PR DESCRIPTION
This commit refactors the dependency handling for the Vitest runner to improve flexibility and correctness, especially for browser-based tests.

The previously hardcoded list of external Angular packages has been removed. Instead, a new `externalPackages: true` option is passed to the application builder, allowing for more dynamic and configurable externalization of packages. This prevents packages from `node_modules` from being bundled into the test entry points.

Note: For cases where a dependency should not be pre-bundled, the `optimizeDeps.exclude` option can be used within a custom runner configuration file.