### PR TITLE
fix(@angular/build): ensure Vitest setup files are executed in order

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
@@ -119,6 +119,7 @@ export async function createVitestConfigPlugin(
           globals: true,
           // Default to `false` to align with the Karma/Jasmine experience.
           isolate: false,
+          sequence: { setupFiles: 'list' },
         },
         optimizeDeps: {
           noDiscovery: true,

--- a/tests/legacy-cli/e2e/tests/vitest/browser-playwright.ts
+++ b/tests/legacy-cli/e2e/tests/vitest/browser-playwright.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { applyVitestBuilder } from '../../utils/vitest';
+import { exec, ng } from '../../utils/process';
+import { installPackage } from '../../utils/packages';
+import { writeFile } from '../../utils/fs';
+
+export default async function (): Promise<void> {
+  await applyVitestBuilder();
+  await installPackage('playwright@1');
+  await installPackage('@vitest/browser-playwright@4');
+  await exec('npx', 'playwright', 'install', 'chromium', '--only-shell');
+
+  await ng('generate', 'component', 'my-comp');
+
+  await writeFile(
+    'src/setup1.ts',
+    `
+      import { getTestBed } from '@angular/core/testing';
+
+      getTestBed().configureTestingModule({});
+    `,
+  );
+
+  const { stdout } = await ng(
+    'test',
+    '--no-watch',
+    '--browsers',
+    'chromiumHeadless',
+    '--setup-files',
+    'src/setup1.ts',
+  );
+
+  assert.match(stdout, /2 passed/, 'Expected 2 tests to pass.');
+}

--- a/tests/legacy-cli/e2e/tests/vitest/browser-webdriverio.ts
+++ b/tests/legacy-cli/e2e/tests/vitest/browser-webdriverio.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { applyVitestBuilder } from '../../utils/vitest';
+import { ng } from '../../utils/process';
+import { installPackage } from '../../utils/packages';
+import { writeFile } from '../../utils/fs';
+
+export default async function (): Promise<void> {
+  await applyVitestBuilder();
+  await installPackage('webdriverio@9');
+  await installPackage('@vitest/browser-webdriverio@4');
+
+  await ng('generate', 'component', 'my-comp');
+
+  await writeFile(
+    'src/setup1.ts',
+    `
+    import { getTestBed } from '@angular/core/testing';
+
+    getTestBed().configureTestingModule({});
+  `,
+  );
+
+  const { stdout } = await ng(
+    'test',
+    '--no-watch',
+    '--browsers',
+    'chromeHeadless',
+    '--setup-files',
+    'src/setup1.ts',
+  );
+
+  assert.match(stdout, /2 passed/, 'Expected 2 tests to pass.');
+}


### PR DESCRIPTION
This commit configures the Vitest runner to execute setup files in the order they are defined. This is crucial for ensuring that polyfills and the Angular TestBed are initialized in the correct sequence before any tests are run, preventing potential issues with the testing environment.