### PR TITLE
test: enable two lint rules that are now passing

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -190,9 +190,7 @@ export default [
       ],
 
       '@typescript-eslint/await-thenable': 'off',
-      '@typescript-eslint/ban-types': 'off',
       '@typescript-eslint/no-implied-eval': 'off',
-      '@typescript-eslint/no-var-requires': 'off',
       '@typescript-eslint/no-unsafe-argument': 'off',
       '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-unsafe-call': 'off',


### PR DESCRIPTION
Removed "off" directives for "@typescript-eslint/ban-types" and "@typescript-eslint/no-var-requires" as there are no longer any failures associated with these rules.