### PR TITLE
fix(@angular/cli): rename mcp devserver tools to comply with naming spec

### DIFF
--- a/packages/angular/cli/src/commands/mcp/tools/build.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/build.ts
@@ -97,7 +97,7 @@ Perform a one-off, non-watched build using "ng build". Use this tool whenever th
 </Use Cases>
 <Operational Notes>
 * This tool runs "ng build" so it expects to run within an Angular workspace.
-* If you want a watched build which updates as files are changed, use "devserver/start" instead, which also serves the app.
+* If you want a watched build which updates as files are changed, use "devserver.start" instead, which also serves the app.
 * You can provide a project instead of building the root one. The "list_projects" MCP tool could be used to obtain the list of projects.
 * This tool defaults to a development environment while a regular "ng build" defaults to a production environment. An unexpected build
   failure might suggest the project is not configured for the requested environment.

--- a/packages/angular/cli/src/commands/mcp/tools/devserver/devserver-start.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/devserver/devserver-start.ts
@@ -66,26 +66,26 @@ export const DEVSERVER_START_TOOL: McpToolDeclaration<
   typeof devserverStartToolInputSchema.shape,
   typeof devserverStartToolOutputSchema.shape
 > = declareTool({
-  name: 'devserver/start',
+  name: 'devserver.start',
   title: 'Start Development Server',
   description: `
 <Purpose>
-Starts the Angular development server ("ng serve") as a background process. Follow this up with "devserver/wait_for_build" to wait until
+Starts the Angular development server ("ng serve") as a background process. Follow this up with "devserver.wait_for_build" to wait until
 the first build completes.
 </Purpose>
 <Use Cases>
 * **Starting the Server:** Use this tool to begin serving the application. The tool will return immediately while the server runs in the
   background.
-* **Get Initial Build Logs:** Once a dev server has started, use the "devserver/wait_for_build" tool to ensure it's alive. If there are any
-  build errors, "devserver/wait_for_build" would provide them back and you can give them to the user or rely on them to propose a fix.
-* **Get Updated Build Logs:** Important: as long as a devserver is alive (i.e. "devserver/stop" wasn't called), after every time you make a
-  change to the workspace, re-run "devserver/wait_for_build" to see whether the change was successfully built and wait for the devserver to
+* **Get Initial Build Logs:** Once a dev server has started, use the "devserver.wait_for_build" tool to ensure it's alive. If there are any
+  build errors, "devserver.wait_for_build" would provide them back and you can give them to the user or rely on them to propose a fix.
+* **Get Updated Build Logs:** Important: as long as a devserver is alive (i.e. "devserver.stop" wasn't called), after every time you make a
+  change to the workspace, re-run "devserver.wait_for_build" to see whether the change was successfully built and wait for the devserver to
   be updated.
 </Use Cases>
 <Operational Notes>
 * This tool manages development servers by itself. It maintains at most a single dev server instance for each project in the monorepo.
 * This is an asynchronous operation. Subsequent commands can be ran while the server is active.
-* Use 'devserver/stop' to gracefully shut down the server and access the full log output.
+* Use 'devserver.stop' to gracefully shut down the server and access the full log output.
 </Operational Notes>
 `,
   isReadOnly: true,

--- a/packages/angular/cli/src/commands/mcp/tools/devserver/devserver-stop.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/devserver/devserver-stop.ts
@@ -53,11 +53,11 @@ export const DEVSERVER_STOP_TOOL: McpToolDeclaration<
   typeof devserverStopToolInputSchema.shape,
   typeof devserverStopToolOutputSchema.shape
 > = declareTool({
-  name: 'devserver/stop',
+  name: 'devserver.stop',
   title: 'Stop Development Server',
   description: `
 <Purpose>
-Stops a running Angular development server ("ng serve") that was started with the "devserver/start" tool.
+Stops a running Angular development server ("ng serve") that was started with the "devserver.start" tool.
 </Purpose>
 <Use Cases>
 * **Stopping the Server:** Use this tool to terminate a running development server and retrieve the logs.

--- a/packages/angular/cli/src/commands/mcp/tools/devserver/devserver-wait-for-build.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/devserver/devserver-wait-for-build.ts
@@ -89,26 +89,26 @@ export const DEVSERVER_WAIT_FOR_BUILD_TOOL: McpToolDeclaration<
   typeof devserverWaitForBuildToolInputSchema.shape,
   typeof devserverWaitForBuildToolOutputSchema.shape
 > = declareTool({
-  name: 'devserver/wait_for_build',
+  name: 'devserver.wait_for_build',
   title: 'Wait for Devserver Build',
   description: `
 <Purpose>
-Waits for a dev server that was started with the "devserver/start" tool to complete its build, then reports the build logs from its most
+Waits for a dev server that was started with the "devserver.start" tool to complete its build, then reports the build logs from its most
 recent build.
 </Purpose>
 <Use Cases>
-* **Waiting for a build:** As long as a devserver is alive ("devserver/start" was called for this project and "devserver_stop" wasn't
+* **Waiting for a build:** As long as a devserver is alive ("devserver.start" was called for this project and "devserver.stop" wasn't
   called yet), then if you're making a file change and want to ensure it was successfully built, call this tool instead of any other build
   tool or command. When it retuns you'll get build logs back **and** you'll know the user's devserver is up-to-date with the latest changes.
 </Use Cases>
 <Operational Notes>
-* This tool expects that a dev server was launched on the same project with the "devserver/start" tool, otherwise a "no_devserver_found"
+* This tool expects that a dev server was launched on the same project with the "devserver.start" tool, otherwise a "no_devserver_found"
   status will be returned.
 * This tool will block until the build is complete or the timeout is reached. If you expect a long build process, consider increasing the
-  timeout. Timeouts on initial run (right after "devserver/start" calls) or after a big change are not necessarily indicative of an error.
+  timeout. Timeouts on initial run (right after "devserver.start" calls) or after a big change are not necessarily indicative of an error.
 * If you encountered a timeout and it might be reasonable, just call this tool again.
 * If the dev server is not building, it will return quickly, with the logs from the last build.
-* A 'no_devserver_found' status can indicate the underlying server was stopped for some reason. Try first to call the "devserver/start"
+* A 'no_devserver_found' status can indicate the underlying server was stopped for some reason. Try first to call the "devserver.start"
   tool again, before giving up.
 </Operational Notes>
 `,


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ ] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
This fixes a warning about invalid characters in tool names as per the spec: https://modelcontextprotocol.io/specification/draft/server/tools#tool-names

```
2025-12-17 16:32:44.992 [warning] [server stderr] Tool name validation warning for "devserver/wait_for_build":
2025-12-17 16:32:44.992 [warning] [server stderr]   - Tool name contains invalid characters: "/"
```

## What is the new behavior?

This change renames `devserver/start`, `devserver/stop`, and `devserver/wait_for_build` to `devserver.start`, `devserver.stop`, and `devserver.wait_for_build` respectively.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
