### PR TITLE
fix(@angular/build): Ensure disposal of close-javascript-transformer

### DIFF
--- a/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
@@ -591,6 +591,7 @@ export function createCompilerPlugin(
       build.onDispose(() => {
         sharedTSCompilationState?.dispose();
         void compilation.close?.();
+        void javascriptTransformer.close();
         void cacheStore?.close();
       });
 


### PR DESCRIPTION
The onDispose callback doesn't close the javascriptTransformer correctly yet. This ensures that all worker pools are cleaned after a disposal.

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently the javascriptTransformer is not closed explicitly.

Issue Number: N/A

## What is the new behavior?

Like all other parts (compilation and cache), the javascriptTransformer is now closed explicitly. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
