### PR TITLE
build: restore `ng-dev` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "postinstall": "husky",
     "ts-circular-deps": "ng-dev ts-circular-deps --config ./scripts/circular-deps-test.conf.mjs",
     "check-tooling-setup": "tsc --project .ng-dev/tsconfig.json",
-    "diff-release-package": "node scripts/diff-release-package.mts"
+    "diff-release-package": "node scripts/diff-release-package.mts",
+    "ng-dev": "ng-dev"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This got dropped in https://github.com/angular/angular-cli/pull/32088/, but is needed because the release process calls `pnpm run ng-dev`, which requires a script to exist. Meanwhile `pnpm ng-dev` does not.