### PR TITLE
fix(@schematics/angular): flag '--file-name-style-guide=2016' - wrong import in main.ts

### DIFF
--- a/packages/schematics/angular/application/files/standalone-files/src/main.ts.template
+++ b/packages/schematics/angular/application/files/standalone-files/src/main.ts.template
@@ -1,6 +1,6 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
-import { App } from './app/app';
+import { App } from './app/app<%= suffix %>';
 
 bootstrapApplication(App, appConfig)
   .catch((err) => console.error(err));

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -876,8 +876,10 @@ describe('Application Schematic', () => {
       const options = { ...defaultOptions, fileNameStyleGuide: '2016' as const };
       const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
       const component = tree.readContent('/projects/foo/src/app/app.component.ts');
+      const main = tree.readContent('/projects/foo/src/main.ts');
       expect(component).toContain(`templateUrl: './app.component.html'`);
       expect(component).toContain(`styleUrl: './app.component.css'`);
+      expect(main).toContain(`import { App } from './app/app.component'`);
     });
 
     it('should create a test file with import from the path without suffix', async () => {


### PR DESCRIPTION
 ## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Follow-up PR to https://github.com/angular/angular-cli/pull/31831

When scaffolding new app with standalone components using `--file-name-style-guide=2016`, the `main.ts` file refers to non-existing `.app/app` file.

Steps to reproduce:
```bash
npx @angular/cli@21.0.0-rc.5 new nmy-app --file-name-style-guide=2016
```

Issue Number: N/A

## What is the new behavior?

`main.ts.template` file used for scaffolding app with standalone component has been adjusted to use `suffix` variable.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
