### PR TITLE
refactor(@angular-devkit/architect-cli): replace ansi-colors with node:util.styleText

### DIFF
--- a/packages/angular_devkit/architect_cli/BUILD.bazel
+++ b/packages/angular_devkit/architect_cli/BUILD.bazel
@@ -19,7 +19,6 @@ ts_project(
     deps = [
         ":node_modules/@angular-devkit/architect",
         ":node_modules/@angular-devkit/core",
-        ":node_modules/ansi-colors",
         ":node_modules/yargs-parser",
         "//:node_modules/@types/node",
         "//:node_modules/@types/yargs-parser",

--- a/packages/angular_devkit/architect_cli/bin/architect.ts
+++ b/packages/angular_devkit/architect_cli/bin/architect.ts
@@ -11,9 +11,9 @@ import { Architect } from '@angular-devkit/architect';
 import { WorkspaceNodeModulesArchitectHost } from '@angular-devkit/architect/node';
 import { JsonValue, json, logging, schema, tags, workspaces } from '@angular-devkit/core';
 import { NodeJsSyncHost, createConsoleLogger } from '@angular-devkit/core/node';
-import * as ansiColors from 'ansi-colors';
 import { existsSync } from 'node:fs';
 import * as path from 'node:path';
+import { styleText } from 'node:util';
 import yargsParser, { camelCase, decamelize } from 'yargs-parser';
 
 function findUp(names: string | string[], from: string) {
@@ -58,9 +58,6 @@ function usage(logger: logging.Logger, exitCode = 0): never {
   return process.exit(exitCode);
 }
 
-// Create a separate instance to prevent unintended global changes to the color configuration
-const colors = ansiColors.create();
-
 async function _executeTarget(
   parentLogger: logging.Logger,
   workspace: workspaces.WorkspaceDefinition,
@@ -100,9 +97,9 @@ async function _executeTarget(
   try {
     const result = await run.lastOutput;
     if (result.success) {
-      parentLogger.info(colors.green('SUCCESS'));
+      parentLogger.info(styleText(['green'], 'SUCCESS'));
     } else {
-      parentLogger.info(colors.red('FAILURE'));
+      parentLogger.info(styleText(['red'], 'FAILURE'));
     }
     parentLogger.info('Result: ' + JSON.stringify({ ...result, info: undefined }, null, 4));
 
@@ -114,7 +111,7 @@ async function _executeTarget(
 
     return result.success ? 0 : 1;
   } catch (err) {
-    parentLogger.info(colors.red('ERROR'));
+    parentLogger.info(styleText(['red'], 'ERROR'));
     parentLogger.info('\nLogs:');
     logs.forEach((l) => parentLogger.next(l));
 
@@ -141,9 +138,9 @@ async function main(args: string[]): Promise<number> {
   const logger = createConsoleLogger(argv['verbose'], process.stdout, process.stderr, {
     info: (s) => s,
     debug: (s) => s,
-    warn: (s) => colors.bold.yellow(s),
-    error: (s) => colors.bold.red(s),
-    fatal: (s) => colors.bold.red(s),
+    warn: (s) => styleText(['yellow', 'bold'], s),
+    error: (s) => styleText(['red', 'bold'], s),
+    fatal: (s) => styleText(['red', 'bold'], s),
   });
 
   // Check the target.

--- a/packages/angular_devkit/architect_cli/package.json
+++ b/packages/angular_devkit/architect_cli/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "@angular-devkit/architect": "workspace:0.0.0-EXPERIMENTAL-PLACEHOLDER",
     "@angular-devkit/core": "workspace:0.0.0-PLACEHOLDER",
-    "ansi-colors": "4.1.3",
     "yargs-parser": "22.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -568,9 +568,6 @@ importers:
       '@angular-devkit/core':
         specifier: workspace:0.0.0-PLACEHOLDER
         version: link:../core
-      ansi-colors:
-        specifier: 4.1.3
-        version: 4.1.3
       yargs-parser:
         specifier: 22.0.0
         version: 22.0.0


### PR DESCRIPTION
This commit removes the external dependency 'ansi-colors' from the `@angular-devkit/architect-cli` package and replaces its usage with the native 'node:util.styleText' function for console output styling. This change reduces the project's dependency footprint and leverages built-in Node.js functionality.