### PR TITLE
build: simplify format configuration and update ng-dev dependency  

### DIFF
--- a/.ng-dev/format.mjs
+++ b/.ng-dev/format.mjs
@@ -4,8 +4,6 @@
  * @type { import("@angular/ng-dev").FormatConfig }
  */
 export const format = {
-  'prettier': {
-    matchers: ['**/*.{mts,cts,ts,mjs,cjs,js,json,yml,yaml,md}'],
-  },
+  'prettier': true,
   'buildifier': true,
 };

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@angular/forms": "21.1.0-next.1",
     "@angular/localize": "21.1.0-next.1",
     "@angular/material": "21.1.0-next.1",
-    "@angular/ng-dev": "https://github.com/angular/dev-infra-private-ng-dev-builds.git#a6bcef88323031f5c157227705792019833c5c08",
+    "@angular/ng-dev": "https://github.com/angular/dev-infra-private-ng-dev-builds.git#9037bb2813539aab76b41abd85ea690e0d839e4a",
     "@angular/platform-browser": "21.1.0-next.1",
     "@angular/platform-server": "21.1.0-next.1",
     "@angular/router": "21.1.0-next.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,8 +47,8 @@ importers:
         specifier: 21.1.0-next.1
         version: 21.1.0-next.1(ccb492dd96d90eab040ed852f8404aa4)
       '@angular/ng-dev':
-        specifier: https://github.com/angular/dev-infra-private-ng-dev-builds.git#a6bcef88323031f5c157227705792019833c5c08
-        version: https://codeload.github.com/angular/dev-infra-private-ng-dev-builds/tar.gz/a6bcef88323031f5c157227705792019833c5c08(@modelcontextprotocol/sdk@1.24.2(zod@4.1.13))
+        specifier: https://github.com/angular/dev-infra-private-ng-dev-builds.git#9037bb2813539aab76b41abd85ea690e0d839e4a
+        version: https://codeload.github.com/angular/dev-infra-private-ng-dev-builds/tar.gz/9037bb2813539aab76b41abd85ea690e0d839e4a(@modelcontextprotocol/sdk@1.24.2(zod@4.1.13))
       '@angular/platform-browser':
         specifier: 21.1.0-next.1
         version: 21.1.0-next.1(@angular/animations@21.1.0-next.1(@angular/core@21.1.0-next.1(@angular/compiler@21.1.0-next.1)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.0-next.1(@angular/core@21.1.0-next.1(@angular/compiler@21.1.0-next.1)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.0-next.1(@angular/compiler@21.1.0-next.1)(rxjs@7.8.2)(zone.js@0.16.0))
@@ -1054,9 +1054,9 @@ packages:
       '@angular/platform-browser': ^21.0.0-0 || ^21.1.0-0 || ^21.2.0-0 || ^21.3.0-0 || ^22.0.0-0
       rxjs: ^6.5.3 || ^7.4.0
 
-  '@angular/ng-dev@https://codeload.github.com/angular/dev-infra-private-ng-dev-builds/tar.gz/a6bcef88323031f5c157227705792019833c5c08':
-    resolution: {tarball: https://codeload.github.com/angular/dev-infra-private-ng-dev-builds/tar.gz/a6bcef88323031f5c157227705792019833c5c08}
-    version: 0.0.0-73051ae248ba64911a8e7e66536d8c99ba07ef2a
+  '@angular/ng-dev@https://codeload.github.com/angular/dev-infra-private-ng-dev-builds/tar.gz/9037bb2813539aab76b41abd85ea690e0d839e4a':
+    resolution: {tarball: https://codeload.github.com/angular/dev-infra-private-ng-dev-builds/tar.gz/9037bb2813539aab76b41abd85ea690e0d839e4a}
+    version: 0.0.0-a88cb5b721f1547ed5cbdcc5779cade25500f575
     hasBin: true
 
   '@angular/platform-browser@21.1.0-next.1':
@@ -2300,8 +2300,8 @@ packages:
     resolution: {integrity: sha512-IJn+8A3QZJfe7FUtWqHVNo3xJs7KFpurCWGWCiCz3oEh+BkRymKZ1QxfAbU2yGMDzTytLGQ2IV6T2r3cuo75/w==}
     engines: {node: '>=18'}
 
-  '@google/genai@1.30.0':
-    resolution: {integrity: sha512-3MRcgczBFbUat1wIlZoLJ0vCCfXgm7Qxjh59cZi2X08RgWLtm9hKOspzp7TOg1TV2e26/MLxR2GR5yD5GmBV2w==}
+  '@google/genai@1.31.0':
+    resolution: {integrity: sha512-rK0RKXxNkbK35eDl+G651SxtxwHNEOogjyeZJUJe+Ed4yxu3xy5ufCiU0+QLT7xo4M9Spey8OAYfD8LPRlYBKw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.20.1
@@ -9525,11 +9525,11 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@angular/ng-dev@https://codeload.github.com/angular/dev-infra-private-ng-dev-builds/tar.gz/a6bcef88323031f5c157227705792019833c5c08(@modelcontextprotocol/sdk@1.24.2(zod@4.1.13))':
+  '@angular/ng-dev@https://codeload.github.com/angular/dev-infra-private-ng-dev-builds/tar.gz/9037bb2813539aab76b41abd85ea690e0d839e4a(@modelcontextprotocol/sdk@1.24.2(zod@4.1.13))':
     dependencies:
       '@actions/core': 1.11.1
       '@google-cloud/spanner': 8.0.0(supports-color@10.2.2)
-      '@google/genai': 1.30.0(@modelcontextprotocol/sdk@1.24.2(zod@4.1.13))(bufferutil@4.0.9)(supports-color@10.2.2)(utf-8-validate@6.0.5)
+      '@google/genai': 1.31.0(@modelcontextprotocol/sdk@1.24.2(zod@4.1.13))(bufferutil@4.0.9)(supports-color@10.2.2)(utf-8-validate@6.0.5)
       '@inquirer/prompts': 8.0.2(@types/node@24.10.1)
       '@inquirer/type': 4.0.2(@types/node@24.10.1)
       '@octokit/auth-app': 8.1.2
@@ -10979,7 +10979,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@google/genai@1.30.0(@modelcontextprotocol/sdk@1.24.2(zod@4.1.13))(bufferutil@4.0.9)(supports-color@10.2.2)(utf-8-validate@6.0.5)':
+  '@google/genai@1.31.0(@modelcontextprotocol/sdk@1.24.2(zod@4.1.13))(bufferutil@4.0.9)(supports-color@10.2.2)(utf-8-validate@6.0.5)':
     dependencies:
       google-auth-library: 10.5.0(supports-color@10.2.2)
       ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5)


### PR DESCRIPTION
The matchers option has been removed and is now built-in.