### PR TITLE
fix(@angular/ssr): add leading slash to well-known non-Angular URLs

### DIFF
--- a/packages/angular/ssr/src/app.ts
+++ b/packages/angular/ssr/src/app.ts
@@ -34,8 +34,8 @@ import { buildPathWithParams, joinUrlParts, stripLeadingSlash } from './utils/ur
  * bypass the Angular routing and rendering process.
  */
 const WELL_KNOWN_NON_ANGULAR_URLS: ReadonlySet<string> = new Set<string>([
-  'favicon.ico',
-  '.well-known/appspecific/com.chrome.devtools.json',
+  '/favicon.ico',
+  '/.well-known/appspecific/com.chrome.devtools.json',
 ]);
 
 /**

--- a/packages/angular/ssr/test/app_spec.ts
+++ b/packages/angular/ssr/test/app_spec.ts
@@ -139,6 +139,14 @@ describe('AngularServerApp', () => {
   });
 
   describe('handle', () => {
+    it('should return null for well-known non-angular URLs', async () => {
+      const response = await app.handle(
+        new Request('http://localhost/.well-known/appspecific/com.chrome.devtools.json'),
+      );
+
+      expect(response).toBeNull();
+    });
+
     describe('CSR and SSG pages', () => {
       it('should correctly render the content for the requested page', async () => {
         const response = await app.handle(new Request('http://localhost/home'));


### PR DESCRIPTION
Pathnames always start with slash.