### PR TITLE
build: update to latest ng-dev tooling for caretaker handoff update

### DIFF
--- a/.ng-dev/caretaker.mjs
+++ b/.ng-dev/caretaker.mjs
@@ -1,6 +1,6 @@
 /**
  * The configuration for `ng-dev caretaker` commands.
- * 
+ *
  * @type { import("@angular/ng-dev").CaretakerConfig }
  */
 export const caretaker = {
@@ -14,5 +14,4 @@ export const caretaker = {
       query: `is:pr is:open label:"action: merge-assistance"`,
     },
   ],
-  caretakerGroup: 'angular-cli-caretaker',
 };


### PR DESCRIPTION
Update to the latest tooling to upate how caretaker handoff is handled, using new standardized groupings
