### PR TITLE
fix(@schematics/angular): remove `inlineSources` from library tsconfig template

### DIFF
--- a/packages/schematics/angular/library/files/tsconfig.lib.json.template
+++ b/packages/schematics/angular/library/files/tsconfig.lib.json.template
@@ -6,7 +6,6 @@
     "outDir": "<%= relativePathToWorkspaceRoot %>/out-tsc/lib",
     "declaration": true,
     "declarationMap": true,
-    "inlineSources": true,
     "types": []
   },
   "include": [


### PR DESCRIPTION


This is redundant as sourcemaps are enabled internally in ng-packagr.

Closes #31665