### PR TITLE
test: migrate tar extraction to `tar-stream` for E2E setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,6 @@
     "rollup-plugin-sourcemaps2": "0.5.4",
     "semver": "7.7.3",
     "source-map-support": "0.5.21",
-    "tar": "^7.0.0",
     "ts-node": "^10.9.1",
     "tslib": "2.8.1",
     "typescript": "5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,9 +280,6 @@ importers:
       source-map-support:
         specifier: 0.5.21
         version: 0.5.21
-      tar:
-        specifier: ^7.0.0
-        version: 7.5.2
       ts-node:
         specifier: ^10.9.1
         version: 10.9.2(@types/node@22.19.1)(typescript@5.9.3)
@@ -897,9 +894,15 @@ importers:
       '@angular-devkit/schematics':
         specifier: workspace:*
         version: link:../packages/angular_devkit/schematics
+      '@types/tar-stream':
+        specifier: 3.1.4
+        version: 3.1.4
       rxjs:
         specifier: 7.8.2
         version: 7.8.2
+      tar-stream:
+        specifier: 3.1.7
+        version: 3.1.7
       tree-kill:
         specifier: 1.2.2
         version: 1.2.2
@@ -3823,6 +3826,9 @@ packages:
 
   '@types/stack-trace@0.0.33':
     resolution: {integrity: sha512-O7in6531Bbvlb2KEsJ0dq0CHZvc3iWSR5ZYMtvGgnHA56VgriAN/AU2LorfmcvAl2xc9N5fbCTRyMRRl8nd74g==}
+
+  '@types/tar-stream@3.1.4':
+    resolution: {integrity: sha512-921gW0+g29mCJX0fRvqeHzBlE/XclDaAG0Ousy1LCghsOhvaKacDeRGEVzQP9IPfKn8Vysy7FEXAIxycpc/CMg==}
 
   '@types/watchpack@2.4.5':
     resolution: {integrity: sha512-8CarnGOIYYRL342jwQyHrGwz4vCD3y5uwwYmzQVzT2Z24DqSd6wwBva6m0eNJX4S5pVmrx9xUEbOsOoqBVhWsg==}
@@ -12476,6 +12482,10 @@ snapshots:
       '@types/node': 22.19.1
 
   '@types/stack-trace@0.0.33': {}
+
+  '@types/tar-stream@3.1.4':
+    dependencies:
+      '@types/node': 22.19.1
 
   '@types/watchpack@2.4.5':
     dependencies:

--- a/tests/legacy-cli/e2e/utils/BUILD.bazel
+++ b/tests/legacy-cli/e2e/utils/BUILD.bazel
@@ -16,10 +16,11 @@ ts_project(
         "//:node_modules/fast-glob",
         "//:node_modules/protractor",
         "//:node_modules/semver",
-        "//:node_modules/tar",
         "//:node_modules/verdaccio",
         "//:node_modules/verdaccio-auth-memory",
+        "//tests:node_modules/@types/tar-stream",
         "//tests:node_modules/rxjs",
+        "//tests:node_modules/tar-stream",
         "//tests:node_modules/tree-kill",
     ],
 )

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,7 +1,9 @@
 {
   "devDependencies": {
+    "@types/tar-stream": "3.1.4",
     "@angular-devkit/schematics": "workspace:*",
     "rxjs": "7.8.2",
+    "tar-stream": "3.1.7",
     "tree-kill": "1.2.2"
   }
 }


### PR DESCRIPTION
This commit replaces the `tar` package with `tar-stream` for file extraction in the e2e test utilities.

The primary advantage of this change is a significant reduction in dependency size. The `tar` package is approximately 2MB on disk, whereas `tar-stream` is only ~235KB. This improves installation speed and reduces the overall disk footprint of the project.

The implementation in `extractFile` has been updated to use the `tar-stream` event-based API and now includes `zlib.createGunzip()` to correctly handle compressed tarballs.