### PR TITLE
Revert "fix(@schematics/angular): add MCP configuration file to new workspaces"

### DIFF
--- a/packages/schematics/angular/workspace/files/__dot__gitignore.template
+++ b/packages/schematics/angular/workspace/files/__dot__gitignore.template
@@ -26,7 +26,6 @@ yarn-error.log
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
-!.vscode/mcp.json
 .history/*
 
 # Miscellaneous

--- a/packages/schematics/angular/workspace/files/__dot__vscode/mcp.json.template
+++ b/packages/schematics/angular/workspace/files/__dot__vscode/mcp.json.template
@@ -1,9 +1,0 @@
-{
-  // For more information, visit: https://angular.dev/ai/mcp
-  "mcpServers": {
-    "angular-cli": {
-      "command": "npx",
-      "args": ["-y", "@angular/cli", "mcp"]
-    }
-  }
-}

--- a/packages/schematics/angular/workspace/index_spec.ts
+++ b/packages/schematics/angular/workspace/index_spec.ts
@@ -29,7 +29,6 @@ describe('Workspace Schematic', () => {
       jasmine.arrayContaining([
         '/.vscode/extensions.json',
         '/.vscode/launch.json',
-        '/.vscode/mcp.json',
         '/.vscode/tasks.json',
         '/.editorconfig',
         '/angular.json',
@@ -71,7 +70,6 @@ describe('Workspace Schematic', () => {
       jasmine.arrayContaining([
         '/.vscode/extensions.json',
         '/.vscode/launch.json',
-        '/.vscode/mcp.json',
         '/.vscode/tasks.json',
         '/angular.json',
         '/.gitignore',


### PR DESCRIPTION
This reverts commit 7a52e3c4946206858587208c2e2f5c575697efe9.

This is a feature and modifies `ng new` output which should be limited to minor or major releases, not patch releases.