### PR TITLE
refactor(@angular-devkit/architect): consolidate architect cli into core package

### DIFF
--- a/packages/angular_devkit/architect/BUILD.bazel
+++ b/packages/angular_devkit/architect/BUILD.bazel
@@ -110,6 +110,8 @@ npm_package(
         "README.md",
         ":architect",
         ":license",
+        "//packages/angular_devkit/architect/bin",
+        "//packages/angular_devkit/architect/bin:cli.js",
         "//packages/angular_devkit/architect/node",
         "//packages/angular_devkit/architect/testing",
     ],

--- a/packages/angular_devkit/architect/bin/BUILD.bazel
+++ b/packages/angular_devkit/architect/bin/BUILD.bazel
@@ -1,0 +1,28 @@
+# Copyright Google Inc. All Rights Reserved.
+#
+# Use of this source code is governed by an MIT-style license that can be
+# found in the LICENSE file at https://angular.dev/license
+
+load("//tools:defaults.bzl", "ts_project")
+
+licenses(["notice"])
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files([
+    "cli.js",
+])
+
+ts_project(
+    name = "bin",
+    srcs = glob(
+        include = ["**/*.ts"],
+        exclude = ["**/*_spec.ts"],
+    ),
+    deps = [
+        "//:node_modules/@types/node",
+        "//packages/angular_devkit/architect",
+        "//packages/angular_devkit/architect:node_modules/@angular-devkit/core",
+        "//packages/angular_devkit/architect/node",
+    ],
+)

--- a/packages/angular_devkit/architect/bin/architect.ts
+++ b/packages/angular_devkit/architect/bin/architect.ts
@@ -7,13 +7,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { Architect } from '@angular-devkit/architect';
-import { WorkspaceNodeModulesArchitectHost } from '@angular-devkit/architect/node';
 import { JsonValue, json, logging, schema, strings, tags, workspaces } from '@angular-devkit/core';
 import { NodeJsSyncHost, createConsoleLogger } from '@angular-devkit/core/node';
 import { existsSync } from 'node:fs';
 import * as path from 'node:path';
 import { parseArgs, styleText } from 'node:util';
+import { Architect } from '../index';
+import { WorkspaceNodeModulesArchitectHost } from '../node/index';
 
 function findUp(names: string | string[], from: string) {
   if (!Array.isArray(names)) {

--- a/packages/angular_devkit/architect/bin/cli.js
+++ b/packages/angular_devkit/architect/bin/cli.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+require('./architect');

--- a/packages/angular_devkit/architect/package.json
+++ b/packages/angular_devkit/architect/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0-EXPERIMENTAL-PLACEHOLDER",
   "description": "Angular Build Facade",
   "experimental": true,
+  "bin": {
+    "architect": "./bin/cli.js"
+  },
   "main": "src/index.js",
   "typings": "src/index.d.ts",
   "dependencies": {

--- a/packages/angular_devkit/architect_cli/BUILD.bazel
+++ b/packages/angular_devkit/architect_cli/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:defaults.bzl", "npm_package", "ts_project")
+load("//tools:defaults.bzl", "npm_package")
 
 # Copyright Google Inc. All Rights Reserved.
 #
@@ -10,18 +10,6 @@ licenses(["notice"])
 package(default_visibility = ["//visibility:public"])
 
 npm_link_all_packages()
-
-ts_project(
-    name = "architect_cli",
-    srcs = [
-        "bin/architect.ts",
-    ],
-    deps = [
-        ":node_modules/@angular-devkit/architect",
-        ":node_modules/@angular-devkit/core",
-        "//:node_modules/@types/node",
-    ],
-)
 
 genrule(
     name = "license",
@@ -34,12 +22,11 @@ npm_package(
     name = "pkg",
     pkg_deps = [
         "//packages/angular_devkit/architect:package.json",
-        "//packages/angular_devkit/core:package.json",
     ],
     tags = ["release-package"],
     deps = [
         ":README.md",
-        ":architect_cli",
+        ":bin/cli.js",
         ":license",
     ],
 )

--- a/packages/angular_devkit/architect_cli/bin/cli.js
+++ b/packages/angular_devkit/architect_cli/bin/cli.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import '@angular-devkit/architect/bin/architect.js';

--- a/packages/angular_devkit/architect_cli/package.json
+++ b/packages/angular_devkit/architect_cli/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@angular-devkit/architect-cli",
   "version": "0.0.0-EXPERIMENTAL-PLACEHOLDER",
+  "type": "module",
   "description": "Angular Architect CLI",
   "homepage": "https://github.com/angular/angular-cli",
   "experimental": true,
   "bin": {
-    "architect": "./bin/architect.js"
+    "architect": "./bin/cli.js"
   },
   "keywords": [
     "build system",
@@ -14,7 +15,6 @@
     "tooling"
   ],
   "dependencies": {
-    "@angular-devkit/architect": "workspace:0.0.0-EXPERIMENTAL-PLACEHOLDER",
-    "@angular-devkit/core": "workspace:0.0.0-PLACEHOLDER"
+    "@angular-devkit/architect": "workspace:0.0.0-EXPERIMENTAL-PLACEHOLDER"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -565,9 +565,6 @@ importers:
       '@angular-devkit/architect':
         specifier: workspace:0.0.0-EXPERIMENTAL-PLACEHOLDER
         version: link:../architect
-      '@angular-devkit/core':
-        specifier: workspace:0.0.0-PLACEHOLDER
-        version: link:../core
 
   packages/angular_devkit/build_angular:
     dependencies:

--- a/tests/e2e/tests/architect_cli/direct_execution.ts
+++ b/tests/e2e/tests/architect_cli/direct_execution.ts
@@ -1,0 +1,14 @@
+import * as assert from 'node:assert/strict';
+import { exec } from '../../utils/process';
+import { join } from 'node:path';
+
+export default async function () {
+  // Run help command
+  const binPath = join('node_modules', '.bin', 'architect');
+  const { stdout } = await exec(binPath, '--help');
+
+  assert.ok(
+    stdout.includes('architect [project][:target][:configuration] [options, ...]'),
+    'Expected stdout to contain usage information.',
+  );
+}

--- a/tests/e2e/tests/architect_cli/package_execution.ts
+++ b/tests/e2e/tests/architect_cli/package_execution.ts
@@ -1,0 +1,22 @@
+import * as assert from 'node:assert/strict';
+import { exec } from '../../utils/process';
+import { installPackage, uninstallPackage } from '../../utils/packages';
+import { join } from 'node:path';
+
+export default async function () {
+  // Install CLI package
+  installPackage('@angular-devkit/architect-cli');
+
+  try {
+    // Run help command
+    const binPath = join('node_modules', '.bin', 'architect');
+    const { stdout } = await exec(binPath, '--help');
+
+    assert.ok(
+      stdout.includes('architect [project][:target][:configuration] [options, ...]'),
+      'Expected stdout to contain usage information.',
+    );
+  } finally {
+    uninstallPackage('@angular-devkit/architect-cli');
+  }
+}


### PR DESCRIPTION
Moves the `architect` CLI implementation from `@angular-devkit/architect-cli` into the `@angular-devkit/architect` package itself.

This change aims to make the `@angular-devkit/architect` package more self-contained by hosting its own CLI entry point. The `@angular-devkit/architect-cli` package now serves as a lightweight wrapper, importing the `architect` binary directly from the core package.