### PR TITLE
fix(@angular/build): remove LmdbCacheStore export from private API

### DIFF
--- a/packages/angular/build/src/private.ts
+++ b/packages/angular/build/src/private.ts
@@ -36,7 +36,6 @@ export { SassWorkerImplementation } from './tools/sass/sass-service';
 
 export { SourceFileCache } from './tools/esbuild/angular/source-file-cache';
 export { Cache } from './tools/esbuild/cache';
-export { LmdbCacheStore } from './tools/esbuild/lmdb-cache-store';
 export { createJitResourceTransformer } from './tools/angular/transformers/jit-resource-transformer';
 export { JavaScriptTransformer } from './tools/esbuild/javascript-transformer';
 


### PR DESCRIPTION
This is needed as otherwise LMDB would be considered as a non optional dependency.

Closes #32110