### PR TITLE
refactor(@angular-devkit/build-angular): remove redundant spinner coloring

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/index.ts
@@ -43,7 +43,6 @@ import {
   normalizeOptimization,
   urlJoin,
 } from '../../utils';
-import { colors } from '../../utils/color';
 import { copyAssets } from '../../utils/copy-assets';
 import { assertIsError } from '../../utils/error';
 import { i18nInlineEmittedFiles } from '../../utils/i18n-inlining';
@@ -280,7 +279,7 @@ export function buildWebpackBrowser(
                       );
                       spinner.succeed('Copying assets complete.');
                     } catch (err) {
-                      spinner.fail(colors.redBright('Copying of assets failed.'));
+                      spinner.fail('Copying of assets failed.');
                       assertIsError(err);
 
                       return {

--- a/packages/angular_devkit/build_angular/src/builders/server/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/index.ts
@@ -28,7 +28,6 @@ import {
   deleteOutputDir,
   normalizeAssetPatterns,
 } from '../../utils';
-import { colors } from '../../utils/color';
 import { copyAssets } from '../../utils/copy-assets';
 import { assertIsError } from '../../utils/error';
 import { i18nInlineEmittedFiles } from '../../utils/i18n-inlining';
@@ -121,7 +120,7 @@ export function execute(
               );
               spinner.succeed('Copying assets complete.');
             } catch (err) {
-              spinner.fail(colors.redBright('Copying of assets failed.'));
+              spinner.fail('Copying of assets failed.');
               assertIsError(err);
 
               return {


### PR DESCRIPTION
This commit refactors the usage of the `Spinner` class in `@angular-devkit/build-angular` builders by removing explicit `colors.redBright` calls when invoking `spinner.fail()`.

The `Spinner.fail()` method already applies red bright coloring internally. This change centralizes the styling logic within the `Spinner` class and prevents redundant coloring or unnecessary dependency usage at the call site.