### PR TITLE
fix(@angular/build): fix setup files duplicate modules

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
@@ -11,7 +11,7 @@ import { toPosixPath } from '../../../../utils/path';
 import type { ApplicationBuilderInternalOptions } from '../../../application/options';
 import { OutputHashing } from '../../../application/schema';
 import { NormalizedUnitTestBuilderOptions, injectTestingPolyfills } from '../../options';
-import { findTests, getTestEntrypoints } from '../../test-discovery';
+import { findTests, getSetupEntrypoints, getTestEntrypoints } from '../../test-discovery';
 import { RunnerOptions } from '../api';
 
 function createTestBedInitVirtualFile(
@@ -88,12 +88,19 @@ export async function getVitestBuildOptions(
     );
   }
 
-  const entryPoints = getTestEntrypoints(testFiles, {
+  const testEntryPoints = getTestEntrypoints(testFiles, {
     projectSourceRoot,
     workspaceRoot,
     removeTestExtension: true,
   });
-  entryPoints.set('init-testbed', 'angular:test-bed-init');
+  const setupEntryPoints = getSetupEntrypoints(options.setupFiles, {
+    projectSourceRoot,
+    workspaceRoot,
+    removeTestExtension: true,
+  });
+  setupEntryPoints.set('init-testbed', 'angular:test-bed-init');
+
+  const entryPoints = new Map([...testEntryPoints, ...setupEntryPoints]);
 
   // The 'vitest' package is always external for testing purposes
   const externalDependencies = ['vitest'];
@@ -138,6 +145,6 @@ export async function getVitestBuildOptions(
     virtualFiles: {
       'angular:test-bed-init': testBedInitContents,
     },
-    testEntryPointMappings: entryPoints,
+    testEntryPointMappings: testEntryPoints,
   };
 }

--- a/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
@@ -26,6 +26,7 @@ import type { TestExecutor } from '../api';
 import { setupBrowserConfiguration } from './browser-provider';
 import { findVitestBaseConfig } from './configuration';
 import { createVitestConfigPlugin, createVitestPlugins } from './plugins';
+import { getSetupEntrypoints } from '../../test-discovery';
 
 export class VitestExecutor implements TestExecutor {
   private vitest: Vitest | undefined;
@@ -127,9 +128,19 @@ export class VitestExecutor implements TestExecutor {
   }
 
   private prepareSetupFiles(): string[] {
-    const { setupFiles } = this.options;
+    const { setupFiles, workspaceRoot } = this.options;
+
+    const setupFilesEntrypoints = getSetupEntrypoints(setupFiles, {
+      projectSourceRoot: this.options.projectSourceRoot,
+      workspaceRoot,
+      removeTestExtension: true,
+    });
+    const setupFileNames = Array.from(setupFilesEntrypoints.keys()).map(
+      (entrypoint) => `${entrypoint}.js`,
+    );
+
     // Add setup file entries for TestBed initialization and project polyfills
-    const testSetupFiles = ['init-testbed.js', ...setupFiles];
+    const testSetupFiles = ['init-testbed.js', ...setupFileNames];
 
     // TODO: Provide additional result metadata to avoid needing to extract based on filename
     if (this.buildResultFiles.has('polyfills.js')) {


### PR DESCRIPTION
This includes setup files in the initial build and avoids lazy discovery and thus module duplicates.
Module duplicates can break many things such as dependency injection.

⚠️ this only handles `setupFiles` directly provided to the builder.
Handling `setupFiles` from the Vitest config requires substantial additional effort. 

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [X] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #31732 

## What is the new behavior?

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
