### PR TITLE
fix(@angular/build): correct Vitest coverage path resolution for JSDOM on Windows

### DIFF
--- a/tests/legacy-cli/e2e/tests/vitest/larger-project-coverage.ts
+++ b/tests/legacy-cli/e2e/tests/vitest/larger-project-coverage.ts
@@ -36,16 +36,12 @@ export default async function () {
   const { stdout: jsdomStdout } = await ng('test', '--no-watch', '--coverage');
   assert.match(jsdomStdout, expectedMessage, `Expected ${totalTests} tests to pass in JSDOM mode.`);
 
-  // TODO: Investigate why coverage-final.json is empty on Windows in JSDOM mode.
-  // For now, skip the coverage report check on Windows.
-  if (process.platform !== 'win32') {
-    // Assert that every generated file is in the coverage report by reading the JSON output.
-    const jsdomSummary = JSON.parse(await readFile(coverageJsonPath));
-    const jsdomSummaryKeys = Object.keys(jsdomSummary);
-    for (const file of generatedFiles) {
-      const found = jsdomSummaryKeys.some((key) => key.endsWith(file));
-      assert.ok(found, `Expected ${file} to be in the JSDOM coverage report.`);
-    }
+  // Assert that every generated file is in the coverage report by reading the JSON output.
+  const jsdomSummary = JSON.parse(await readFile(coverageJsonPath));
+  const jsdomSummaryKeys = Object.keys(jsdomSummary);
+  for (const file of generatedFiles) {
+    const found = jsdomSummaryKeys.some((key) => key.endsWith(file));
+    assert.ok(found, `Expected ${file} to be in the JSDOM coverage report.`);
   }
 
   // Setup for browser mode


### PR DESCRIPTION
This commit addresses an issue where Vitest coverage reports were incomplete on Windows when using the JSDOM test environment. The root cause is an improperly formatted absolute path that can result from manually converting a file URL back to a path on Windows, leading to a superfluous leading slash (e.g., '/D:/path' instead of 'D:/path'). The 'angular:test-in-memory-provider' plugin now explicitly detects and removes this leading slash from absolute Windows paths, thereby correcting the path format and enabling proper source file mapping for coverage collection.

Closes #31842