### PR TITLE
test: improve vitest e2e test stability and performance

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/browser-provider.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/browser-provider.ts
@@ -76,7 +76,21 @@ export async function setupBrowserConfiguration(
       // Validate that the imported module has the expected structure
       const providerFactory = providerModule[providerName];
       if (typeof providerFactory === 'function') {
-        provider = providerFactory();
+        if (
+          providerName === 'playwright' &&
+          process.env['CHROME_BIN']?.includes('rules_browsers')
+        ) {
+          // Use the Chrome binary from the 'rules_browsers' toolchain (via CHROME_BIN)
+          // for Playwright when available to ensure hermetic testing, preventing reliance
+          // on locally installed or NPM-managed browser versions.
+          provider = providerFactory({
+            launchOptions: {
+              executablePath: process.env.CHROME_BIN,
+            },
+          });
+        } else {
+          provider = providerFactory();
+        }
       } else {
         errors ??= [];
         errors.push(

--- a/tests/legacy-cli/e2e/tests/vitest/tslib-resolution.ts
+++ b/tests/legacy-cli/e2e/tests/vitest/tslib-resolution.ts
@@ -1,6 +1,6 @@
 import { writeFile } from '../../utils/fs';
 import { installPackage } from '../../utils/packages';
-import { exec, ng } from '../../utils/process';
+import { ng } from '../../utils/process';
 import { applyVitestBuilder } from '../../utils/vitest';
 import assert from 'node:assert';
 
@@ -8,7 +8,6 @@ export default async function () {
   await applyVitestBuilder();
   await installPackage('playwright@1');
   await installPackage('@vitest/browser-playwright@4');
-  await exec('npx', 'playwright', 'install', 'chromium', '--only-shell');
 
   // Add a custom decorator to trigger tslib usage
   await writeFile(


### PR DESCRIPTION
- Use Chrome binary from `rules_browsers` for Playwright in Vitest browser tests for hermetic testing and avoids re-downloads of chrome.
- Batch `ng generate` commands in e2e tests to improve performance.
- Remove now redundant chromium install commands from e2e tests.
