### PR TITLE
refactor(@angular-devkit/schematics-cli): migrate argument parsing to node:util.parseArgs

### DIFF
--- a/packages/angular_devkit/schematics_cli/BUILD.bazel
+++ b/packages/angular_devkit/schematics_cli/BUILD.bazel
@@ -49,9 +49,7 @@ ts_project(
         ":node_modules/@angular-devkit/schematics",
         ":node_modules/@inquirer/prompts",
         ":node_modules/ansi-colors",
-        ":node_modules/yargs-parser",
         "//:node_modules/@types/node",
-        "//:node_modules/@types/yargs-parser",
     ],
 )
 

--- a/packages/angular_devkit/schematics_cli/package.json
+++ b/packages/angular_devkit/schematics_cli/package.json
@@ -19,7 +19,6 @@
     "@angular-devkit/core": "workspace:0.0.0-PLACEHOLDER",
     "@angular-devkit/schematics": "workspace:0.0.0-PLACEHOLDER",
     "@inquirer/prompts": "7.10.1",
-    "ansi-colors": "4.1.3",
-    "yargs-parser": "22.0.0"
+    "ansi-colors": "4.1.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -846,9 +846,6 @@ importers:
       ansi-colors:
         specifier: 4.1.3
         version: 4.1.3
-      yargs-parser:
-        specifier: 22.0.0
-        version: 22.0.0
 
   packages/ngtools/webpack:
     devDependencies:


### PR DESCRIPTION
This commit migrates the command-line argument parsing in the `@angular-devkit/schematics-cli` package from the external `yargs-parser` library to Node.js's native `node:util.parseArgs` API.

The updated parsing logic includes explicit definition of known CLI options, correct handling of camel-casing for schematic options, processing of `--no-` prefixes, and support for collecting multiple values for a single option.