### PR TITLE
fix(@schematics/angular): add MCP configuration file to new workspaces

### DIFF
--- a/packages/schematics/angular/workspace/files/__dot__gitignore.template
+++ b/packages/schematics/angular/workspace/files/__dot__gitignore.template
@@ -26,6 +26,7 @@ yarn-error.log
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+!.vscode/mcp.json
 .history/*
 
 # Miscellaneous

--- a/packages/schematics/angular/workspace/files/__dot__vscode/mcp.json.template
+++ b/packages/schematics/angular/workspace/files/__dot__vscode/mcp.json.template
@@ -1,0 +1,9 @@
+{
+  // For more information, visit: https://angular.dev/ai/mcp
+  "mcpServers": {
+    "angular-cli": {
+      "command": "npx",
+      "args": ["-y", "@angular/cli", "mcp"]
+    }
+  }
+}

--- a/packages/schematics/angular/workspace/index_spec.ts
+++ b/packages/schematics/angular/workspace/index_spec.ts
@@ -29,6 +29,7 @@ describe('Workspace Schematic', () => {
       jasmine.arrayContaining([
         '/.vscode/extensions.json',
         '/.vscode/launch.json',
+        '/.vscode/mcp.json',
         '/.vscode/tasks.json',
         '/.editorconfig',
         '/angular.json',
@@ -70,6 +71,7 @@ describe('Workspace Schematic', () => {
       jasmine.arrayContaining([
         '/.vscode/extensions.json',
         '/.vscode/launch.json',
+        '/.vscode/mcp.json',
         '/.vscode/tasks.json',
         '/angular.json',
         '/.gitignore',


### PR DESCRIPTION
Closes #31888
Changes:
  - Add .vscode/mcp.json template with angular-cli MCP server configuration
  - Update .gitignore template to whitelist .vscode/mcp.json
  - Update workspace schematic tests to expect mcp.json file


## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
When using `ng new`, it does not create any mcp.json files.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #31888

## What is the new behavior?
When using `ng new`, it now creates an mcp.json file including Angular MCP.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
I included the Angular MCP by default.