### PR TITLE
fix(@schematics/angular): fix migration of `jasmine.clock().mockDate()`

### DIFF
--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-misc.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-misc.ts
@@ -61,7 +61,15 @@ export function transformTimerMocks(
       node,
       `Transformed \`jasmine.clock().${pae.name.text}\` to \`vi.${newMethodName}\`.`,
     );
-    const newArgs = newMethodName === 'useFakeTimers' ? [] : node.arguments;
+    let newArgs: readonly ts.Expression[] = node.arguments;
+    if (newMethodName === 'useFakeTimers') {
+      newArgs = [];
+    }
+    if (newMethodName === 'setSystemTime' && node.arguments.length === 0) {
+      newArgs = [
+        ts.factory.createNewExpression(ts.factory.createIdentifier('Date'), undefined, []),
+      ];
+    }
 
     return createViCallExpression(newMethodName, newArgs);
   }

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-misc_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-misc_spec.ts
@@ -31,6 +31,11 @@ describe('Jasmine to Vitest Transformer', () => {
         input: `jasmine.clock().mockDate(new Date('2025-01-01'));`,
         expected: `vi.setSystemTime(new Date('2025-01-01'));`,
       },
+      {
+        description: 'should transform jasmine.clock().mockDate() to vi.setSystemTime(new Date())',
+        input: `jasmine.clock().mockDate();`,
+        expected: `vi.setSystemTime(new Date());`,
+      },
     ];
 
     testCases.forEach(({ description, input, expected }) => {


### PR DESCRIPTION
The migration previously migrated `jasmine.clock().mockDate()` to `vi.setSystemTime()`, which does not compile because `vi.setSystemTime()` requires an argument. This commit fixes it by migrating `jasmine.clock().mockDate()` to `vi.setSystemTime(new Date())`.

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ ] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
