### PR TITLE
build: use Node.js built-in TypeScript support for dev-infra scripts

### DIFF
--- a/.ng-dev/commit-message.mjs
+++ b/.ng-dev/commit-message.mjs
@@ -1,4 +1,4 @@
-import { packages } from '../scripts/packages.mjs';
+import { packages } from '../scripts/packages.mts';
 
 /**
  * The configuration for `ng-dev commit-message` commands.

--- a/.ng-dev/release.mjs
+++ b/.ng-dev/release.mjs
@@ -1,5 +1,5 @@
 import semver from 'semver';
-import { releasePackages } from '../scripts/packages.mjs';
+import { releasePackages } from '../scripts/packages.mts';
 
 /**
  * Configuration for the `ng-dev release` command.
@@ -12,14 +12,13 @@ export const release = {
   buildPackages: async () => {
     // The `performNpmReleaseBuild` function is loaded at runtime to avoid loading additional
     // files and dependencies unless a build is required.
-    const { performNpmReleaseBuild } = await import('../scripts/build-packages-dist.mjs');
+    const { performNpmReleaseBuild } = await import('../scripts/build-packages-dist.mts');
     return performNpmReleaseBuild();
   },
   prereleaseCheck: async (newVersionStr) => {
     const newVersion = new semver.SemVer(newVersionStr);
-    const { assertValidDependencyRanges } = await import(
-      '../scripts/release-checks/dependency-ranges/index.mjs'
-    );
+    const { assertValidDependencyRanges } =
+      await import('../scripts/release-checks/dependency-ranges/index.mts');
 
     await assertValidDependencyRanges(newVersion, releasePackages);
   },

--- a/.ng-dev/tsconfig.json
+++ b/.ng-dev/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "resolveJsonModule": true,
     "allowJs": true,
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true,
     "module": "Node16",
     "moduleResolution": "Node16",
     "checkJs": true,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "Angular DevKit"
   ],
   "scripts": {
-    "admin": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only ./scripts/devkit-admin.mjs",
+    "admin": "node --no-warnings=ExperimentalWarning --experimental-transform-types ./scripts/devkit-admin.mts",
     "bazel": "bazelisk",
     "test": "bazel test //packages/...",
     "build": "pnpm -s admin build",
@@ -20,10 +20,9 @@
     "templates": "pnpm -s admin templates",
     "validate": "pnpm -s admin validate",
     "postinstall": "husky",
-    "ng-dev": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only node_modules/@angular/ng-dev/bundles/cli.mjs",
-    "ts-circular-deps": "pnpm -s ng-dev ts-circular-deps --config ./scripts/circular-deps-test.conf.mjs",
+    "ts-circular-deps": "ng-dev ts-circular-deps --config ./scripts/circular-deps-test.conf.mjs",
     "check-tooling-setup": "tsc --project .ng-dev/tsconfig.json",
-    "diff-release-package": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only scripts/diff-release-package.mts"
+    "diff-release-package": "node scripts/diff-release-package.mts"
   },
   "repository": {
     "type": "git",

--- a/scripts/build-packages-dist.mts
+++ b/scripts/build-packages-dist.mts
@@ -12,7 +12,7 @@
  * distribution folder within the project.
  */
 
-import { BuiltPackage } from '@angular/ng-dev';
+import type { BuiltPackage } from '@angular/ng-dev';
 import { execSync } from 'node:child_process';
 import {
   chmodSync,

--- a/scripts/circular-deps-test.conf.mjs
+++ b/scripts/circular-deps-test.conf.mjs
@@ -9,7 +9,7 @@
 import { statSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { packages } from './packages.mjs';
+import { packages } from './packages.mts';
 
 export const baseDir = '../';
 export const goldenFile = '../goldens/circular-deps/packages.json';

--- a/scripts/create.mts
+++ b/scripts/create.mts
@@ -11,8 +11,8 @@ import * as child_process from 'node:child_process';
 import { copyFile, readFile, rm, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import build from './build.mjs';
-import { packages } from './packages.mjs';
+import build from './build.mts';
+import { packages } from './packages.mts';
 
 export interface CreateOptions extends Record<string, unknown> {
   _: string[];

--- a/scripts/devkit-admin.mts
+++ b/scripts/devkit-admin.mts
@@ -42,7 +42,7 @@ console.error = function (...args) {
 };
 
 try {
-  const script = await import(`./${scriptName}.mjs`);
+  const script = await import(`./${scriptName}.mts`);
   const exitCode = await script.default(args, cwd);
   process.exitCode = typeof exitCode === 'number' ? exitCode : 0;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/scripts/json-help.mts
+++ b/scripts/json-help.mts
@@ -10,7 +10,7 @@ import { spawnSync } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import create from './create.mjs';
+import create from './create.mts';
 
 const __dirname = import.meta.dirname;
 

--- a/scripts/release-checks/dependency-ranges/index.mts
+++ b/scripts/release-checks/dependency-ranges/index.mts
@@ -8,8 +8,8 @@
 
 import { Log, ReleasePrecheckError, bold } from '@angular/ng-dev';
 import semver from 'semver';
-import { checkSchematicsAngularLatestVersion } from './latest-versions-check.mjs';
-import { PackageJson, checkPeerDependencies } from './peer-deps-check.mjs';
+import { checkSchematicsAngularLatestVersion } from './latest-versions-check.mts';
+import { type PackageJson, checkPeerDependencies } from './peer-deps-check.mts';
 
 /** Environment variable that can be used to skip this pre-check. */
 const skipEnvVar = 'SKIP_DEPENDENCY_RANGE_PRECHECK';

--- a/scripts/snapshots.mts
+++ b/scripts/snapshots.mts
@@ -11,8 +11,8 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import build from './build.mjs';
-import jsonHelp, { createTemporaryProject } from './json-help.mjs';
-import { PackageInfo, packages } from './packages.mjs';
+import jsonHelp, { createTemporaryProject } from './json-help.mts';
+import { type PackageInfo, packages } from './packages.mts';
 
 const __dirname = import.meta.dirname;
 

--- a/scripts/templates.mts
+++ b/scripts/templates.mts
@@ -9,7 +9,7 @@
 import lodash from 'lodash';
 import { readFile, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
-import { releasePackages } from './packages.mjs';
+import { releasePackages } from './packages.mts';
 
 const __dirname = import.meta.dirname;
 

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "module": "Node16",
     "moduleResolution": "Node16",
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true,
+    "rewriteRelativeImportExtensions": true,
     "noEmit": true,
     "types": []
   },

--- a/scripts/validate-user-analytics.mts
+++ b/scripts/validate-user-analytics.mts
@@ -15,7 +15,7 @@ import {
   EventCustomDimension,
   EventCustomMetric,
   UserCustomDimension,
-} from '../packages/angular/cli/src/analytics/analytics-parameters.mjs';
+} from '../packages/angular/cli/src/analytics/analytics-parameters.ts';
 
 const __dirname = import.meta.dirname;
 const userAnalyticsTable = lodash.template(
@@ -82,7 +82,7 @@ async function _checkDimensions(dimensionsTable: string) {
   };
 
   // Find all the schemas
-  const { packages } = await import('./packages.mjs');
+  const { packages } = await import('./packages.mts');
   const packagesPaths = packages.map(({ root }) => root);
   for (const packagePath of packagesPaths) {
     const schemasPaths = await glob('**/schema.json', { cwd: packagePath });

--- a/scripts/validate.mts
+++ b/scripts/validate.mts
@@ -7,8 +7,8 @@
  */
 
 import { execSync } from 'node:child_process';
-import templates from './templates.mjs';
-import validateUserAnalytics from './validate-user-analytics.mjs';
+import templates from './templates.mts';
+import validateUserAnalytics from './validate-user-analytics.mts';
 
 export default async function (options: { verbose: boolean }) {
   let error = false;
@@ -24,7 +24,7 @@ export default async function (options: { verbose: boolean }) {
   }
 
   console.info('Running templates validation...');
-  await templates({});
+  await templates();
   if (execSync(`git status --porcelain`).toString()) {
     console.error(
       'Running templates updated files... Please run "devkit-admin templates" before submitting a PR.',


### PR DESCRIPTION
This change removes the use of `ts-node` to execute both `ng-dev` and the repo dev scripts. Due to the use of enums imports from `@angular/cli` package code for the analytics validation, the `admin` package script currently requires the `--experimental-transform-types` option.