### PR TITLE
fix(@angular/build): remove explicit test isolation configuration

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
@@ -117,8 +117,7 @@ export async function createVitestConfigPlugin(
         test: {
           setupFiles,
           globals: true,
-          // Default to `false` to align with the Karma/Jasmine experience.
-          isolate: false,
+          // Allow Vitest to manage test isolation by its default behavior.
           sequence: { setupFiles: 'list' },
         },
         optimizeDeps: {


### PR DESCRIPTION
This commit removes the explicit `isolate` option from the Vitest configuration within the Angular CLI builder.

Previously, the `isolate` option was explicitly set to `false` for DOM emulation and browser mode. However, due to observed non-deterministic failures and the need for consistent isolation behavior across all environments, it's more robust to allow Vitest to manage test isolation by its own default mechanisms. This change ensures that Vitest's internal defaults for isolation are respected, which are generally designed for optimal reliability.