### PR TITLE
fix(@schematics/angular): handle createSpyObj without base name on refactor-jasmine-vitest

### DIFF
--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-spy.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-spy.ts
@@ -227,13 +227,14 @@ export function transformCreateSpyObj(
     'Transformed `jasmine.createSpyObj()` to an object literal with `vi.fn()`.',
   );
 
-  const baseNameArg = node.arguments[0];
-  const baseName = ts.isStringLiteral(baseNameArg) ? baseNameArg.text : undefined;
-  const methods = node.arguments[1];
-  const propertiesArg = node.arguments[2];
+  const firstArg = node.arguments[0];
+  const hasBaseName = ts.isStringLiteral(firstArg);
+  const baseName = hasBaseName ? firstArg.text : undefined;
+  const methods = hasBaseName ? node.arguments[1] : firstArg;
+  const propertiesArg = hasBaseName ? node.arguments[2] : node.arguments[1];
   let properties: ts.PropertyAssignment[] = [];
 
-  if (node.arguments.length < 2) {
+  if (node.arguments.length < 2 && hasBaseName) {
     const category = 'createSpyObj-single-argument';
     reporter.recordTodo(category);
     addTodoComment(node, category);

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-spy_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-spy_spec.ts
@@ -123,6 +123,15 @@ vi.spyOn(service, 'myMethod').and.unknownStrategy();`,
         };`,
       },
       {
+        description:
+          'should transform jasmine.createSpyObj with an array of methods without base name',
+        input: `const myService = jasmine.createSpyObj(['methodA', 'methodB']);`,
+        expected: `const myService = {
+          methodA: vi.fn(),
+          methodB: vi.fn(),
+        };`,
+      },
+      {
         description: 'should add a TODO if the second argument is not a literal',
         input: `const myService = jasmine.createSpyObj('MyService', methodNames);`,
         expected: `
@@ -140,6 +149,15 @@ vi.spyOn(service, 'myMethod').and.unknownStrategy();`,
       },
       {
         description:
+          'should transform jasmine.createSpyObj with an object of return values without base name',
+        input: `const myService = jasmine.createSpyObj({ methodA: 'foo', methodB: 42 });`,
+        expected: `const myService = {
+          methodA: vi.fn().mockReturnValue('foo'),
+          methodB: vi.fn().mockReturnValue(42),
+        };`,
+      },
+      {
+        description:
           'should transform jasmine.createSpyObj with an object of return values containing an asymmetric matcher',
         input: `const myService = jasmine.createSpyObj('MyService', { methodA: jasmine.any(String) });`,
         expected: `const myService = {
@@ -147,7 +165,7 @@ vi.spyOn(service, 'myMethod').and.unknownStrategy();`,
         };`,
       },
       {
-        description: 'should add a TODO for jasmine.createSpyObj with only one argument',
+        description: 'should add a TODO for jasmine.createSpyObj with only base name argument',
         input: `const myService = jasmine.createSpyObj('MyService');`,
         expected: `
           // TODO: vitest-migration: jasmine.createSpyObj called with a single argument is not supported for transformation. See: https://vitest.dev/api/vi.html#vi-fn
@@ -167,6 +185,15 @@ vi.spyOn(service, 'myMethod').and.unknownStrategy();`,
         input: `const myService = jasmine.createSpyObj('MyService', { methodA: 'foo' }, { propA: 'valueA' });`,
         expected: `const myService = {
           methodA: vi.fn().mockName("MyService.methodA").mockReturnValue('foo'),
+          propA: 'valueA',
+        };`,
+      },
+      {
+        description:
+          'should transform jasmine.createSpyObj with a method map and a property map without base name',
+        input: `const myService = jasmine.createSpyObj({ methodA: 'foo' }, { propA: 'valueA' });`,
+        expected: `const myService = {
+          methodA: vi.fn().mockReturnValue('foo'),
           propA: 'valueA',
         };`,
       },


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/angular/angular-cli/issues/31941

## What is the new behavior?

Within the `refactor-jasmine-vitest` schematic `jasmine.createSpyObj` calls without base name are transformed correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
