### PR TITLE
fix(@angular/build): conditionally manage Vitest UI option

### DIFF
--- a/packages/angular/build/src/builders/unit-test/options.ts
+++ b/packages/angular/build/src/builders/unit-test/options.ts
@@ -119,7 +119,7 @@ export async function normalizeOptions(
     browserViewport: width && height ? { width, height } : undefined,
     watch,
     debug: options.debug ?? false,
-    ui: options.ui ?? false,
+    ui: process.env['CI'] ? false : ui,
     providersFile: options.providersFile && path.join(workspaceRoot, options.providersFile),
     setupFiles: options.setupFiles
       ? options.setupFiles.map((setupFile) => path.join(workspaceRoot, setupFile))

--- a/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
@@ -220,7 +220,7 @@ export class VitestExecutor implements TestExecutor {
         cache: cacheOptions.enabled ? undefined : false,
         testNamePattern: this.options.filter,
         watch,
-        ui,
+        ...(typeof ui === 'boolean' ? { ui } : {}),
         ...debugOptions,
       },
       {

--- a/packages/angular/build/src/builders/unit-test/schema.json
+++ b/packages/angular/build/src/builders/unit-test/schema.json
@@ -67,8 +67,7 @@
     },
     "ui": {
       "type": "boolean",
-      "description": "Enables the Vitest UI for interactive test execution. This option is only available for the Vitest runner.",
-      "default": false
+      "description": "Enables the Vitest UI for interactive test execution. This option is only available for the Vitest runner."
     },
     "coverage": {
       "type": "boolean",


### PR DESCRIPTION
This change improves the handling of the Vitest UI option in the unit test builder. The `ui` option is now automatically disabled when running in a CI environment to prevent issues with automated pipelines. Additionally, the `ui` property is only included in the Vitest configuration if it's explicitly a boolean, making the option handling more robust.

Removing the default value for `ui` from the schema allows the option to be overridden by custom runner configuration files when not explicitly defined in `angular.json` or via the command line.