### PR TITLE
test: remove RxJS from E2E process utility

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -891,9 +891,6 @@ importers:
       '@types/tar-stream':
         specifier: 3.1.4
         version: 3.1.4
-      rxjs:
-        specifier: 7.8.2
-        version: 7.8.2
       tar-stream:
         specifier: 3.1.7
         version: 3.1.7

--- a/tests/legacy-cli/e2e/utils/BUILD.bazel
+++ b/tests/legacy-cli/e2e/utils/BUILD.bazel
@@ -19,7 +19,6 @@ ts_project(
         "//:node_modules/verdaccio",
         "//:node_modules/verdaccio-auth-memory",
         "//tests:node_modules/@types/tar-stream",
-        "//tests:node_modules/rxjs",
         "//tests:node_modules/tar-stream",
         "//tests:node_modules/tree-kill",
     ],

--- a/tests/package.json
+++ b/tests/package.json
@@ -2,7 +2,6 @@
   "devDependencies": {
     "@types/tar-stream": "3.1.4",
     "@angular-devkit/schematics": "workspace:*",
-    "rxjs": "7.8.2",
     "tar-stream": "3.1.7",
     "tree-kill": "1.2.2"
   }


### PR DESCRIPTION
Replaces RxJS-based retry logic in `execAndWaitForOutputToMatch` with standard async/await for better readability and reduced dependency footprint.