### PR TITLE
ci: run separate npm package manager E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         os: [ubuntu-latest]
         node: [20, 22, 24]
         subset: [esbuild, webpack]
-        shard: [0, 1, 2, 3, 4, 5]
+        shard: [0, 1, 2, 3, 4]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Initialize environment
@@ -95,7 +95,7 @@ jobs:
         with:
           google_credential: ${{ secrets.RBE_TRUSTED_BUILDS_USER }}
       - name: Run CLI E2E tests
-        run: pnpm bazel test --test_env=E2E_SHARD_TOTAL=6 --test_env=E2E_SHARD_INDEX=${{ matrix.shard }} --config=e2e //tests/legacy-cli:e2e.${{ matrix.subset }}_node${{ matrix.node }}
+        run: pnpm bazel test --test_env=E2E_SHARD_TOTAL=5 --test_env=E2E_SHARD_INDEX=${{ matrix.shard }} --config=e2e //tests/legacy-cli:e2e.${{ matrix.subset }}_node${{ matrix.node }}
 
   build-e2e-windows:
     runs-on: ubuntu-latest
@@ -135,7 +135,7 @@ jobs:
         os: [windows-2025]
         node: [22]
         subset: [esbuild, webpack]
-        shard: [0, 1, 2, 3, 4, 5]
+        shard: [0, 1, 2, 3, 4]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Initialize environment
@@ -152,7 +152,14 @@ jobs:
         with:
           test_target_name: e2e.${{ matrix.subset }}_node${{ matrix.node }}
         env:
-          E2E_SHARD_TOTAL: 6
+          E2E_SHARD_TOTAL: 5
+          E2E_SHARD_INDEX: ${{ matrix.shard }}
+      - name: Run CLI npm package manager tests
+        uses: ./.github/shared-actions/windows-bazel-test
+        with:
+          test_target_name: e2e.npm_node${{ matrix.node }}
+        env:
+          E2E_SHARD_TOTAL: 5
           E2E_SHARD_INDEX: ${{ matrix.shard }}
 
   e2e-package-managers:
@@ -162,7 +169,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: [22]
-        subset: [yarn, pnpm, bun]
+        subset: [npm, yarn, pnpm, bun]
         shard: [0, 1, 2]
     runs-on: ${{ matrix.os }}
     steps:
@@ -188,7 +195,7 @@ jobs:
         os: [ubuntu-latest]
         node: [22]
         subset: [esbuild, webpack]
-        shard: [0, 1, 2, 3, 4, 5]
+        shard: [0, 1, 2, 3, 4]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Initialize environment
@@ -202,7 +209,7 @@ jobs:
         with:
           google_credential: ${{ secrets.RBE_TRUSTED_BUILDS_USER }}
       - name: Run CLI E2E tests
-        run: pnpm bazel test --test_env=E2E_SHARD_TOTAL=6 --test_env=E2E_SHARD_INDEX=${{ matrix.shard }} --config=e2e //tests/legacy-cli:e2e.snapshots.${{ matrix.subset }}_node${{ matrix.node }}
+        run: pnpm bazel test --test_env=E2E_SHARD_TOTAL=5 --test_env=E2E_SHARD_INDEX=${{ matrix.shard }} --config=e2e //tests/legacy-cli:e2e.snapshots.${{ matrix.subset }}_node${{ matrix.node }}
 
   browsers:
     needs: build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -111,7 +111,7 @@ jobs:
         os: [ubuntu-latest]
         node: [22]
         subset: [esbuild, webpack]
-        shard: [0, 1, 2, 3, 4, 5]
+        shard: [0, 1, 2, 3, 4]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Initialize environment
@@ -123,7 +123,7 @@ jobs:
       - name: Setup Bazel RBE
         uses: angular/dev-infra/github-actions/bazel/configure-remote@73051ae248ba64911a8e7e66536d8c99ba07ef2a
       - name: Run CLI E2E tests
-        run: pnpm bazel test --test_env=E2E_SHARD_TOTAL=6 --test_env=E2E_SHARD_INDEX=${{ matrix.shard }} --config=e2e //tests/legacy-cli:e2e.${{ matrix.subset }}_node${{ matrix.node }}
+        run: pnpm bazel test --test_env=E2E_SHARD_TOTAL=5 --test_env=E2E_SHARD_INDEX=${{ matrix.shard }} --config=e2e //tests/legacy-cli:e2e.${{ matrix.subset }}_node${{ matrix.node }}
 
   build-e2e-windows-subset:
     runs-on: ubuntu-latest
@@ -180,7 +180,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: [22]
-        subset: [yarn, pnpm, bun]
+        subset: [npm, yarn, pnpm, bun]
         shard: [0, 1, 2]
     runs-on: ${{ matrix.os }}
     steps:
@@ -204,7 +204,7 @@ jobs:
         os: [ubuntu-latest]
         node: [22]
         subset: [esbuild, webpack]
-        shard: [0, 1, 2, 3, 4, 5]
+        shard: [0, 1, 2, 3, 4]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Initialize environment
@@ -216,4 +216,4 @@ jobs:
       - name: Setup Bazel RBE
         uses: angular/dev-infra/github-actions/bazel/configure-remote@73051ae248ba64911a8e7e66536d8c99ba07ef2a
       - name: Run CLI E2E tests
-        run: pnpm bazel test --test_env=E2E_SHARD_TOTAL=6 --test_env=E2E_SHARD_INDEX=${{ matrix.shard }} --config=e2e //tests/legacy-cli:e2e.snapshots.${{ matrix.subset }}_node${{ matrix.node }}
+        run: pnpm bazel test --test_env=E2E_SHARD_TOTAL=5 --test_env=E2E_SHARD_INDEX=${{ matrix.shard }} --config=e2e //tests/legacy-cli:e2e.snapshots.${{ matrix.subset }}_node${{ matrix.node }}

--- a/tests/legacy-cli/e2e.bzl
+++ b/tests/legacy-cli/e2e.bzl
@@ -88,6 +88,7 @@ def e2e_suites(name, runner, data):
         _e2e_suite(name, runner, "esbuild", data, toolchain_name, toolchain)
 
         # Package manager subsets
+        _e2e_suite(name, runner, "npm", data, toolchain_name, toolchain)
         _e2e_suite(name, runner, "bun", data, toolchain_name, toolchain)
         _e2e_suite(name, runner, "pnpm", data, toolchain_name, toolchain)
         _e2e_suite(name, runner, "yarn", data, toolchain_name, toolchain)
@@ -143,7 +144,7 @@ def _e2e_tests(name, runner, toolchain, **kwargs):
 
 def _e2e_suite(name, runner, type, data, toolchain_name = "", toolchain = None):
     """
-    Setup a predefined test suite (yarn|pnpm|bun|esbuild|saucelabs|npm).
+    Setup a predefined test suite (yarn|pnpm|bun|esbuild|webpack|saucelabs|npm).
     """
     args = []
     tests = None
@@ -152,22 +153,22 @@ def _e2e_suite(name, runner, type, data, toolchain_name = "", toolchain = None):
     if toolchain_name:
         toolchain_name = "_" + toolchain_name
 
-    if type == "yarn" or type == "bun" or type == "pnpm":
+    if type == "npm" or type == "yarn" or type == "bun" or type == "pnpm":
         args.append("--package-manager=%s" % type)
         args.append("--esbuild")
         tests = PACKAGE_MANAGER_SUBSET_TESTS
-        ignore = BROWSER_TESTS + WEBPACK_IGNORE_TESTS
+        ignore = BROWSER_TESTS
     elif type == "esbuild":
         args.append("--esbuild")
         tests = ESBUILD_TESTS
-        ignore = BROWSER_TESTS
+        ignore = BROWSER_TESTS + PACKAGE_MANAGER_SUBSET_TESTS
     elif type == "saucelabs":
         args.append("--esbuild")
         tests = BROWSER_TESTS
         ignore = None
     elif type == "webpack":
         tests = None
-        ignore = BROWSER_TESTS + WEBPACK_IGNORE_TESTS
+        ignore = BROWSER_TESTS + WEBPACK_IGNORE_TESTS + PACKAGE_MANAGER_SUBSET_TESTS
 
     # Standard e2e tests
     _e2e_tests(


### PR DESCRIPTION
Improves the organization of the E2E tests by grouping package manager related tests into the same job matrix. Also reduces the number of test shards for the core E2E tests by one due to the lower amount of tests.