### PR TITLE
refactor(@angular-devkit/architect-cli): remove yargs-parser dependency

### DIFF
--- a/packages/angular_devkit/architect_cli/BUILD.bazel
+++ b/packages/angular_devkit/architect_cli/BUILD.bazel
@@ -19,9 +19,7 @@ ts_project(
     deps = [
         ":node_modules/@angular-devkit/architect",
         ":node_modules/@angular-devkit/core",
-        ":node_modules/yargs-parser",
         "//:node_modules/@types/node",
-        "//:node_modules/@types/yargs-parser",
     ],
 )
 

--- a/packages/angular_devkit/architect_cli/package.json
+++ b/packages/angular_devkit/architect_cli/package.json
@@ -15,7 +15,6 @@
   ],
   "dependencies": {
     "@angular-devkit/architect": "workspace:0.0.0-EXPERIMENTAL-PLACEHOLDER",
-    "@angular-devkit/core": "workspace:0.0.0-PLACEHOLDER",
-    "yargs-parser": "22.0.0"
+    "@angular-devkit/core": "workspace:0.0.0-PLACEHOLDER"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -568,9 +568,6 @@ importers:
       '@angular-devkit/core':
         specifier: workspace:0.0.0-PLACEHOLDER
         version: link:../core
-      yargs-parser:
-        specifier: 22.0.0
-        version: 22.0.0
 
   packages/angular_devkit/build_angular:
     dependencies:


### PR DESCRIPTION
Replaces `yargs-parser` with `node:util` `parseArgs` in the architect CLI binary. This aligns the argument parsing logic with other CLI tools in the repo and removes an external dependency.