### PR TITLE
refactor(@angular-devkit/schematics-cli): replace ansi-colors with node:util.styleText

### DIFF
--- a/packages/angular_devkit/schematics_cli/BUILD.bazel
+++ b/packages/angular_devkit/schematics_cli/BUILD.bazel
@@ -48,7 +48,6 @@ ts_project(
         ":node_modules/@angular-devkit/core",
         ":node_modules/@angular-devkit/schematics",
         ":node_modules/@inquirer/prompts",
-        ":node_modules/ansi-colors",
         "//:node_modules/@types/node",
     ],
 )

--- a/packages/angular_devkit/schematics_cli/bin/schematics.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics.ts
@@ -11,10 +11,9 @@ import { JsonValue, logging, schema } from '@angular-devkit/core';
 import { ProcessOutput, createConsoleLogger } from '@angular-devkit/core/node';
 import { UnsuccessfulWorkflowExecution, strings } from '@angular-devkit/schematics';
 import { NodeWorkflow } from '@angular-devkit/schematics/tools';
-import ansiColors from 'ansi-colors';
 import { existsSync } from 'node:fs';
 import * as path from 'node:path';
-import { parseArgs } from 'node:util';
+import { parseArgs, styleText } from 'node:util';
 
 /**
  * Parse the name of schematic passed in argument, and return a {collection, schematic} named
@@ -223,16 +222,13 @@ export async function main({
 }: MainOptions): Promise<0 | 1> {
   const { cliOptions, schematicOptions, _ } = parseOptions(args);
 
-  // Create a separate instance to prevent unintended global changes to the color configuration
-  const colors = ansiColors.create();
-
   /** Create the DevKit Logger used through the CLI. */
   const logger = createConsoleLogger(!!cliOptions.verbose, stdout, stderr, {
     info: (s) => s,
     debug: (s) => s,
-    warn: (s) => colors.bold.yellow(s),
-    error: (s) => colors.bold.red(s),
-    fatal: (s) => colors.bold.red(s),
+    warn: (s) => styleText(['bold', 'yellow'], s),
+    error: (s) => styleText(['bold', 'red'], s),
+    fatal: (s) => styleText(['bold', 'red'], s),
   });
 
   if (cliOptions.help) {
@@ -315,21 +311,21 @@ export async function main({
       case 'update':
         loggingQueue.push(
           // TODO: `as unknown` was necessary during TS 5.9 update. Figure out a long-term solution.
-          `${colors.cyan('UPDATE')} ${eventPath} (${(event.content as unknown as Buffer).length} bytes)`,
+          `${styleText(['cyan'], 'UPDATE')} ${eventPath} (${(event.content as unknown as Buffer).length} bytes)`,
         );
         break;
       case 'create':
         loggingQueue.push(
           // TODO: `as unknown` was necessary during TS 5.9 update. Figure out a long-term solution.
-          `${colors.green('CREATE')} ${eventPath} (${(event.content as unknown as Buffer).length} bytes)`,
+          `${styleText(['green'], 'CREATE')} ${eventPath} (${(event.content as unknown as Buffer).length} bytes)`,
         );
         break;
       case 'delete':
-        loggingQueue.push(`${colors.yellow('DELETE')} ${eventPath}`);
+        loggingQueue.push(`${styleText(['yellow'], 'DELETE')} ${eventPath}`);
         break;
       case 'rename':
         loggingQueue.push(
-          `${colors.blue('RENAME')} ${eventPath} => ${removeLeadingSlash(event.to)}`,
+          `${styleText(['blue'], 'RENAME')} ${eventPath} => ${removeLeadingSlash(event.to)}`,
         );
         break;
     }

--- a/packages/angular_devkit/schematics_cli/package.json
+++ b/packages/angular_devkit/schematics_cli/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "@angular-devkit/core": "workspace:0.0.0-PLACEHOLDER",
     "@angular-devkit/schematics": "workspace:0.0.0-PLACEHOLDER",
-    "@inquirer/prompts": "7.10.1",
-    "ansi-colors": "4.1.3"
+    "@inquirer/prompts": "7.10.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -833,9 +833,6 @@ importers:
       '@inquirer/prompts':
         specifier: 7.10.1
         version: 7.10.1(@types/node@24.10.2)
-      ansi-colors:
-        specifier: 4.1.3
-        version: 4.1.3
 
   packages/ngtools/webpack:
     devDependencies:


### PR DESCRIPTION
This commit removes the external dependency 'ansi-colors' from the `@angular-devkit/schematics-cli` package and replaces its usage with the native 'node:util.styleText' function for console output styling. This change reduces the project's dependency footprint and leverages built-in Node.js functionality.