### PR TITLE
refactor(@angular/cli): introduce Host abstraction for `find_examples` MCP tool

### DIFF
--- a/packages/angular/cli/src/commands/mcp/mcp-server.ts
+++ b/packages/angular/cli/src/commands/mcp/mcp-server.ts
@@ -11,6 +11,7 @@ import { join } from 'node:path';
 import type { AngularWorkspace } from '../../utilities/config';
 import { VERSION } from '../../utilities/version';
 import type { DevServer } from './dev-server';
+import { LocalWorkspaceHost } from './host';
 import { registerInstructionsResource } from './resources/instructions';
 import { AI_TUTOR_TOOL } from './tools/ai-tutor';
 import { BEST_PRACTICES_TOOL } from './tools/best-practices';
@@ -115,6 +116,7 @@ equivalent actions.
       logger,
       exampleDatabasePath: join(__dirname, '../../../lib/code-examples.db'),
       devServers: new Map<string, DevServer>(),
+      host: LocalWorkspaceHost,
     },
     toolDeclarations,
   );

--- a/packages/angular/cli/src/commands/mcp/testing/mock-host.ts
+++ b/packages/angular/cli/src/commands/mcp/testing/mock-host.ts
@@ -13,9 +13,12 @@ import type { Host } from '../host';
  * This class allows spying on host methods and controlling their return values.
  */
 export class MockHost implements Host {
-  runCommand = jasmine.createSpy('runCommand').and.resolveTo({ stdout: '', stderr: '' });
+  runCommand = jasmine.createSpy('runCommand').and.resolveTo({ logs: [] });
   stat = jasmine.createSpy('stat');
   existsSync = jasmine.createSpy('existsSync');
+  readFile = jasmine.createSpy('readFile').and.resolveTo('');
+  glob = jasmine.createSpy('glob').and.returnValue((async function* () {})());
+  resolveModule = jasmine.createSpy('resolveRequest').and.returnValue('/dev/null');
   spawn = jasmine.createSpy('spawn');
   getAvailablePort = jasmine.createSpy('getAvailablePort');
 }

--- a/packages/angular/cli/src/commands/mcp/tools/examples/database-discovery_spec.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/examples/database-discovery_spec.ts
@@ -1,0 +1,137 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import type { Stats } from 'node:fs';
+import { Host } from '../../host';
+import { getVersionSpecificExampleDatabases } from './database-discovery';
+
+describe('getVersionSpecificExampleDatabases', () => {
+  let mockHost: jasmine.SpyObj<Host>;
+  let mockLogger: { warn: jasmine.Spy };
+
+  beforeEach(() => {
+    mockHost = jasmine.createSpyObj('Host', ['resolveModule', 'readFile', 'stat']);
+    mockLogger = {
+      warn: jasmine.createSpy('warn'),
+    };
+  });
+
+  it('should find a valid example database from a package', async () => {
+    mockHost.resolveModule.and.callFake((specifier) => {
+      if (specifier === '@angular/core/package.json') {
+        return '/path/to/node_modules/@angular/core/package.json';
+      }
+      throw new Error(`Unexpected module specifier: ${specifier}`);
+    });
+    mockHost.readFile.and.resolveTo(
+      JSON.stringify({
+        name: '@angular/core',
+        version: '18.1.0',
+        angular: {
+          examples: {
+            format: 'sqlite',
+            path: './resources/code-examples.db',
+          },
+        },
+      }),
+    );
+    mockHost.stat.and.resolveTo({ size: 1024 } as Stats);
+
+    const databases = await getVersionSpecificExampleDatabases(
+      '/path/to/workspace',
+      mockLogger,
+      mockHost,
+    );
+
+    expect(databases.length).toBe(1);
+    expect(databases[0].dbPath).toBe(
+      '/path/to/node_modules/@angular/core/resources/code-examples.db',
+    );
+    expect(databases[0].source).toBe('package @angular/core@18.1.0');
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it('should skip packages without angular.examples metadata', async () => {
+    mockHost.resolveModule.and.returnValue('/path/to/node_modules/@angular/core/package.json');
+    mockHost.readFile.and.resolveTo(JSON.stringify({ name: '@angular/core', version: '18.1.0' }));
+
+    const databases = await getVersionSpecificExampleDatabases(
+      '/path/to/workspace',
+      mockLogger,
+      mockHost,
+    );
+
+    expect(databases.length).toBe(0);
+  });
+
+  it('should handle packages that are not found', async () => {
+    mockHost.resolveModule.and.throwError(new Error('Cannot find module'));
+
+    const databases = await getVersionSpecificExampleDatabases(
+      '/path/to/workspace',
+      mockLogger,
+      mockHost,
+    );
+
+    expect(databases.length).toBe(0);
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it('should reject database paths that attempt path traversal', async () => {
+    mockHost.resolveModule.and.returnValue('/path/to/node_modules/@angular/core/package.json');
+    mockHost.readFile.and.resolveTo(
+      JSON.stringify({
+        name: '@angular/core',
+        version: '18.1.0',
+        angular: {
+          examples: {
+            format: 'sqlite',
+            path: '../outside-package/danger.db',
+          },
+        },
+      }),
+    );
+
+    const databases = await getVersionSpecificExampleDatabases(
+      '/path/to/workspace',
+      mockLogger,
+      mockHost,
+    );
+
+    expect(databases.length).toBe(0);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      jasmine.stringMatching(/Detected a potential path traversal attempt/),
+    );
+  });
+
+  it('should skip database files larger than 10MB', async () => {
+    mockHost.resolveModule.and.returnValue('/path/to/node_modules/@angular/core/package.json');
+    mockHost.readFile.and.resolveTo(
+      JSON.stringify({
+        name: '@angular/core',
+        version: '18.1.0',
+        angular: {
+          examples: {
+            format: 'sqlite',
+            path: './resources/code-examples.db',
+          },
+        },
+      }),
+    );
+    mockHost.stat.and.resolveTo({ size: 11 * 1024 * 1024 } as Stats); // 11MB
+
+    const databases = await getVersionSpecificExampleDatabases(
+      '/path/to/workspace',
+      mockLogger,
+      mockHost,
+    );
+
+    expect(databases.length).toBe(0);
+    expect(mockLogger.warn).toHaveBeenCalledWith(jasmine.stringMatching(/is larger than 10MB/));
+  });
+});

--- a/packages/angular/cli/src/commands/mcp/tools/examples/index.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/examples/index.ts
@@ -71,9 +71,9 @@ new or evolving features.
   factory: createFindExampleHandler,
 });
 
-async function createFindExampleHandler({ logger, exampleDatabasePath }: McpToolContext) {
+async function createFindExampleHandler({ logger, exampleDatabasePath, host }: McpToolContext) {
   const runtimeDb = process.env['NG_MCP_EXAMPLES_DIR']
-    ? await setupRuntimeExamples(process.env['NG_MCP_EXAMPLES_DIR'])
+    ? await setupRuntimeExamples(process.env['NG_MCP_EXAMPLES_DIR'], host)
     : undefined;
 
   suppressSqliteWarning();
@@ -91,6 +91,7 @@ async function createFindExampleHandler({ logger, exampleDatabasePath }: McpTool
       const versionSpecificDbs = await getVersionSpecificExampleDatabases(
         input.workspacePath,
         logger,
+        host,
       );
       for (const db of versionSpecificDbs) {
         resolvedDbs.push({ path: db.dbPath, source: db.source });

--- a/packages/angular/cli/src/commands/mcp/tools/tool-registry.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/tool-registry.ts
@@ -11,6 +11,7 @@ import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types';
 import type { ZodRawShape } from 'zod';
 import type { AngularWorkspace } from '../../../utilities/config';
 import type { DevServer } from '../dev-server';
+import type { Host } from '../host';
 
 export interface McpToolContext {
   server: McpServer;
@@ -18,6 +19,7 @@ export interface McpToolContext {
   logger: { warn(text: string): void };
   exampleDatabasePath?: string;
   devServers: Map<string, DevServer>;
+  host: Host;
 }
 
 export type McpToolFactory<TInput extends ZodRawShape> = (


### PR DESCRIPTION
This commit introduces a `Host` abstraction layer for the `find_examples` MCP tool, enhancing its testability and modularity by decoupling it from direct Node.js APIs.