### PR TITLE
refactor(@angular/cli): add generic package manifest resolver

### DIFF
--- a/packages/angular/cli/src/package-managers/host.ts
+++ b/packages/angular/cli/src/package-managers/host.ts
@@ -15,7 +15,7 @@
 
 import { spawn } from 'node:child_process';
 import { Stats } from 'node:fs';
-import { mkdtemp, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { PackageManagerError } from './error';
@@ -37,6 +37,13 @@ export interface Host {
    * @returns A promise that resolves to an array of file and directory names.
    */
   readdir(path: string): Promise<string[]>;
+
+  /**
+   * Reads the content of a file.
+   * @param path The path to the file.
+   * @returns A promise that resolves to the file content as a string.
+   */
+  readFile(path: string): Promise<string>;
 
   /**
    * Creates a new, unique temporary directory.
@@ -85,6 +92,7 @@ export interface Host {
 export const NodeJS_HOST: Host = {
   stat,
   readdir,
+  readFile: (path: string) => readFile(path, { encoding: 'utf8' }),
   writeFile,
   createTempDirectory: () => mkdtemp(join(tmpdir(), 'angular-cli-')),
   deleteDirectory: (path: string) => rm(path, { recursive: true, force: true }),

--- a/packages/angular/cli/src/package-managers/package-manager-descriptor.ts
+++ b/packages/angular/cli/src/package-managers/package-manager-descriptor.ts
@@ -82,7 +82,7 @@ export interface PackageManagerDescriptor {
     listDependencies: (stdout: string, logger?: Logger) => Map<string, InstalledPackage>;
 
     /** A function to parse the output of `getManifestCommand` for a specific version. */
-    getPackageManifest: (stdout: string, logger?: Logger) => PackageManifest | null;
+    getRegistryManifest: (stdout: string, logger?: Logger) => PackageManifest | null;
 
     /** A function to parse the output of `getManifestCommand` for the full package metadata. */
     getRegistryMetadata: (stdout: string, logger?: Logger) => PackageMetadata | null;
@@ -122,7 +122,7 @@ export const SUPPORTED_PACKAGE_MANAGERS = {
     viewCommandFieldArgFormatter: (fields) => [...fields],
     outputParsers: {
       listDependencies: parseNpmLikeDependencies,
-      getPackageManifest: parseNpmLikeManifest,
+      getRegistryManifest: parseNpmLikeManifest,
       getRegistryMetadata: parseNpmLikeMetadata,
     },
   },
@@ -144,7 +144,7 @@ export const SUPPORTED_PACKAGE_MANAGERS = {
     viewCommandFieldArgFormatter: (fields) => ['--fields', fields.join(',')],
     outputParsers: {
       listDependencies: parseYarnModernDependencies,
-      getPackageManifest: parseNpmLikeManifest,
+      getRegistryManifest: parseNpmLikeManifest,
       getRegistryMetadata: parseNpmLikeMetadata,
     },
   },
@@ -168,7 +168,7 @@ export const SUPPORTED_PACKAGE_MANAGERS = {
     getManifestCommand: ['info', '--json'],
     outputParsers: {
       listDependencies: parseYarnClassicDependencies,
-      getPackageManifest: parseYarnLegacyManifest,
+      getRegistryManifest: parseYarnLegacyManifest,
       getRegistryMetadata: parseNpmLikeMetadata,
     },
   },
@@ -190,7 +190,7 @@ export const SUPPORTED_PACKAGE_MANAGERS = {
     viewCommandFieldArgFormatter: (fields) => [...fields],
     outputParsers: {
       listDependencies: parseNpmLikeDependencies,
-      getPackageManifest: parseNpmLikeManifest,
+      getRegistryManifest: parseNpmLikeManifest,
       getRegistryMetadata: parseNpmLikeMetadata,
     },
   },
@@ -212,7 +212,7 @@ export const SUPPORTED_PACKAGE_MANAGERS = {
     viewCommandFieldArgFormatter: (fields) => [...fields],
     outputParsers: {
       listDependencies: parseNpmLikeDependencies,
-      getPackageManifest: parseNpmLikeManifest,
+      getRegistryManifest: parseNpmLikeManifest,
       getRegistryMetadata: parseNpmLikeMetadata,
     },
   },

--- a/packages/angular/cli/src/package-managers/testing/mock-host.ts
+++ b/packages/angular/cli/src/package-managers/testing/mock-host.ts
@@ -58,4 +58,8 @@ export class MockHost implements Host {
   writeFile(): Promise<void> {
     throw new Error('Method not implemented.');
   }
+
+  readFile(): Promise<string> {
+    throw new Error('Method not implemented.');
+  }
 }


### PR DESCRIPTION
Extends the package manager abstraction to resolve manifests for various specifier types beyond registry packages. This is crucial for supporting packages installed from local directories, file archives, and git repositories.

A new `getManifest` method is introduced on the `PackageManager` service. This method acts as a unified entry point for manifest resolution:
- It uses `npm-package-arg` to parse the package specifier and determine its type (registry, directory, file, git, etc.).
- For local directory specifiers, it reads the `package.json` directly from the filesystem for maximum efficiency.
- For other non-registry specifiers (git repos, remote tarballs, local tarballs), it uses the `acquireTempPackage` flow to safely fetch and extract the package.
- When acquiring a package, lifecycle scripts are disabled for improved security and performance.
- To reliably determine the package name for non-registry types, the manifest resolver now inspects the temporary `package.json` after the package manager has installed the dependency.

The existing `getPackageManifest` method has been renamed to `getRegistryManifest` to more accurately reflect its purpose.