### PR TITLE
test: remove several unused eslint disable directives

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/babel/webpack-loader.ts
+++ b/packages/angular_devkit/build_angular/src/tools/babel/webpack-loader.ts
@@ -36,7 +36,6 @@ let linkerPluginCreator:
  */
 let i18nPluginCreators: I18nPluginCreators | undefined;
 
-// eslint-disable-next-line max-lines-per-function
 export default custom<ApplicationPresetOptions>(() => {
   const baseOptions = Object.freeze({
     babelrc: false,

--- a/packages/angular_devkit/core/src/virtual-fs/host/record_spec.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/record_spec.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { path } from '../path';
 import { stringToFileBuffer } from './buffer';
 import { CordHost } from './record';

--- a/packages/angular_devkit/schematics/src/rules/base_spec.ts
+++ b/packages/angular_devkit/schematics/src/rules/base_spec.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { Path, virtualFs } from '@angular-devkit/core';
 import { lastValueFrom, of as observableOf } from 'rxjs';
 import { Rule, SchematicContext, Source } from '../engine/interface';

--- a/packages/angular_devkit/schematics/src/rules/call_spec.ts
+++ b/packages/angular_devkit/schematics/src/rules/call_spec.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { of as observableOf } from 'rxjs';
 import { Rule, SchematicContext, Source } from '../engine/interface';

--- a/packages/angular_devkit/schematics_cli/bin/schematics.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics.ts
@@ -216,7 +216,6 @@ function getPackageManagerName() {
   return 'npm';
 }
 
-// eslint-disable-next-line max-lines-per-function
 export async function main({
   args,
   stdout = process.stdout,

--- a/packages/ngtools/webpack/src/transformers/replace_resources_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/replace_resources_spec.ts
@@ -28,7 +28,6 @@ function transform(
 }
 
 describe('@ngtools/webpack transformers', () => {
-  /* eslint-disable max-len */
   describe('find_resources', () => {
     it('should replace resources', () => {
       const input = tags.stripIndent`

--- a/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.integration_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.integration_spec.ts
@@ -464,7 +464,6 @@ describe('Jasmine to Vitest Transformer - Integration Tests', () => {
       });
     `;
 
-    /* eslint-disable max-len */
     const vitestCode = `
       describe('Unsupported Features', () => {
         beforeAll(() => {
@@ -496,7 +495,6 @@ describe('Jasmine to Vitest Transformer - Integration Tests', () => {
         });
       });
     `;
-    /* eslint-enable max-len */
 
     await expectTransformation(jasmineCode, vitestCode);
   });

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-misc_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-misc_spec.ts
@@ -132,7 +132,6 @@ describe('Jasmine to Vitest Transformer', () => {
             return a.toString() === b.toString();
           });
         `,
-        // eslint-disable-next-line max-len
         expected: `// TODO: vitest-migration: jasmine.addCustomEqualityTester is not supported. Please manually migrate to expect.addEqualityTesters(). See: https://vitest.dev/api/expect.html#expect-addequalitytesters
           jasmine.addCustomEqualityTester((a, b) => {
             return a.toString() === b.toString();

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-spy_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-spy_spec.ts
@@ -59,7 +59,6 @@ describe('Jasmine to Vitest Transformer', () => {
       {
         description: 'should add a TODO for jasmine.spyOnAllFunctions(object)',
         input: `jasmine.spyOnAllFunctions(myObject);`,
-        // eslint-disable-next-line max-len
         expected: `// TODO: vitest-migration: Vitest does not have a direct equivalent for jasmine.spyOnAllFunctions(). Please spy on individual methods manually using vi.spyOn(). See: https://vitest.dev/api/vi.html#vi-spyon
           jasmine.spyOnAllFunctions(myObject);
         `,
@@ -99,7 +98,6 @@ describe('Jasmine to Vitest Transformer', () => {
       {
         description: 'should add a TODO for an unsupported spy strategy',
         input: `spyOn(service, 'myMethod').and.unknownStrategy();`,
-        // eslint-disable-next-line max-len
         expected: `// TODO: vitest-migration: Unsupported spy strategy ".and.unknownStrategy()" found. Please migrate this manually. See: https://vitest.dev/api/mocked.html#mock
 vi.spyOn(service, 'myMethod').and.unknownStrategy();`,
       },
@@ -269,7 +267,6 @@ vi.spyOn(service, 'myMethod').and.unknownStrategy();`,
       {
         description: 'should add a TODO for spy.calls.mostRecent() without .args',
         input: `const mostRecent = mySpy.calls.mostRecent();`,
-        // eslint-disable-next-line max-len
         expected: `// TODO: vitest-migration: Direct usage of mostRecent() is not supported. Please refactor to access .args directly or use vi.mocked(spy).mock.lastCall. See: https://vitest.dev/api/mocked.html#mock-lastcall
 const mostRecent = mySpy.calls.mostRecent();`,
       },

--- a/packages/schematics/angular/utility/standalone/rules_spec.ts
+++ b/packages/schematics/angular/utility/standalone/rules_spec.ts
@@ -354,7 +354,6 @@ describe('standalone utilities', () => {
         host,
       );
 
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       await expectAsync(promise).toBeRejectedWithError(
         `Cannot add provider to invalid bootstrapApplication call in ${mainPath}`,
       );
@@ -384,7 +383,6 @@ describe('standalone utilities', () => {
         host,
       );
 
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       await expectAsync(promise).toBeRejectedWithError(
         `Cannot statically analyze bootstrapApplication call in ${mainPath}`,
       );
@@ -402,7 +400,6 @@ describe('standalone utilities', () => {
         host,
       );
 
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       await expectAsync(promise).toBeRejectedWithError('Bootstrap call not found');
     });
   });


### PR DESCRIPTION
Several unused eslint directives have been removed from source code files. This is only an initial set with more that could be removed in the future.