### PR TITLE
fix(@angular/cli): correctly handle yarn classic tag manifest fetching

### DIFF
--- a/packages/angular/cli/src/package-managers/package-manager-descriptor.ts
+++ b/packages/angular/cli/src/package-managers/package-manager-descriptor.ts
@@ -20,7 +20,8 @@ import {
   parseNpmLikeManifest,
   parseNpmLikeMetadata,
   parseYarnClassicDependencies,
-  parseYarnLegacyManifest,
+  parseYarnClassicManifest,
+  parseYarnClassicMetadata,
   parseYarnModernDependencies,
 } from './parsers';
 
@@ -72,6 +73,9 @@ export interface PackageManagerDescriptor {
 
   /** The command to fetch the registry manifest of a package. */
   readonly getManifestCommand: readonly string[];
+
+  /** Whether a specific version lookup is needed prior to fetching a registry manifest. */
+  readonly requiresManifestVersionLookup?: boolean;
 
   /** A function that formats the arguments for field-filtered registry views. */
   readonly viewCommandFieldArgFormatter?: (fields: readonly string[]) => string[];
@@ -166,10 +170,11 @@ export const SUPPORTED_PACKAGE_MANAGERS = {
     versionCommand: ['--version'],
     listDependenciesCommand: ['list', '--depth=0', '--json'],
     getManifestCommand: ['info', '--json'],
+    requiresManifestVersionLookup: true,
     outputParsers: {
       listDependencies: parseYarnClassicDependencies,
-      getRegistryManifest: parseYarnLegacyManifest,
-      getRegistryMetadata: parseNpmLikeMetadata,
+      getRegistryManifest: parseYarnClassicManifest,
+      getRegistryMetadata: parseYarnClassicMetadata,
     },
   },
   pnpm: {


### PR DESCRIPTION
Introduces a `requiresManifestVersionLookup` property to `PackageManagerDescriptor` to control whether a package manager needs an explicit metadata lookup for tags, ranges, or when no `fetchSpec` is provided before attempting to fetch the full registry manifest.

This change optimizes manifest fetching by enabling a preliminary metadata lookup for package managers like `yarn-classic` that require it to resolve tags and ranges to concrete versions.