### PR TITLE
fix(@angular/build): allow `globals` to be set to false

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
@@ -48,6 +48,7 @@ function createTestBedInitVirtualFile(
     import { NgModule${usesZoneJS ? ', provideZoneChangeDetection' : ''} } from '@angular/core';
     import { getTestBed, ɵgetCleanupHook as getCleanupHook } from '@angular/core/testing';
     import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';
+    import { afterEach, beforeEach } from 'vitest';
     ${providersImport}
 
     const ANGULAR_TESTBED_SETUP = Symbol.for('@angular/cli/testbed-setup');

--- a/packages/angular/build/src/builders/unit-test/tests/behavior/runner-config-vitest_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/behavior/runner-config-vitest_spec.ts
@@ -89,7 +89,7 @@ describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
       expect(results.numPassedTests).toBe(1);
     });
 
-    it('should allow overriding builder options via runnerConfig file', async () => {
+    it('should allow overriding globals to false via runnerConfig file', async () => {
       harness.useTarget('test', {
         ...BASE_OPTIONS,
         runnerConfig: 'vitest.config.ts',
@@ -111,7 +111,7 @@ describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
       harness.writeFile(
         'src/app/app.component.spec.ts',
         `
-        import { vi, test, expect } from 'vitest';
+        import { expect } from 'vitest';
         test('should pass', () => {
           expect(true).toBe(true);
         });
@@ -120,6 +120,38 @@ describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
 
       const { result } = await harness.executeOnce();
       expect(result?.success).toBeFalse();
+    });
+
+    it('should initialize environment even when globals are disabled in runnerConfig file', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        runnerConfig: 'vitest.config.ts',
+      });
+
+      harness.writeFile(
+        'vitest.config.ts',
+        `
+        import { defineConfig } from 'vitest/config';
+        export default defineConfig({
+          test: {
+            globals: false,
+          },
+        });
+        `,
+      );
+
+      harness.writeFile(
+        'src/app/app.component.spec.ts',
+        `
+        import { test, expect } from 'vitest';
+        test('should pass', () => {
+          expect(true).toBe(true);
+        });
+        `,
+      );
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
     });
 
     it('should fail when a DOM-dependent test is run in a node environment', async () => {


### PR DESCRIPTION
Closes #31785

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [X] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #31785

## What is the new behavior?

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
