### PR TITLE
build: remove repo root usage of `yargs-parser`

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,6 @@
     "unenv": "^1.10.0",
     "verdaccio": "6.2.3",
     "verdaccio-auth-memory": "^10.0.0",
-    "yargs-parser": "22.0.0",
     "zod": "4.1.13",
     "zone.js": "^0.16.0"
   },

--- a/packages/angular_devkit/architect_cli/BUILD.bazel
+++ b/packages/angular_devkit/architect_cli/BUILD.bazel
@@ -21,10 +21,10 @@ ts_project(
         ":node_modules/@angular-devkit/core",
         ":node_modules/ansi-colors",
         ":node_modules/progress",
+        ":node_modules/yargs-parser",
         "//:node_modules/@types/node",
         "//:node_modules/@types/progress",
         "//:node_modules/@types/yargs-parser",
-        "//:node_modules/yargs-parser",
     ],
 )
 

--- a/packages/angular_devkit/schematics_cli/BUILD.bazel
+++ b/packages/angular_devkit/schematics_cli/BUILD.bazel
@@ -49,9 +49,9 @@ ts_project(
         ":node_modules/@angular-devkit/schematics",
         ":node_modules/@inquirer/prompts",
         ":node_modules/ansi-colors",
+        ":node_modules/yargs-parser",
         "//:node_modules/@types/node",
         "//:node_modules/@types/yargs-parser",
-        "//:node_modules/yargs-parser",
     ],
 )
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -304,9 +304,6 @@ importers:
       verdaccio-auth-memory:
         specifier: ^10.0.0
         version: 10.3.1
-      yargs-parser:
-        specifier: 22.0.0
-        version: 22.0.0
       zod:
         specifier: 4.1.13
         version: 4.1.13

--- a/scripts/devkit-admin.mts
+++ b/scripts/devkit-admin.mts
@@ -8,16 +8,24 @@
  */
 
 import path from 'node:path';
-import { styleText } from 'node:util';
-import yargsParser from 'yargs-parser';
+import { parseArgs, styleText } from 'node:util';
 
-const args = yargsParser(process.argv.slice(2), {
-  boolean: ['verbose'],
-  configuration: {
-    'camel-case-expansion': false,
+const { values, positionals } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    verbose: {
+      type: 'boolean',
+    },
   },
+  allowPositionals: true,
+  strict: false, // Allow unknown options to pass through.
 });
-const scriptName = args._.shift();
+
+const scriptName = positionals.shift();
+const args = {
+  ...values,
+  _: positionals,
+};
 
 const cwd = process.cwd();
 const scriptDir = import.meta.dirname;


### PR DESCRIPTION
The `scripts/devkit-admin.mts` infrastructure script has been migrated to use the native Node.js `parseArgs` API. This removes the last non-package usage of the `yargs-parser` package and allows the root level dependency to be removed.