### PR TITLE
fix(@angular/build): correctly invoke isTTY as a function

### DIFF
--- a/packages/angular/build/src/utils/check-port.ts
+++ b/packages/angular/build/src/utils/check-port.ts
@@ -32,7 +32,7 @@ export async function checkPort(port: number, host: string): Promise<number> {
           return;
         }
 
-        if (!isTTY) {
+        if (!isTTY()) {
           reject(createInUseError(port));
 
           return;


### PR DESCRIPTION
Addresses an issue where 'isTTY' was incorrectly treated as a property instead of being called as a function, ensuring proper terminal detection.
