### PR TITLE
fix(@schematics/angular): silently skip when the build target already uses one of the new builders

### DIFF
--- a/packages/schematics/angular/migrations/use-application-builder/migration.ts
+++ b/packages/schematics/angular/migrations/use-application-builder/migration.ts
@@ -174,7 +174,11 @@ function updateProjects(tree: Tree, context: SchematicContext) {
       }
 
       const buildTarget = project.targets.get('build');
-      if (!buildTarget || buildTarget.builder === Builders.Application) {
+      if (
+        !buildTarget ||
+        buildTarget.builder === Builders.Application ||
+        buildTarget.builder === Builders.BuildApplication
+      ) {
         continue;
       }
 


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Current when migrating an app that's already using the new builders, it shows an unnecessary error that imo should be only displayed for non supported builders


Issue Number: N/A

## What is the new behavior?

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
