### PR TITLE
ci: relocate license check to prevent blocking other CI jobs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,8 +55,6 @@ jobs:
         run: pnpm ts-circular-deps check
       - name: Run Validation
         run: pnpm admin validate
-      - name: Check Package Licenses
-        uses: angular/dev-infra/github-actions/linting/licenses@c855fffb4b01bc06e743eb3bdfd54c866af09ad8
       - name: Check tooling setup
         run: pnpm check-tooling-setup
       - name: Check commit message
@@ -67,6 +65,8 @@ jobs:
         # Code formatting checks are only done on pull requests as its too late to validate once
         # it has been merged.
         run: pnpm ng-dev format changed --check ${{ github.event.pull_request.base.sha }}
+      - name: Check Package Licenses
+        uses: angular/dev-infra/github-actions/linting/licenses@c855fffb4b01bc06e743eb3bdfd54c866af09ad8
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Relocates the "Check Package Licenses" step in `pr.yml` to ensure that failures in this specific check do not prevent other critical CI jobs from completing or providing feedback on pull requests.
