### PR TITLE
ci: add 'less' to Renovate's ignored dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,25 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "baseBranchPatterns": [
-    "main",
-    "21.0.x"
-  ],
-  "extends": [
-    "github>angular/dev-infra//renovate-presets/default.json5"
-  ],
-  "ignorePaths": [
-    "tests/legacy-cli/e2e/assets/**",
-    "tests/schematics/update/packages/**"
-  ],
+  "baseBranchPatterns": ["main", "21.0.x"],
+  "extends": ["github>angular/dev-infra//renovate-presets/default.json5"],
+  "ignoreDeps": ["less"],
+  "ignorePaths": ["tests/legacy-cli/e2e/assets/**", "tests/schematics/update/packages/**"],
   "packageRules": [
     {
       "enabled": false,
-      "matchFileNames": [
-        "tests/legacy-cli/e2e/ng-snapshot/package.json"
-      ],
-      "matchBaseBranches": [
-        "!main"
-      ]
+      "matchFileNames": ["tests/legacy-cli/e2e/ng-snapshot/package.json"],
+      "matchBaseBranches": ["!main"]
     },
     {
       "matchFileNames": [
@@ -27,9 +16,7 @@
         "packages/angular_devkit/schematics_cli/schematic/files/package.json",
         "packages/schematics/angular/utility/latest-versions/package.json"
       ],
-      "matchPackageNames": [
-        "*"
-      ],
+      "matchPackageNames": ["*"],
       "groupName": "schematics dependencies",
       "lockFileMaintenance": {
         "enabled": false


### PR DESCRIPTION
It seems that the recent less releases are unintended.

See: https://github.com/less/less.js/issues/4394
