### PR TITLE
fix(@angular/build): inject testing polyfills in Karma unit-test executor

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/karma/executor.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/karma/executor.ts
@@ -11,7 +11,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { ApplicationBuilderInternalOptions } from '../../../application/options';
 import type { KarmaBuilderOptions, KarmaBuilderTransformsOptions } from '../../../karma';
-import { NormalizedUnitTestBuilderOptions } from '../../options';
+import { type NormalizedUnitTestBuilderOptions, injectTestingPolyfills } from '../../options';
 import type { TestExecutor } from '../api';
 
 export class KarmaExecutor implements TestExecutor {
@@ -70,7 +70,7 @@ export class KarmaExecutor implements TestExecutor {
     const karmaOptions: KarmaBuilderOptions = {
       karmaConfig,
       tsConfig: unitTestOptions.tsConfig ?? buildTargetOptions.tsConfig,
-      polyfills: buildTargetOptions.polyfills,
+      polyfills: injectTestingPolyfills(buildTargetOptions.polyfills),
       assets: buildTargetOptions.assets,
       scripts: buildTargetOptions.scripts,
       styles: buildTargetOptions.styles,


### PR DESCRIPTION
This commit ensures that testing polyfills (specifically `zone.js/testing`) are correctly injected when using the new unit-test builder with the Karma runner. Previously, only the application polyfills were included, which could lead to runtime errors in tests dependent on `zone.js/testing`.

Closes #32032