### PR TITLE
fix(@angular/build): enable test isolation by default in browser mode

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
@@ -117,8 +117,9 @@ export async function createVitestConfigPlugin(
         test: {
           setupFiles,
           globals: true,
-          // Default to `false` to align with the Karma/Jasmine experience.
-          isolate: false,
+          // Default to `false` to align with the Karma/Jasmine experience when using DOM emulation
+          // TODO: Investigate how this can be the default for browser mode as well
+          isolate: !!browser?.enabled,
           sequence: { setupFiles: 'list' },
         },
         optimizeDeps: {


### PR DESCRIPTION
This commit enables test isolation by default when running tests in a browser.

Disabling test isolation in browser mode has been found to cause non-deterministic test failures. To improve reliability, this change conditionally enables the `isolate` option when a browser provider is active.

Isolation remains disabled for DOM emulation environments to maintain alignment with the traditional Karma/Jasmine experience. Further investigation is needed to determine if isolation can be safely disabled for browser mode in the future.