### PR TITLE
docs: release notes for the v21.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+<a name="21.0.2"></a>
+
+# 21.0.2 (2025-12-03)
+
+### @angular/cli
+
+| Commit                                                                                              | Type | Description                                   |
+| --------------------------------------------------------------------------------------------------- | ---- | --------------------------------------------- |
+| [f1a7116cd](https://github.com/angular/angular-cli/commit/f1a7116cdff1bd83b26b0d64cea14ec4e8084583) | fix  | update `@modelcontextprotocol/sdk` to v1.24.0 |
+
+### @angular-devkit/schematics
+
+| Commit                                                                                              | Type | Description                       |
+| --------------------------------------------------------------------------------------------------- | ---- | --------------------------------- |
+| [dc6d9469e](https://github.com/angular/angular-cli/commit/dc6d9469ea494bbfee7da191774e9fa3c0baf30a) | fix  | remove lazy imports in node tasks |
+
+### @angular/build
+
+| Commit                                                                                              | Type | Description                                                |
+| --------------------------------------------------------------------------------------------------- | ---- | ---------------------------------------------------------- |
+| [f8a1939fd](https://github.com/angular/angular-cli/commit/f8a1939fdf5abbc1de439d288d9357d4f92a72a9) | fix  | add filename truncation to test discovery                  |
+| [86dd3297f](https://github.com/angular/angular-cli/commit/86dd3297f7ad81788713cfd8dae48c0fad4b89ab) | fix  | allow overriding Vitest coverage `reportsDirectory` option |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="20.3.13"></a>
 
 # 20.3.13 (2025-12-03)


### PR DESCRIPTION
Cherry-picks the changelog from the "21.0.x" branch to the next branch (main).