### PR TITLE
test: rename npm E2E suite to webpack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: [20, 22, 24]
-        subset: [npm, esbuild]
+        subset: [esbuild, webpack]
         shard: [0, 1, 2, 3, 4, 5]
     runs-on: ${{ matrix.os }}
     steps:
@@ -134,7 +134,7 @@ jobs:
       matrix:
         os: [windows-2025]
         node: [22]
-        subset: [npm, esbuild]
+        subset: [esbuild, webpack]
         shard: [0, 1, 2, 3, 4, 5]
     runs-on: ${{ matrix.os }}
     steps:
@@ -187,7 +187,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: [22]
-        subset: [npm, esbuild]
+        subset: [esbuild, webpack]
         shard: [0, 1, 2, 3, 4, 5]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -110,7 +110,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: [22]
-        subset: [npm, esbuild]
+        subset: [esbuild, webpack]
         shard: [0, 1, 2, 3, 4, 5]
     runs-on: ${{ matrix.os }}
     steps:
@@ -203,7 +203,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: [22]
-        subset: [npm, esbuild]
+        subset: [esbuild, webpack]
         shard: [0, 1, 2, 3, 4, 5]
     runs-on: ${{ matrix.os }}
     steps:

--- a/tests/legacy-cli/e2e.bzl
+++ b/tests/legacy-cli/e2e.bzl
@@ -83,11 +83,14 @@ def e2e_suites(name, runner, data):
         # Default target meant to be run manually for debugging, customizing test cli via bazel
         _e2e_tests(name + "_" + toolchain_name, runner, data = data, toolchain = toolchain, tags = ["manual"])
 
-        _e2e_suite(name, runner, "npm", data, toolchain_name, toolchain)
+        # Main test suites
+        _e2e_suite(name, runner, "webpack", data, toolchain_name, toolchain)
+        _e2e_suite(name, runner, "esbuild", data, toolchain_name, toolchain)
+
+        # Package manager subsets
         _e2e_suite(name, runner, "bun", data, toolchain_name, toolchain)
         _e2e_suite(name, runner, "pnpm", data, toolchain_name, toolchain)
         _e2e_suite(name, runner, "yarn", data, toolchain_name, toolchain)
-        _e2e_suite(name, runner, "esbuild", data, toolchain_name, toolchain)
 
     # Saucelabs tests are only run on the default toolchain
     _e2e_suite(name, runner, "saucelabs", data)
@@ -162,7 +165,7 @@ def _e2e_suite(name, runner, type, data, toolchain_name = "", toolchain = None):
         args.append("--esbuild")
         tests = BROWSER_TESTS
         ignore = None
-    elif type == "npm":
+    elif type == "webpack":
         tests = None
         ignore = BROWSER_TESTS + WEBPACK_IGNORE_TESTS
 


### PR DESCRIPTION
The current `npm` E2E test suite is actually the browser builder (Webpack-based) tests. The name has now been updated to better reflect the test behavior.