### PR TITLE
fix(@angular-devkit/schematics): remove lazy imports in node tasks

### DIFF
--- a/packages/angular_devkit/schematics/tasks/node/index.ts
+++ b/packages/angular_devkit/schematics/tasks/node/index.ts
@@ -7,29 +7,28 @@
  */
 
 import { TaskExecutor, TaskExecutorFactory } from '../../src';
+import NodePackageExecutor from '../package-manager/executor';
 import { NodePackageName, NodePackageTaskFactoryOptions } from '../package-manager/options';
+import RepositoryInitializerExecutor from '../repo-init/executor';
 import {
   RepositoryInitializerName,
   RepositoryInitializerTaskFactoryOptions,
 } from '../repo-init/options';
+import RunSchematicExecutor from '../run-schematic/executor';
 import { RunSchematicName } from '../run-schematic/options';
 
 export class BuiltinTaskExecutor {
   static readonly NodePackage: TaskExecutorFactory<NodePackageTaskFactoryOptions> = {
     name: NodePackageName,
-    create: (options) =>
-      import('../package-manager/executor').then((mod) => mod.default(options)) as Promise<
-        TaskExecutor<{}>
-      >,
+    create: async (options) => NodePackageExecutor(options) as TaskExecutor<{}>,
   };
   static readonly RepositoryInitializer: TaskExecutorFactory<RepositoryInitializerTaskFactoryOptions> =
     {
       name: RepositoryInitializerName,
-      create: (options) => import('../repo-init/executor').then((mod) => mod.default(options)),
+      create: async (options) => RepositoryInitializerExecutor(options) as TaskExecutor<{}>,
     };
   static readonly RunSchematic: TaskExecutorFactory<{}> = {
     name: RunSchematicName,
-    create: () =>
-      import('../run-schematic/executor').then((mod) => mod.default()) as Promise<TaskExecutor<{}>>,
+    create: async () => RunSchematicExecutor() as TaskExecutor<{}>,
   };
 }


### PR DESCRIPTION
This commit replaces lazy imports with static imports in the node tasks of `@angular-devkit/schematics`. This change fixes an issue where migrations could fail during an update process if the package layout changes on disk (e.g. due to `npm` hoisting changes) after the main module is loaded but before the lazy chunks are requested. By using static imports, we ensure all necessary code is loaded upfront.

Closes #31974

