### PR TITLE
fix(@angular/ssr): correctly handle auxiliary routes

### DIFF
--- a/packages/angular/ssr/src/routes/router.ts
+++ b/packages/angular/ssr/src/routes/router.ts
@@ -7,7 +7,7 @@
  */
 
 import { AngularAppManifest } from '../manifest';
-import { stripIndexHtmlFromURL, stripMatrixParams, stripAuxiliaryRoutes } from '../utils/url';
+import { stripAuxiliaryRoutes, stripIndexHtmlFromURL, stripMatrixParams } from '../utils/url';
 import { extractRoutesAndCreateRouteTree } from './ng-routes';
 import { RouteTree, RouteTreeNodeMetadata } from './route-tree';
 

--- a/packages/angular/ssr/src/utils/url.ts
+++ b/packages/angular/ssr/src/utils/url.ts
@@ -264,7 +264,9 @@ export function constructUrl(pathname: string, search: string, hash: string): st
  * // → '/path/to/resource'
  * ```
  */
+
 export function stripAuxiliaryRoutes(pathname: string): string {
   const index = pathname.indexOf('(');
+
   return index !== -1 ? pathname.slice(0, index) : pathname;
 }

--- a/packages/angular/ssr/test/utils/url_spec.ts
+++ b/packages/angular/ssr/test/utils/url_spec.ts
@@ -11,11 +11,11 @@ import {
   addTrailingSlash,
   buildPathWithParams,
   joinUrlParts,
+  stripAuxiliaryRoutes,
   stripIndexHtmlFromURL,
   stripLeadingSlash,
   stripMatrixParams,
   stripTrailingSlash,
-  stripAuxiliaryRoutes,
 } from '../../src/utils/url';
 
 describe('URL Utils', () => {


### PR DESCRIPTION
This commit updates Angular SSR URL preprocessing to remove auxiliary outlet route segments before route matching. Previously, URLs containing auxiliary routes appended with outlet syntax, such as `/path(foo:bar)`, could prevent correct route resolution.

A new `stripAuxiliaryRoutes` utility function has been added to strip these segments, ensuring that SSR route matching behaves consistently with client-side routing.

This issue is similar to #31457, and the fix is based from #31476

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Similar to #31457, Angular SSR seems not to accept URLs with auxiliary routes.

For example:
```
export const routes: Routes = [
  {
    path: '',
    pathMatch: 'full',
    redirectTo: '/lorem1',
  },
  {
    path: 'lorem1',
    component: Lorem1Component,
  },
  {
    path: 'lorem2',
    component: Lorem2Component,
    outlet: 'secondary',
  },
]
```

Running:

```
curl http://localhost:4200/lorem1\(secondary\:lorem2\)

<html lang="en">
<head>
<meta charset="utf-8">
<title>Error</title>
</head>
<body>
<pre>Cannot GET /lorem1(secondary:lorem2)</pre>
</body>
</html>

```

Reproduction: https://stackblitz.com/edit/angular-ssr-matrix-params-denial-vly6p1dh?file=src%2Fapp%2Fapp-routes.ts


## What is the new behavior?

The routes resolved correctly

```
curl http://localhost:4200/lorem1\(secondary\:lorem2\)

<!DOCTYPE html><html lang="en"><head>
    <script type="module" src="/@vite/client"></script>

    <title>Demo</title>
    <meta charset="UTF-8">
    <base href="/">
  </head>
  <body>
    <app-root ng-version="21.0.1" ng-server-context="ssr">

<router-outlet></router-outlet>
<lorem1>lorem1</lorem1>
<!--container--><br>
<router-outlet name="secondary"></router-outlet>
<lorem2>lorem2</lorem2>
<!--container-->

</app-root>
 <script src="main.js" type="module"></script>
</body></html>
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

none
