### PR TITLE
refactor: simplify dynamic import type assertions and remove resolution mode hints

### DIFF
--- a/packages/angular/build/src/tools/vite/middlewares/ssr-middleware.ts
+++ b/packages/angular/build/src/tools/vite/middlewares/ssr-middleware.ts
@@ -37,8 +37,7 @@ export function createAngularSsrInternalMiddleware(
       // which must be processed by the runtime linker, even if they are not used.
       await import('@angular/compiler');
       const { writeResponseToNodeResponse, createWebRequestFromNodeRequest } = (await import(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        '@angular/ssr/node' as any
+        '@angular/ssr/node' as string
       )) as typeof import('@angular/ssr/node', { with: { 'resolution-mode': 'import' } });
 
       const { ɵgetOrCreateAngularServerApp } = (await server.ssrLoadModule('/main.server.mjs')) as {
@@ -88,8 +87,7 @@ export async function createAngularSsrExternalMiddleware(
   await import('@angular/compiler');
 
   const { createWebRequestFromNodeRequest, writeResponseToNodeResponse } = (await import(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    '@angular/ssr/node' as any
+    '@angular/ssr/node' as string
   )) as typeof import('@angular/ssr/node', { with: { 'resolution-mode': 'import' } });
 
   return function angularSsrExternalMiddleware(

--- a/packages/angular/build/src/utils/server-rendering/launch-server.ts
+++ b/packages/angular/build/src/utils/server-rendering/launch-server.ts
@@ -21,8 +21,7 @@ export const DEFAULT_URL = new URL('http://ng-localhost/');
 export async function launchServer(): Promise<URL> {
   const { reqHandler } = await loadEsmModuleFromMemory('./server.mjs');
   const { createWebRequestFromNodeRequest, writeResponseToNodeResponse } = (await import(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    '@angular/ssr/node' as any
+    '@angular/ssr/node' as string
   )) as typeof import('@angular/ssr/node', { with: { 'resolution-mode': 'import' } });
 
   if (!isSsrNodeRequestHandler(reqHandler) && !isSsrRequestHandler(reqHandler)) {

--- a/packages/angular/cli/src/command-builder/command-module.ts
+++ b/packages/angular/cli/src/command-builder/command-module.ts
@@ -14,8 +14,7 @@ import type {
   Argv,
   CamelCaseKey,
   CommandModule as YargsCommandModule,
-  // Resolution mode is required due to CamelCaseKey missing from esm types
-} from 'yargs' with { 'resolution-mode': 'require' };
+} from 'yargs';
 import { Parser as yargsParser } from 'yargs/helpers';
 import { getAnalyticsUserId } from '../analytics/analytics';
 import { AnalyticsCollector } from '../analytics/analytics-collector';


### PR DESCRIPTION


Remove `any` castings
