### PR TITLE
fix(@schematics/angular): add missing imports for lifecycle hooks in jasmine-vitest migration

### DIFF
--- a/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.ts
@@ -57,6 +57,19 @@ import { RefactorReporter } from './utils/refactor-reporter';
 const BLANK_LINE_PLACEHOLDER = '// __PRESERVE_BLANK_LINE__';
 
 /**
+ * Vitest function names that should be imported when using the --add-imports option.
+ */
+const VITEST_FUNCTION_NAMES = new Set([
+  'describe',
+  'it',
+  'expect',
+  'beforeEach',
+  'afterEach',
+  'beforeAll',
+  'afterAll',
+]);
+
+/**
  * Replaces blank lines in the content with a placeholder to prevent TypeScript's printer
  * from removing them. This ensures that the original formatting of blank lines is preserved.
  * @param content The source code content.
@@ -183,7 +196,7 @@ export function transformJasmineToVitest(
       if (ts.isCallExpression(transformedNode)) {
         if (options.addImports && ts.isIdentifier(transformedNode.expression)) {
           const name = transformedNode.expression.text;
-          if (name === 'describe' || name === 'it' || name === 'expect') {
+          if (VITEST_FUNCTION_NAMES.has(name)) {
             addVitestValueImport(pendingVitestValueImports, name);
           }
         }

--- a/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer_add-imports_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer_add-imports_spec.ts
@@ -81,5 +81,41 @@ describe('Jasmine to Vitest Transformer', () => {
       `;
       await expectTransformation(input, expected, true);
     });
+
+    it('should add imports for beforeEach and afterEach when addImports is true', async () => {
+      const input = `
+        describe('My Suite', () => {
+          beforeEach(() => {});
+          afterEach(() => {});
+        });
+      `;
+      const expected = `
+        import { afterEach, beforeEach, describe } from 'vitest';
+
+        describe('My Suite', () => {
+          beforeEach(() => {});
+          afterEach(() => {});
+        });
+      `;
+      await expectTransformation(input, expected, true);
+    });
+
+    it('should add imports for beforeAll and afterAll when addImports is true', async () => {
+      const input = `
+        describe('My Suite', () => {
+          beforeAll(() => {});
+          afterAll(() => {});
+        });
+      `;
+      const expected = `
+        import { afterAll, beforeAll, describe } from 'vitest';
+
+        describe('My Suite', () => {
+          beforeAll(() => {});
+          afterAll(() => {});
+        });
+      `;
+      await expectTransformation(input, expected, true);
+    });
   });
 });


### PR DESCRIPTION


## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When using `ng g refactor-jasmine-vitest --add-imports` the lifecycle hooks of vitest are not imported

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
