### PR TITLE
test(@angular/build): add test with 'vitest' import in browser mode

### DIFF
--- a/tests/legacy-cli/e2e/tests/vitest/browser-no-globals.ts
+++ b/tests/legacy-cli/e2e/tests/vitest/browser-no-globals.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { writeFile } from '../../utils/fs';
+import { installPackage } from '../../utils/packages';
+import { exec, ng } from '../../utils/process';
+import { applyVitestBuilder } from '../../utils/vitest';
+
+/**
+ * Allow `vitest` import in browser mode.
+ * @see https://github.com/angular/angular-cli/issues/31745
+ */
+export default async function (): Promise<void> {
+  await applyVitestBuilder();
+
+  await installPackage('playwright@1');
+  await installPackage('@vitest/browser-playwright@4');
+
+  await exec('npx', 'playwright', 'install', 'chromium', '--only-shell');
+
+  await writeFile(
+    'src/app/app.spec.ts',
+    `
+    import { test, expect } from 'vitest';
+
+    test('should pass', () => {
+      expect(true).toBe(true);
+    });
+  `,
+  );
+
+  const { stdout } = await ng('test', '--browsers', 'ChromiumHeadless');
+
+  assert.match(stdout, /1 passed/, 'Expected 1 tests to pass.');
+}


### PR DESCRIPTION
This fixes the following error:
  'The entry point "vitest" cannot be marked as external'

by excluding vitest from the discovered dependencies handed to optimizeDeps.include

Closes #31745

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [X] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #31745

## What is the new behavior?

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
