### PR TITLE
refactor(@angular-devkit/schematics): update type usage to support isolated declarations

### DIFF
--- a/goldens/public-api/angular_devkit/schematics/tools/index.api.md
+++ b/goldens/public-api/angular_devkit/schematics/tools/index.api.md
@@ -203,7 +203,7 @@ export class NodeModulesTestEngineHost extends NodeModulesEngineHost {
     // (undocumented)
     protected _resolveCollectionPath(name: string, requester?: string): string;
     // (undocumented)
-    get tasks(): TaskConfiguration<{}>[];
+    get tasks(): TaskConfiguration[];
     // (undocumented)
     transformContext(context: FileSystemSchematicContext): FileSystemSchematicContext;
 }

--- a/packages/angular_devkit/schematics/tasks/repo-init/init-task.ts
+++ b/packages/angular_devkit/schematics/tasks/repo-init/init-task.ts
@@ -15,12 +15,10 @@ export interface CommitOptions {
   email?: string;
 }
 
-export class RepositoryInitializerTask
-  implements TaskConfigurationGenerator<RepositoryInitializerTaskOptions>
-{
+export class RepositoryInitializerTask implements TaskConfigurationGenerator<RepositoryInitializerTaskOptions> {
   constructor(
-    public workingDirectory?: string,
-    public commitOptions?: CommitOptions,
+    public workingDirectory?: string | undefined,
+    public commitOptions?: CommitOptions | undefined,
   ) {}
 
   toConfiguration(): TaskConfiguration<RepositoryInitializerTaskOptions> {

--- a/packages/angular_devkit/schematics/testing/schematic-test-runner.ts
+++ b/packages/angular_devkit/schematics/testing/schematic-test-runner.ts
@@ -25,7 +25,7 @@ import { BuiltinTaskExecutor } from '../tasks/node';
 import { NodeModulesTestEngineHost, validateOptionsWithSchema } from '../tools';
 
 export class UnitTestTree extends DelegateTree {
-  get files() {
+  get files(): string[] {
     const result: string[] = [];
     this.visit((path) => result.push(path));
 
@@ -74,7 +74,7 @@ export class SchematicTestRunner {
     this._collection = this._engine.createCollection(this._collectionName);
   }
 
-  get engine() {
+  get engine(): SchematicEngine<{}, {}> {
     return this._engine;
   }
   get logger(): logging.Logger {
@@ -84,7 +84,7 @@ export class SchematicTestRunner {
     return [...this._engineHost.tasks];
   }
 
-  registerCollection(collectionName: string, collectionPath: string) {
+  registerCollection(collectionName: string, collectionPath: string): void {
     this._engineHost.registerCollection(collectionName, collectionPath);
   }
 

--- a/packages/angular_devkit/schematics/tools/export-ref.ts
+++ b/packages/angular_devkit/schematics/tools/export-ref.ts
@@ -26,13 +26,13 @@ export class ExportStringRef<T> {
     }
   }
 
-  get ref() {
+  get ref(): T | undefined {
     return this._ref;
   }
-  get module() {
+  get module(): string {
     return this._module;
   }
-  get path() {
+  get path(): string {
     return this._path;
   }
 }

--- a/packages/angular_devkit/schematics/tools/fallback-engine-host.ts
+++ b/packages/angular_devkit/schematics/tools/fallback-engine-host.ts
@@ -41,7 +41,7 @@ export class FallbackEngineHost implements EngineHost<{}, {}> {
 
   addHost<CollectionT extends object, SchematicT extends object>(
     host: EngineHost<CollectionT, SchematicT>,
-  ) {
+  ): void {
     this._hosts.push(host);
   }
 

--- a/packages/angular_devkit/schematics/tools/file-system-engine-host-base.ts
+++ b/packages/angular_devkit/schematics/tools/file-system-engine-host-base.ts
@@ -119,7 +119,7 @@ export abstract class FileSystemEngineHostBase implements FileSystemEngineHost {
   private _contextTransforms: ContextTransform[] = [];
   private _taskFactories = new Map<string, () => Observable<TaskExecutor>>();
 
-  listSchematicNames(collection: FileSystemCollectionDesc, includeHidden?: boolean) {
+  listSchematicNames(collection: FileSystemCollectionDesc, includeHidden?: boolean): string[] {
     const schematics: string[] = [];
     for (const key of Object.keys(collection.schematics)) {
       const schematic = collection.schematics[key];
@@ -140,11 +140,13 @@ export abstract class FileSystemEngineHostBase implements FileSystemEngineHost {
     return schematics;
   }
 
-  registerOptionsTransform<T extends object | null, R extends object>(t: OptionTransform<T, R>) {
+  registerOptionsTransform<T extends object | null, R extends object>(
+    t: OptionTransform<T, R>,
+  ): void {
     this._transforms.push(t);
   }
 
-  registerContextTransform(t: ContextTransform) {
+  registerContextTransform(t: ContextTransform): void {
     this._contextTransforms.push(t);
   }
 

--- a/packages/angular_devkit/schematics/tools/file-system-engine-host.ts
+++ b/packages/angular_devkit/schematics/tools/file-system-engine-host.ts
@@ -48,7 +48,10 @@ export class FileSystemEngineHost extends FileSystemEngineHostBase {
     throw new CollectionCannotBeResolvedException(name);
   }
 
-  protected _resolveReferenceString(refString: string, parentPath: string) {
+  protected _resolveReferenceString(
+    refString: string,
+    parentPath: string,
+  ): { ref: RuleFactory<{}>; path: string } | null {
     // Use the same kind of export strings as NodeModule.
     const ref = new ExportStringRef<RuleFactory<{}>>(refString, parentPath);
     if (!ref.ref) {

--- a/packages/angular_devkit/schematics/tools/node-module-engine-host.ts
+++ b/packages/angular_devkit/schematics/tools/node-module-engine-host.ts
@@ -106,7 +106,7 @@ export class NodeModulesEngineHost extends FileSystemEngineHostBase {
     refString: string,
     parentPath: string,
     collectionDescription?: FileSystemCollectionDesc,
-  ) {
+  ): { ref: RuleFactory<{}>; path: string } | null {
     const ref = new ExportStringRef<RuleFactory<{}>>(refString, parentPath);
     if (!ref.ref) {
       return null;

--- a/packages/angular_devkit/schematics/tools/node-modules-test-engine-host.ts
+++ b/packages/angular_devkit/schematics/tools/node-modules-test-engine-host.ts
@@ -18,15 +18,15 @@ export class NodeModulesTestEngineHost extends NodeModulesEngineHost {
   #collections = new Map<string, string>();
   #tasks: TaskConfiguration[] = [];
 
-  get tasks() {
+  get tasks(): TaskConfiguration[] {
     return this.#tasks;
   }
 
-  clearTasks() {
+  clearTasks(): void {
     this.#tasks = [];
   }
 
-  registerCollection(name: string, path: string) {
+  registerCollection(name: string, path: string): void {
     this.#collections.set(name, path);
   }
 


### PR DESCRIPTION
This commit addresses various TypeScript compilation errors that arise when the 'isolatedDeclarations' option is enabled.