### PR TITLE
feat(@schematics/angular): add browserMode option to jasmine-vitest schematic

### DIFF
--- a/packages/schematics/angular/refactor/jasmine-vitest/index.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/index.ts
@@ -121,6 +121,7 @@ export default function (options: Schema): Rule {
       const content = tree.readText(file);
       const newContent = transformJasmineToVitest(file, content, reporter, {
         addImports: !!options.addImports,
+        browserMode: !!options.browerMode,
       });
 
       if (content !== newContent) {

--- a/packages/schematics/angular/refactor/jasmine-vitest/schema.json
+++ b/packages/schematics/angular/refactor/jasmine-vitest/schema.json
@@ -30,6 +30,11 @@
       "type": "boolean",
       "description": "Whether to add imports for the Vitest API. The Angular `unit-test` system automatically uses the Vitest globals option, which means explicit imports for global APIs like `describe`, `it`, `expect`, and `vi` are often not strictly necessary unless Vitest has been configured not to use globals.",
       "default": false
+    },
+    "browserMode": {
+      "type": "boolean",
+      "description": "Whether the tests are intended to run in browser mode. If true, the `toHaveClass` assertions are left as is because Vitest browser mode has such an assertion. Otherwise they're migrated to an equivalent assertion.",
+      "default": false
     }
   }
 }

--- a/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.ts
@@ -152,7 +152,7 @@ export function transformJasmineToVitest(
   filePath: string,
   content: string,
   reporter: RefactorReporter,
-  options: { addImports: boolean },
+  options: { addImports: boolean; browserMode: boolean },
 ): string {
   const contentWithPlaceholders = preserveBlankLines(content);
 
@@ -189,7 +189,9 @@ export function transformJasmineToVitest(
         }
 
         for (const transformer of callExpressionTransformers) {
-          transformedNode = transformer(transformedNode, refactorCtx);
+          if (!(options.browserMode && transformer === transformToHaveClass)) {
+            transformedNode = transformer(transformedNode, refactorCtx);
+          }
         }
       } else if (ts.isPropertyAccessExpression(transformedNode)) {
         for (const transformer of propertyAccessExpressionTransformers) {

--- a/packages/schematics/angular/refactor/jasmine-vitest/test-helpers.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/test-helpers.ts
@@ -30,7 +30,10 @@ export async function expectTransformation(
 ): Promise<void> {
   const logger = new logging.NullLogger();
   const reporter = new RefactorReporter(logger);
-  const transformed = transformJasmineToVitest('spec.ts', input, reporter, { addImports });
+  const transformed = transformJasmineToVitest('spec.ts', input, reporter, {
+    addImports,
+    browserMode: false,
+  });
   const formattedTransformed = await format(transformed, { parser: 'typescript' });
   const formattedExpected = await format(expected, { parser: 'typescript' });
 


### PR DESCRIPTION
This option allows not migrating the `toHaveClass` assertion, which exists in Vitest in browser mode and thus is best left as is.

fix #31917

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #31917

## What is the new behavior?

A new `browserMode` option allows not migrating the `toHaveClass` assertion, which exists in Vitest in browser mode and thus is best left as is.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
