### PR TITLE
fix(@angular/build): ensure tests run when compilation error is resolved

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
@@ -90,7 +90,7 @@ export class VitestExecutor implements TestExecutor {
     if (buildResult.kind === ResultKind.Incremental) {
       // To rerun tests, Vitest needs the original test file paths, not the output paths.
       const modifiedSourceFiles = new Set<string>();
-      for (const modifiedFile of buildResult.modified) {
+      for (const modifiedFile of [...buildResult.modified, ...buildResult.added]) {
         // The `modified` files in the build result are the output paths.
         // We need to find the original source file path to pass to Vitest.
         const source = this.entryPointToTestFile.get(modifiedFile);

--- a/packages/angular/build/src/builders/unit-test/tests/behavior/watch_rebuild_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/behavior/watch_rebuild_spec.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { execute } from '../../index';
+import {
+  BASE_OPTIONS,
+  describeBuilder,
+  UNIT_TEST_BUILDER_INFO,
+  setupApplicationTarget,
+} from '../setup';
+
+describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
+  describe('Watch Mode Behavior', () => {
+    beforeEach(async () => {
+      setupApplicationTarget(harness);
+    });
+
+    it('should run tests when a compilation error is fixed and a test failure is introduced simultaneously', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        watch: true,
+      });
+
+      await harness.executeWithCases([
+        // 1. Initial success
+        ({ result }) => {
+          expect(result?.success).toBeTrue();
+
+          // 2. Introduce compilation error
+          harness.writeFiles({
+            'src/app/app.component.spec.ts': `
+              import { describe, expect, test } from 'vitest'
+              describe('AppComponent', () => {
+                test('should create the app', () => {
+                  expect(true).toBe(true); // Syntax error incoming
+                  const x: string = 1; // Type error
+                });
+              });`,
+          });
+        },
+        // 3. Expect compilation error
+        ({ result }) => {
+          expect(result?.success).toBeFalse();
+
+          // 4. Fix compilation error BUT introduce test failure
+          harness.writeFiles({
+            'src/app/app.component.spec.ts': `
+              import { describe, expect, test } from 'vitest'
+              describe('AppComponent', () => {
+                test('should create the app', () => {
+                  expect(true).toBe(false); // Logic failure
+                });
+              });`,
+          });
+        },
+        // 5. Expect test failure (NOT success, which would happen if the test was skipped)
+        ({ result }) => {
+          expect(result?.success).toBeFalse();
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
This commit fixes an issue in the Vitest unit test runner where tests would sometimes fail to re-run after a compilation error was resolved in watch mode.

The issue occurred because the incremental build result's `added` files were not being included in the list of modified files passed to the test runner. When a file had a compilation error, it might be treated as "added" in the subsequent successful build, and previously it was ignored.

Closes #32122