### PR TITLE
fix(@angular/ssr): handle `X-Forwarded-Prefix` and `APP_BASE_HREF` in redirects

### DIFF
--- a/packages/angular/ssr/src/app.ts
+++ b/packages/angular/ssr/src/app.ts
@@ -175,8 +175,15 @@ export class AngularServerApp {
     }
 
     const { redirectTo, status, renderMode } = matchedRoute;
+
     if (redirectTo !== undefined) {
-      return createRedirectResponse(buildPathWithParams(redirectTo, url.pathname), status);
+      return createRedirectResponse(
+        joinUrlParts(
+          request.headers.get('X-Forwarded-Prefix') ?? '',
+          buildPathWithParams(redirectTo, url.pathname),
+        ),
+        status,
+      );
     }
 
     if (renderMode === RenderMode.Prerender) {

--- a/packages/angular/ssr/test/app-engine_spec.ts
+++ b/packages/angular/ssr/test/app-engine_spec.ts
@@ -269,19 +269,5 @@ describe('AngularAppEngine', () => {
       const response = await appEngine.handle(request);
       expect(await response?.text()).toContain('Home works');
     });
-
-    it('should work with encoded characters', async () => {
-      const request = new Request('https://example.com/home?email=xyz%40xyz.com');
-      const response = await appEngine.handle(request);
-      expect(response?.status).toBe(200);
-      expect(await response?.text()).toContain('Home works');
-    });
-
-    it('should work with decoded characters', async () => {
-      const request = new Request('https://example.com/home?email=xyz@xyz.com');
-      const response = await appEngine.handle(request);
-      expect(response?.status).toBe(200);
-      expect(await response?.text()).toContain('Home works');
-    });
   });
 });


### PR DESCRIPTION


This commit ensures that redirects correctly account for the X-Forwarded-Prefix header and APP_BASE_HREF, preventing incorrect redirect loops or invalid URLs when running behind a proxy or with a base href.

Closes #31902
