### PR TITLE
refactor(@angular/build): adjust compiler-cli namespace import

### DIFF
--- a/packages/angular/build/src/tools/angular/angular-host.ts
+++ b/packages/angular/build/src/tools/angular/angular-host.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import type ng from '@angular/compiler-cli';
+import type * as ng from '@angular/compiler-cli';
 import assert from 'node:assert';
 import { createHash } from 'node:crypto';
 import nodePath from 'node:path';

--- a/packages/angular/build/src/tools/angular/compilation/angular-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/angular-compilation.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import type ng from '@angular/compiler-cli';
+import type * as ng from '@angular/compiler-cli';
 import type { PartialMessage } from 'esbuild';
 import type ts from 'typescript';
 import { convertTypeScriptDiagnostic } from '../../esbuild/angular/diagnostics';

--- a/packages/angular/build/src/tools/angular/compilation/aot-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/aot-compilation.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import type ng from '@angular/compiler-cli';
+import type * as ng from '@angular/compiler-cli';
 import assert from 'node:assert';
 import { relative } from 'node:path';
 import ts from 'typescript';

--- a/packages/angular/build/src/tools/angular/compilation/hmr-candidates.ts
+++ b/packages/angular/build/src/tools/angular/compilation/hmr-candidates.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import type ng from '@angular/compiler-cli';
+import type * as ng from '@angular/compiler-cli';
 import assert from 'node:assert';
 import ts from 'typescript';
 

--- a/packages/angular/build/src/tools/angular/compilation/jit-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/jit-compilation.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import type ng from '@angular/compiler-cli';
+import type * as ng from '@angular/compiler-cli';
 import assert from 'node:assert';
 import ts from 'typescript';
 import { profileSync } from '../../esbuild/profiling';

--- a/packages/angular/build/src/tools/angular/compilation/noop-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/noop-compilation.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import type ng from '@angular/compiler-cli';
+import type * as ng from '@angular/compiler-cli';
 import type ts from 'typescript';
 import { AngularHostOptions } from '../angular-host';
 import { AngularCompilation } from './angular-compilation';


### PR DESCRIPTION
Updates the type import for `@angular/compiler-cli` from a default import (`import type ng from ...`) to a full namespace import (`import type * as ng from ...`) across the Angular build tooling.

This change ensures consistent and correct type resolution, aligning with modern TypeScript module standards and preventing potential import resolution issues.