### PR TITLE
fix(#31973): Added JavaScriptTransformer close to dispose method

### DIFF
--- a/packages/angular/build/src/private.ts
+++ b/packages/angular/build/src/private.ts
@@ -59,6 +59,7 @@ export function createCompilerPlugin(
     ),
   );
 }
+export { getSharedCompilationStateCleanup } from './tools/esbuild/angular/compilation-state';
 
 export type { AngularCompilation } from './tools/angular/compilation';
 export { DiagnosticModes } from './tools/angular/compilation';

--- a/packages/angular/build/src/tools/esbuild/angular/compilation-state.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compilation-state.ts
@@ -10,6 +10,17 @@ export class SharedTSCompilationState {
   #pendingCompilation = true;
   #resolveCompilationReady: ((value: boolean) => void) | undefined;
   #compilationReadyPromise: Promise<boolean> | undefined;
+
+  /**
+   * ESbuild doesnt allow for awaiting the cleanup of plugins, therefore this
+   * allows consumers of the compiler-plugin to await the disposal of the plugin
+   * after ESbuild dispose function was called.
+   */
+  #disposeCompilation: (() => void) | undefined;
+  awaitCompilationDisposed: Promise<void> = new Promise((resolve) => {
+    this.#disposeCompilation = resolve;
+  });
+
   #hasErrors = true;
 
   get waitUntilReady(): Promise<boolean> {
@@ -37,6 +48,7 @@ export class SharedTSCompilationState {
 
   dispose(): void {
     this.markAsReady(true);
+    this.#disposeCompilation?.();
     globalSharedCompilationState = undefined;
   }
 }
@@ -45,4 +57,8 @@ let globalSharedCompilationState: SharedTSCompilationState | undefined;
 
 export function getSharedCompilationState(): SharedTSCompilationState {
   return (globalSharedCompilationState ??= new SharedTSCompilationState());
+}
+
+export function getSharedCompilationStateCleanup() {
+  return globalSharedCompilationState?.awaitCompilationDisposed ?? Promise.resolve();
 }

--- a/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
@@ -588,11 +588,14 @@ export function createCompilerPlugin(
         logCumulativeDurations();
       });
 
-      build.onDispose(() => {
-        sharedTSCompilationState?.dispose();
-        void compilation.close?.();
-        void cacheStore?.close();
-      });
+      build.onDispose(
+        () =>
+          void Promise.all(
+            [compilation?.close?.(), cacheStore?.close(), javascriptTransformer.close()].filter(
+              Boolean,
+            ),
+          ).then(() => sharedTSCompilationState?.dispose()),
+      );
 
       /**
        * Checks if the file has side-effects when `advancedOptimizations` is enabled.


### PR DESCRIPTION
This change allows for awaiting the disposed plugin and added the missing close method of the JavaScript transformer to the onDispose. When the plugin is run multiple times on different projects/bundles without proper closing it will result in a node heap corruption. This allows us to cleanup the build before we start a new one.

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The current behavior doesn't cleanup the JavascriptTransformer and also doesn't await the promises. I know that ESbuild is not yet processing promises in the onDispose callback but I am working on that! https://github.com/evanw/esbuild/issues/4356

 In the meantime ESbuild will just treat the callback as a void so no functional changes. 

Closes #31973. 

## What is the new behavior?

For Angular no functional changes other than the clean disposal of the JavascriptTransformer to avoid Node heap corruptions. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

For us this means that we can create a wrapper around the plugin. This wrapper  creates a promise from the callback and awaits that promise after an ESbuild dispose. This allows us to fully cleanup the build after it's finished and thus avoids unwanted memory leaks. 
