### PR TITLE
fix(@schematics/angular): do not set `esModuleInterop` and `moduleResolution` when module is `preserve`

### DIFF
--- a/packages/schematics/angular/migrations/use-application-builder/migration.ts
+++ b/packages/schematics/angular/migrations/use-application-builder/migration.ts
@@ -362,10 +362,16 @@ export default function (): Rule {
     ),
     // Update main tsconfig
     updateJsonFile('tsconfig.json', (rootJson) => {
-      rootJson.modify(['compilerOptions', 'esModuleInterop'], true);
+      const module = rootJson.get(['compilerOptions', 'module']);
+      const hasPreserveModule = typeof module === 'string' && module.toLowerCase() === 'preserve';
+
+      if (!hasPreserveModule) {
+        rootJson.modify(['compilerOptions', 'esModuleInterop'], true);
+        rootJson.modify(['compilerOptions', 'moduleResolution'], 'bundler');
+      }
+
       rootJson.modify(['compilerOptions', 'downlevelIteration'], undefined);
       rootJson.modify(['compilerOptions', 'allowSyntheticDefaultImports'], undefined);
-      rootJson.modify(['compilerOptions', 'moduleResolution'], 'bundler');
     }),
   ]);
 }

--- a/packages/schematics/angular/migrations/use-application-builder/migration_spec.ts
+++ b/packages/schematics/angular/migrations/use-application-builder/migration_spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import { JsonObject } from '@angular-devkit/core';
 import { EmptyTree } from '@angular-devkit/schematics';
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
 import { Builders, ProjectType, WorkspaceSchema } from '../../utility/workspace-models';
@@ -447,5 +448,17 @@ describe(`Migration to use the application builder`, () => {
     const { devDependencies } = JSON.parse(newTree.readContent('/package.json'));
 
     expect(devDependencies['postcss']).toBeUndefined();
+  });
+
+  it('it should not add esModuleInterop and moduleResolution when module is preserve', async () => {
+    tree.overwrite(
+      'tsconfig.json',
+      JSON.stringify({
+        compilerOptions: { module: 'preserve' },
+      }),
+    );
+    const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
+    const { compilerOptions } = newTree.readJson('tsconfig.json') as JsonObject;
+    expect(compilerOptions).toEqual({ module: 'preserve' });
   });
 });


### PR DESCRIPTION


## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Migrating from v20 to v21 causes both esModuleInterop and moduleResolution to be added again which isn't needed when module is set to preserve

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
