### PR TITLE
fix(@angular/build): prioritize string type for runnerConfig schema

### DIFF
--- a/packages/angular/build/src/builders/unit-test/options.ts
+++ b/packages/angular/build/src/builders/unit-test/options.ts
@@ -127,7 +127,11 @@ export async function normalizeOptions(
     dumpVirtualFiles: options.dumpVirtualFiles,
     listTests: options.listTests,
     runnerConfig:
-      typeof runnerConfig === 'string' ? path.resolve(workspaceRoot, runnerConfig) : runnerConfig,
+      typeof runnerConfig === 'string'
+        ? runnerConfig.length === 0
+          ? true
+          : path.resolve(workspaceRoot, runnerConfig)
+        : runnerConfig,
   };
 }
 

--- a/packages/angular/build/src/builders/unit-test/schema.json
+++ b/packages/angular/build/src/builders/unit-test/schema.json
@@ -20,7 +20,7 @@
       "enum": ["karma", "vitest"]
     },
     "runnerConfig": {
-      "type": ["boolean", "string"],
+      "type": ["string", "boolean"],
       "description": "Specifies the configuration file for the selected test runner. If a string is provided, it will be used as the path to the configuration file. If `true`, the builder will search for a default configuration file (e.g., `vitest.config.ts` or `karma.conf.js`). If `false`, no external configuration file will be used.\\nFor Vitest, this enables advanced options and the use of custom plugins. Please note that while the file is loaded, the Angular team does not provide direct support for its specific contents or any third-party plugins used within it.",
       "default": false
     },

--- a/tests/legacy-cli/e2e/tests/vitest/runner-config-path.ts
+++ b/tests/legacy-cli/e2e/tests/vitest/runner-config-path.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { writeMultipleFiles } from '../../utils/fs';
+import { ng } from '../../utils/process';
+import { applyVitestBuilder } from '../../utils/vitest';
+
+export default async function (): Promise<void> {
+  await applyVitestBuilder();
+
+  // Create a custom Vitest configuration file.
+  const customConfigPath = 'vitest.custom.mjs';
+  await writeMultipleFiles({
+    [customConfigPath]: `
+      import { defineConfig } from 'vitest/config';
+      export default defineConfig({
+        test: {
+          // A unique option to confirm this file is being used.
+          passWithNoTests: true,
+        },
+      });
+    `,
+  });
+
+  const absoluteConfigPath = path.resolve(customConfigPath);
+  const { stdout } = await ng('test', `--runner-config=${absoluteConfigPath}`);
+
+  // Assert that the CLI logs the use of the specified configuration file.
+  assert.match(
+    stdout,
+    /vitest\.custom\.mjs/,
+    'Expected a message confirming the use of the custom config file.',
+  );
+}


### PR DESCRIPTION
Reorders the `type` union in the `runnerConfig` option's schema to prioritize `string` over `boolean`.

This change provides a stronger hint to the CLI's argument parser, ensuring that when a value is provided for the option (e.g., a file path), it is unambiguously treated as a string. This improves the robustness of the parsing logic for this union-type option while preserving the functionality of its boolean flag forms.