### PR TITLE
ci: remove single value os matrix field from E2E jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
         node: [20, 22, 24]
         subset: [esbuild, webpack]
         shard: [0, 1, 2, 3, 4, 5]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@73051ae248ba64911a8e7e66536d8c99ba07ef2a
@@ -132,11 +131,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2025]
         node: [22]
         subset: [esbuild, webpack]
         shard: [0, 1, 2, 3, 4, 5]
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-2025
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@73051ae248ba64911a8e7e66536d8c99ba07ef2a
@@ -160,11 +158,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
         node: [22]
         subset: [yarn, pnpm, bun]
         shard: [0, 1, 2]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@73051ae248ba64911a8e7e66536d8c99ba07ef2a
@@ -185,11 +182,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
         node: [22]
         subset: [esbuild, webpack]
         shard: [0, 1, 2, 3, 4, 5]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@73051ae248ba64911a8e7e66536d8c99ba07ef2a

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -108,11 +108,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
         node: [22]
         subset: [esbuild, webpack]
         shard: [0, 1, 2, 3, 4, 5]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@73051ae248ba64911a8e7e66536d8c99ba07ef2a
@@ -178,11 +177,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
         node: [22]
         subset: [yarn, pnpm, bun]
         shard: [0, 1, 2]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@73051ae248ba64911a8e7e66536d8c99ba07ef2a
@@ -201,11 +199,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
         node: [22]
         subset: [esbuild, webpack]
         shard: [0, 1, 2, 3, 4, 5]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@73051ae248ba64911a8e7e66536d8c99ba07ef2a


### PR DESCRIPTION
Since the `os` matrix field only ever has a single value, there is no need to include it in the matrix itself. This also shortens the display name by removing the otherwise static value from each matrix job entry.