### PR TITLE
build: remove repo root usage of `ansi-colors`

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "@typescript-eslint/eslint-plugin": "8.48.0",
     "@typescript-eslint/parser": "8.48.0",
     "ajv": "8.17.1",
-    "ansi-colors": "4.1.3",
     "buffer": "6.0.3",
     "esbuild": "0.27.0",
     "esbuild-wasm": "0.27.0",

--- a/packages/angular_devkit/architect_cli/BUILD.bazel
+++ b/packages/angular_devkit/architect_cli/BUILD.bazel
@@ -19,11 +19,11 @@ ts_project(
     deps = [
         ":node_modules/@angular-devkit/architect",
         ":node_modules/@angular-devkit/core",
+        ":node_modules/ansi-colors",
         ":node_modules/progress",
         "//:node_modules/@types/node",
         "//:node_modules/@types/progress",
         "//:node_modules/@types/yargs-parser",
-        "//:node_modules/ansi-colors",
         "//:node_modules/yargs-parser",
     ],
 )

--- a/packages/angular_devkit/schematics_cli/BUILD.bazel
+++ b/packages/angular_devkit/schematics_cli/BUILD.bazel
@@ -48,9 +48,9 @@ ts_project(
         ":node_modules/@angular-devkit/core",
         ":node_modules/@angular-devkit/schematics",
         ":node_modules/@inquirer/prompts",
+        ":node_modules/ansi-colors",
         "//:node_modules/@types/node",
         "//:node_modules/@types/yargs-parser",
-        "//:node_modules/ansi-colors",
         "//:node_modules/yargs-parser",
     ],
 )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,9 +172,6 @@ importers:
       ajv:
         specifier: 8.17.1
         version: 8.17.1
-      ansi-colors:
-        specifier: 4.1.3
-        version: 4.1.3
       buffer:
         specifier: 6.0.3
         version: 6.0.3

--- a/scripts/devkit-admin.mts
+++ b/scripts/devkit-admin.mts
@@ -7,8 +7,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import colors from 'ansi-colors';
 import path from 'node:path';
+import { styleText } from 'node:util';
 import yargsParser from 'yargs-parser';
 
 const args = yargsParser(process.argv.slice(2), {
@@ -26,11 +26,11 @@ process.chdir(path.join(scriptDir, '..'));
 const originalConsole = { ...console };
 console.warn = function (...args) {
   const [m, ...rest] = args;
-  originalConsole.warn(colors.yellow(m), ...rest);
+  originalConsole.warn(styleText(['yellow'], m), ...rest);
 };
 console.error = function (...args) {
   const [m, ...rest] = args;
-  originalConsole.error(colors.red(m), ...rest);
+  originalConsole.error(styleText(['red'], m), ...rest);
 };
 
 try {


### PR DESCRIPTION
The `scripts/devkit-admin.mts` infrastructure script has been migrated to use the native Node.js `styleText` API. This removes the last non-package usage of the `ansi-colors` package and allows the root level dependency to be removed.