### PR TITLE
fix(@angular/build): ensure TestBed cleanup hooks are always registered

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
@@ -36,6 +36,12 @@ function createTestBedInitVirtualFile(
     import { afterEach, beforeEach } from 'vitest';
     ${providersImport}
 
+    // The beforeEach and afterEach hooks are registered outside the globalThis guard.
+    // This ensures that the hooks are always applied, even in non-isolated browser environments.
+    // Same as https://github.com/angular/angular/blob/05a03d3f975771bb59c7eefd37c01fa127ee2229/packages/core/testing/srcs/test_hooks.ts#L21-L29
+    beforeEach(getCleanupHook(false));
+    afterEach(getCleanupHook(true));
+
     const ANGULAR_TESTBED_SETUP = Symbol.for('@angular/cli/testbed-setup');
     if (!globalThis[ANGULAR_TESTBED_SETUP]) {
       globalThis[ANGULAR_TESTBED_SETUP] = true;
@@ -43,10 +49,6 @@ function createTestBedInitVirtualFile(
       // The Angular TestBed needs to be initialized before any tests are run.
       // In a non-isolated environment, this setup file can be executed multiple times.
       // The guard condition above ensures that the setup is only performed once.
-
-      // Same as https://github.com/angular/angular/blob/05a03d3f975771bb59c7eefd37c01fa127ee2229/packages/core/testing/srcs/test_hooks.ts#L21-L29
-      beforeEach(getCleanupHook(false));
-      afterEach(getCleanupHook(true));
 
       @NgModule({
         providers: [${usesZoneJS ? 'provideZoneChangeDetection(), ' : ''}...providers],


### PR DESCRIPTION
This commit moves the `beforeEach` and `afterEach` hook registrations for TestBed cleanup to be outside the global setup guard.

In environments where test isolation is not strictly enforced (when `isolate: false`), the setup file can be executed multiple times in different contexts. The global guard would previously prevent the hooks from being re-registered, leading to inconsistent test behavior and potential state leakage between tests.

This change ensures the cleanup hooks are always registered, improving the reliability and predictability of tests across all execution environments.