### PR TITLE
fix(@angular/build): disable Vitest test isolation by default

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
@@ -117,7 +117,8 @@ export async function createVitestConfigPlugin(
         test: {
           setupFiles,
           globals: true,
-          // Allow Vitest to manage test isolation by its default behavior.
+          // Default to `false` to align with the Karma/Jasmine experience.
+          isolate: false,
           sequence: { setupFiles: 'list' },
         },
         optimizeDeps: {


### PR DESCRIPTION
Disables test isolation in Vitest by setting `isolate: false` in the default Vitest configuration. This change aligns the default test isolation behavior with the existing Karma/Jasmine experience, promoting standardization across testing frameworks within the Angular CLI.

This also provides significant performance improvements, especially in browser mode, by reducing the overhead associated with test isolation. All known issues related to disabling isolation have been addressed.