### PR TITLE
refactor(@angular/build): remove deprecated browser-level isolate option

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/browser-provider.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/browser-provider.ts
@@ -117,7 +117,6 @@ export async function setupBrowserConfiguration(
     provider,
     headless,
     ui: !headless,
-    isolate: debug,
     viewport,
     instances: browsers.map((browserName) => ({
       browser: normalizeBrowserName(browserName),


### PR DESCRIPTION
This commit removes the deprecated `isolate` option from the browser-level configuration for the Vitest runner.

The `browser.isolate` option has been deprecated in Vitest. Test isolation should now be controlled at the test level, which is already the default behavior. This change aligns the builder with the latest Vitest practices and removes a deprecated setting.