### PR TITLE
refactor(@angular/cli): implement structured error handling in package manager API

### DIFF
--- a/packages/angular/cli/src/package-managers/error.ts
+++ b/packages/angular/cli/src/package-managers/error.ts
@@ -35,3 +35,18 @@ export class PackageManagerError extends Error {
     super(message);
   }
 }
+
+/**
+ * Represents structured information about an error returned by a package manager command.
+ * This is a data interface, not an `Error` subclass.
+ */
+export interface ErrorInfo {
+  /** A specific error code (e.g. 'E404', 'EACCES'). */
+  readonly code: string;
+
+  /** A short, human-readable summary of the error. */
+  readonly summary: string;
+
+  /** An optional, detailed description of the error. */
+  readonly detail?: string;
+}

--- a/packages/angular/cli/src/package-managers/package-manager-descriptor.ts
+++ b/packages/angular/cli/src/package-managers/package-manager-descriptor.ts
@@ -12,14 +12,17 @@
  * package-manager-specific commands, flags, and output parsing.
  */
 
+import { ErrorInfo } from './error';
 import { Logger } from './logger';
 import { PackageManifest, PackageMetadata } from './package-metadata';
 import { InstalledPackage } from './package-tree';
 import {
   parseNpmLikeDependencies,
+  parseNpmLikeError,
   parseNpmLikeManifest,
   parseNpmLikeMetadata,
   parseYarnClassicDependencies,
+  parseYarnClassicError,
   parseYarnClassicManifest,
   parseYarnClassicMetadata,
   parseYarnModernDependencies,
@@ -90,11 +93,29 @@ export interface PackageManagerDescriptor {
 
     /** A function to parse the output of `getManifestCommand` for the full package metadata. */
     getRegistryMetadata: (stdout: string, logger?: Logger) => PackageMetadata | null;
+
+    /** A function to parse the output when a command fails. */
+    getError?: (output: string, logger?: Logger) => ErrorInfo | null;
   };
+
+  /** A function that checks if a structured error represents a "package not found" error. */
+  readonly isNotFound: (error: ErrorInfo) => boolean;
 }
 
 /** A type that represents the name of a supported package manager. */
 export type PackageManagerName = keyof typeof SUPPORTED_PACKAGE_MANAGERS;
+
+/** A set of error codes that are known to indicate a "package not found" error. */
+const NOT_FOUND_ERROR_CODES = new Set(['E404']);
+
+/**
+ * A shared function to check if a structured error represents a "package not found" error.
+ * @param error The structured error to check.
+ * @returns True if the error code is a known "not found" code, false otherwise.
+ */
+function isKnownNotFound(error: ErrorInfo): boolean {
+  return NOT_FOUND_ERROR_CODES.has(error.code);
+}
 
 /**
  * A map of supported package managers to their descriptors.
@@ -128,7 +149,9 @@ export const SUPPORTED_PACKAGE_MANAGERS = {
       listDependencies: parseNpmLikeDependencies,
       getRegistryManifest: parseNpmLikeManifest,
       getRegistryMetadata: parseNpmLikeMetadata,
+      getError: parseNpmLikeError,
     },
+    isNotFound: isKnownNotFound,
   },
   yarn: {
     binary: 'yarn',
@@ -150,7 +173,9 @@ export const SUPPORTED_PACKAGE_MANAGERS = {
       listDependencies: parseYarnModernDependencies,
       getRegistryManifest: parseNpmLikeManifest,
       getRegistryMetadata: parseNpmLikeMetadata,
+      getError: parseNpmLikeError,
     },
+    isNotFound: isKnownNotFound,
   },
   'yarn-classic': {
     binary: 'yarn',
@@ -169,13 +194,15 @@ export const SUPPORTED_PACKAGE_MANAGERS = {
     getRegistryOptions: (registry: string) => ({ args: ['--registry', registry] }),
     versionCommand: ['--version'],
     listDependenciesCommand: ['list', '--depth=0', '--json'],
-    getManifestCommand: ['info', '--json'],
+    getManifestCommand: ['info', '--json', '--verbose'],
     requiresManifestVersionLookup: true,
     outputParsers: {
       listDependencies: parseYarnClassicDependencies,
       getRegistryManifest: parseYarnClassicManifest,
       getRegistryMetadata: parseYarnClassicMetadata,
+      getError: parseYarnClassicError,
     },
+    isNotFound: isKnownNotFound,
   },
   pnpm: {
     binary: 'pnpm',
@@ -197,7 +224,9 @@ export const SUPPORTED_PACKAGE_MANAGERS = {
       listDependencies: parseNpmLikeDependencies,
       getRegistryManifest: parseNpmLikeManifest,
       getRegistryMetadata: parseNpmLikeMetadata,
+      getError: parseNpmLikeError,
     },
+    isNotFound: isKnownNotFound,
   },
   bun: {
     binary: 'bun',
@@ -219,7 +248,9 @@ export const SUPPORTED_PACKAGE_MANAGERS = {
       listDependencies: parseNpmLikeDependencies,
       getRegistryManifest: parseNpmLikeManifest,
       getRegistryMetadata: parseNpmLikeMetadata,
+      getError: parseNpmLikeError,
     },
+    isNotFound: isKnownNotFound,
   },
 } satisfies Record<string, PackageManagerDescriptor>;
 

--- a/packages/angular/cli/src/package-managers/parsers_spec.ts
+++ b/packages/angular/cli/src/package-managers/parsers_spec.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { parseNpmLikeError, parseYarnClassicError } from './parsers';
+
+describe('parsers', () => {
+  describe('parseNpmLikeError', () => {
+    it('should parse a structured JSON error from modern yarn', () => {
+      const stdout = JSON.stringify({
+        code: 'ERR_PNPM_NO_SUCH_PACKAGE',
+        summary: 'No such package.',
+        detail: 'Package not found.',
+      });
+      const error = parseNpmLikeError(stdout);
+      expect(error).toEqual({
+        code: 'ERR_PNPM_NO_SUCH_PACKAGE',
+        summary: 'No such package.',
+        detail: 'Package not found.',
+      });
+    });
+
+    it('should parse a plain text error from npm', () => {
+      const stdout =
+        'npm error code E404\nnpm error 404 Not Found - GET https://registry.example.com/non-existent-package';
+      const error = parseNpmLikeError(stdout);
+      expect(error).toEqual({
+        code: 'E404',
+        summary: '404 Not Found - GET https://registry.example.com/non-existent-package',
+      });
+    });
+
+    it('should parse a plain text error from npm with ERR!', () => {
+      const stderr =
+        'npm ERR! code E404\nnpm ERR! 404 Not Found - GET https://registry.example.com/non-existent-package';
+      const error = parseNpmLikeError(stderr);
+      expect(error).toEqual({
+        code: 'E404',
+        summary: '404 Not Found - GET https://registry.example.com/non-existent-package',
+      });
+    });
+
+    it('should parse a structured JSON error with a message property', () => {
+      const stderr = JSON.stringify({
+        code: 'EUNSUPPORTEDPROTOCOL',
+        message: 'Unsupported protocol.',
+        detail: 'The protocol "invalid:" is not supported.',
+      });
+      const error = parseNpmLikeError(stderr);
+      expect(error).toEqual({
+        code: 'EUNSUPPORTEDPROTOCOL',
+        summary: 'Unsupported protocol.',
+        detail: 'The protocol "invalid:" is not supported.',
+      });
+    });
+
+    it('should return null for empty stdout', () => {
+      const error = parseNpmLikeError('');
+      expect(error).toBeNull();
+    });
+
+    it('should return null for unparsable stdout', () => {
+      const error = parseNpmLikeError('An unexpected error occurred.');
+      expect(error).toBeNull();
+    });
+  });
+
+  describe('parseYarnClassicError', () => {
+    it('should parse a 404 from verbose logs', () => {
+      const stdout =
+        '{"type":"verbose","data":"Request "https://registry.example.com/non-existent-package" finished with status code 404."}';
+      const error = parseYarnClassicError(stdout);
+      expect(error).toEqual({
+        code: 'E404',
+        summary: 'Request failed with status code 404.',
+      });
+    });
+
+    it('should parse a non-404 HTTP error from verbose logs', () => {
+      const stdout =
+        '{"type":"verbose","data":"Request "https://registry.example.com/private-package" finished with status code 401."}';
+      const error = parseYarnClassicError(stdout);
+      expect(error).toEqual({
+        code: 'E401',
+        summary: 'Request failed with status code 401.',
+      });
+    });
+
+    it('should parse a generic JSON error when no HTTP status is found', () => {
+      const stdout = '{"type":"error","data":"An unexpected error occurred."}';
+      const error = parseYarnClassicError(stdout);
+      expect(error).toEqual({
+        code: 'UNKNOWN_ERROR',
+        summary: 'An unexpected error occurred.',
+      });
+    });
+
+    it('should return null for empty stdout', () => {
+      const error = parseYarnClassicError('');
+      expect(error).toBeNull();
+    });
+
+    it('should return null for unparsable stdout', () => {
+      const error = parseYarnClassicError('A random error message.');
+      expect(error).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
This commit introduces a structured error handling system into the package manager abstraction. Previously, the system treated most command failures generically, often assuming a package was simply "not found." This could mask the true root cause of issues such as network failures, registry authentication errors, or unexpected changes in a package manager's output.

The new implementation enhances diagnostics and provides clearer, more actionable error messages by:
- Introducing a standardized `ErrorInfo` interface to represent parsed error details.
- Adding dedicated parsers to extract structured error information (JSON or text-based) from the stderr of npm, yarn, pnpm, and bun.
- Making the core execution logic stricter. It now re-throws the original `PackageManagerError` if a command fails for an unknown reason, preventing silent failures.
- Abstracting the "package not found" check into the `PackageManagerDescriptor`, removing hardcoded logic from the execution layer.
- Improving the `yarn-classic` parser to use verbose logs, allowing it to accurately detect and report specific HTTP status codes (e.g., 401, 403, 404, 500).