### PR TITLE
fix(@angular/build): add browser condition to resolver for vitest

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
@@ -128,7 +128,7 @@ export async function createVitestConfigPlugin(
         },
         resolve: {
           mainFields: ['es2020', 'module', 'main'],
-          conditions: ['es2015', 'es2020', 'module'],
+          conditions: ['es2015', 'es2020', 'module', ...(browser ? ['browser'] : [])],
         },
       };
 


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Given a package.json like following:
```json
{
  "name": "browser-condition",
  "type": "module",
  "exports": {
    ".": {
      "browser": {
        "default": "./browser.js"
      },
      "node": {
        "default": "./node.js"
      },
      "default": "./browser.js"
    }
  }
}
```

Currently, when using vitest, even when testing in real browser, it takes the "node.js" module. 
This, for example, happens when using [`lit`](https://github.com/lit/lit/) components, which are depending on `isServer` const in tests as they load different modules depending on the environment.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Respects the "browser" condition when testing in a real browser and chooses "browser.js" in the above example.

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

We face difficulties, trying to create a test case.
We tried to add a test like following, but the problem is that the dependency `@vitest/browser-playwright` is missing in unit tests. Should it be installed? Or more general, what would be the best way to create a test case?.

```ts
    it('should resolve browser condition', async () => {
      await harness.modifyFile('tsconfig.json', (content) => {
        const tsConfig = JSON.parse(content);
        tsConfig.compilerOptions.paths = {
          'browser-condition': ['browser-condition'],
        };

        return JSON.stringify(tsConfig);
      });

      await harness.writeFile('browser-condition/browser.js', "export const value = 'browser';");
      await harness.writeFile('browser-condition/node.js', "export const value = 'node';");

      const packageJson = {
        name: 'browser-condition',
        type: 'module',
        exports: {
          '.': {
            browser: {
              default: './browser.js',
            },
            node: {
              default: './node.js',
            },
            default: './browser.js',
          },
        },
      };

      await harness.writeFile(
        'browser-condition/package.json',
        JSON.stringify(packageJson, null, 2),
      );

      await harness.modifyFile('src/app/app.component.ts', (content) => {
        return (
          `import { value } from 'browser-condition';\n` +
          content.replace(`title = 'app';`, 'title = value;')
        );
      });

      await harness.modifyFile('src/app/app.component.spec.ts', (content) => {
        return content.replace(
          `expect(app.title).toEqual('app');`,
          `expect(app.title).toEqual('browser');`,
        );
      });

      harness.useTarget('test', {
        ...BASE_OPTIONS,
        browsers: ['chrome'],
      });

      const { result } = await harness.executeOnce();
      expect(result?.success).toBeTrue();
    })
```