### PR TITLE
fix(@angular/build): enhance Vitest resolution for optimal package loading

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
@@ -124,6 +124,10 @@ export async function createVitestConfigPlugin(
           noDiscovery: true,
           include: options.optimizeDepsInclude,
         },
+        resolve: {
+          mainFields: ['es2020', 'module', 'main'],
+          conditions: ['es2015', 'es2020', 'module'],
+        },
       };
 
       const { optimizeDeps, resolve } = config;


### PR DESCRIPTION
Align Vitest's module resolution with the development server to ensure consistent behavior. This change configures Vitest to prioritize ESM-optimized package entry points by setting 'es2020', 'module', and 'main' as main fields and 'es2015', 'es2020', and 'module' as conditions during module resolution. This improves compatibility and performance by utilizing modern JavaScript module formats where available.

Closes #31808