### PR TITLE
test: migrate i18n E2E tests to Puppeteer

### DIFF
--- a/tests/e2e/tests/i18n/ivy-localize-basehref.ts
+++ b/tests/e2e/tests/i18n/ivy-localize-basehref.ts
@@ -9,7 +9,14 @@
 import { expectFileToMatch } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
-import { baseHrefs, externalServer, langTranslations, setupI18nConfig } from './setup';
+import { executeBrowserTest } from '../../utils/puppeteer';
+import {
+  baseHrefs,
+  browserCheck,
+  externalServer,
+  langTranslations,
+  setupI18nConfig,
+} from './setup';
 
 export default async function () {
   // Setup i18n tests and config.
@@ -50,18 +57,12 @@ export default async function () {
     await expectFileToMatch(`${outputPath}/index.html`, `href="${baseHrefs[lang] || '/'}"`);
 
     // Execute Application E2E tests for a production build without dev server
-    const { server, port, url } = await externalServer(
-      outputPath,
-      (baseHrefs[lang] as string) || '/',
-    );
+    const { server, url } = await externalServer(outputPath, (baseHrefs[lang] as string) || '/');
     try {
-      await ng(
-        'e2e',
-        `--port=${port}`,
-        `--configuration=${lang}`,
-        '--dev-server-target=',
-        `--base-url=${url}`,
-      );
+      await executeBrowserTest({
+        baseUrl: url,
+        checkFn: (page) => browserCheck(page, lang),
+      });
     } finally {
       server.close();
     }
@@ -81,18 +82,12 @@ export default async function () {
     await expectFileToMatch(`${outputPath}/index.html`, `href="/test${baseHrefs[lang] || '/'}"`);
 
     // Execute Application E2E tests for a production build without dev server
-    const { server, port, url } = await externalServer(
-      outputPath,
-      '/test' + (baseHrefs[lang] || '/'),
-    );
+    const { server, url } = await externalServer(outputPath, '/test' + (baseHrefs[lang] || '/'));
     try {
-      await ng(
-        'e2e',
-        `--port=${port}`,
-        `--configuration=${lang}`,
-        '--dev-server-target=',
-        `--base-url=${url}`,
-      );
+      await executeBrowserTest({
+        baseUrl: url,
+        checkFn: (page) => browserCheck(page, lang),
+      });
     } finally {
       server.close();
     }

--- a/tests/e2e/tests/i18n/ivy-localize-es2015-e2e.ts
+++ b/tests/e2e/tests/i18n/ivy-localize-es2015-e2e.ts
@@ -1,13 +1,14 @@
-import { getGlobalVariable } from '../../utils/env';
-import { ng } from '../../utils/process';
-import { langTranslations, setupI18nConfig } from './setup';
+import { executeBrowserTest } from '../../utils/puppeteer';
+import { browserCheck, langTranslations, setupI18nConfig } from './setup';
 
 export default async function () {
   // Setup i18n tests and config.
   await setupI18nConfig();
 
   for (const { lang } of langTranslations) {
-    // Execute Application E2E tests with dev server
-    await ng('e2e', `--configuration=${lang}`, '--port=0');
+    await executeBrowserTest({
+      configuration: lang,
+      checkFn: (page) => browserCheck(page, lang),
+    });
   }
 }

--- a/tests/e2e/tests/i18n/ivy-localize-es2015.ts
+++ b/tests/e2e/tests/i18n/ivy-localize-es2015.ts
@@ -1,8 +1,9 @@
 import { getGlobalVariable } from '../../utils/env';
 import { expectFileToMatch } from '../../utils/fs';
 import { ng } from '../../utils/process';
+import { executeBrowserTest } from '../../utils/puppeteer';
 import { expectToFail } from '../../utils/utils';
-import { externalServer, langTranslations, setupI18nConfig } from './setup';
+import { browserCheck, externalServer, langTranslations, setupI18nConfig } from './setup';
 
 export default async function () {
   // Setup i18n tests and config.
@@ -32,15 +33,12 @@ export default async function () {
     await expectFileToMatch(`${outputPath}/index.html`, `lang="${lang}"`);
 
     // Execute Application E2E tests for a production build without dev server
-    const { server, port, url } = await externalServer(outputPath, `/${lang}/`);
+    const { server, url } = await externalServer(outputPath, `/${lang}/`);
     try {
-      await ng(
-        'e2e',
-        `--port=${port}`,
-        `--configuration=${lang}`,
-        '--dev-server-target=',
-        `--base-url=${url}`,
-      );
+      await executeBrowserTest({
+        baseUrl: url,
+        checkFn: (page) => browserCheck(page, lang),
+      });
     } finally {
       server.close();
     }

--- a/tests/e2e/tests/i18n/ivy-localize-locale-data-augment.ts
+++ b/tests/e2e/tests/i18n/ivy-localize-locale-data-augment.ts
@@ -1,14 +1,9 @@
 import { getGlobalVariable } from '../../utils/env';
-import {
-  expectFileToMatch,
-  prependToFile,
-  readFile,
-  replaceInFile,
-  writeFile,
-} from '../../utils/fs';
+import { expectFileToMatch, prependToFile, readFile, writeFile } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
-import { langTranslations, setupI18nConfig } from './setup';
+import { executeBrowserTest } from '../../utils/puppeteer';
+import { browserCheck, langTranslations, setupI18nConfig } from './setup';
 
 export default async function () {
   // Setup i18n tests and config.
@@ -19,9 +14,6 @@ export default async function () {
     const appProject = workspaceJson.projects['test-project'];
     appProject.architect['build'].options.localize = ['fr'];
   });
-
-  // Update E2E test to look for augmented locale data
-  await replaceInFile('./e2e/src/app.fr.e2e-spec.ts', 'janvier', 'changed-janvier');
 
   // Augment the locale data and import into the main application file
   const localeData = await readFile('node_modules/@angular/common/locales/global/fr.js');
@@ -45,6 +37,27 @@ export default async function () {
     }
 
     // Execute Application E2E tests with dev server
-    await ng('e2e', `--configuration=${lang}`, '--port=0');
+    await executeBrowserTest({
+      configuration: lang,
+      checkFn: async (page) => {
+        // Run standard checks but expect failure on date
+        try {
+          await browserCheck(page, lang);
+          throw new Error('Expected browserCheck to fail due to modified locale data');
+        } catch (e) {
+          if (!(e instanceof Error) || !e.message.includes("Expected 'date' to be")) {
+            throw e;
+          }
+        }
+
+        // Verify the modified date
+        const getParagraph = async (id: string) =>
+          page.$eval(`p#${id}`, (el) => el.textContent?.trim());
+        const date = await getParagraph('date');
+        if (date !== 'changed-janvier') {
+          throw new Error(`Expected 'date' to be 'changed-janvier', but got '${date}'.`);
+        }
+      },
+    });
   }
 }

--- a/tests/e2e/tests/i18n/ivy-localize-sub-path.ts
+++ b/tests/e2e/tests/i18n/ivy-localize-sub-path.ts
@@ -10,7 +10,8 @@ import { join } from 'node:path';
 import { expectFileToMatch } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
-import { baseDir, baseHrefs, externalServer, langTranslations, setupI18nConfig } from './setup';
+import { executeBrowserTest } from '../../utils/puppeteer';
+import { baseDir, browserCheck, externalServer, langTranslations, setupI18nConfig } from './setup';
 
 export default async function () {
   // Setup i18n tests and config.
@@ -56,16 +57,13 @@ export default async function () {
     await expectFileToMatch(`${outputPath}/index.html`, `href="${baseHref}"`);
 
     // Execute Application E2E tests for a production build without dev server
-    const { server, port, url } = await externalServer(outputPath, baseHref);
+    const { server, url } = await externalServer(outputPath, baseHref);
 
     try {
-      await ng(
-        'e2e',
-        `--port=${port}`,
-        `--configuration=${lang}`,
-        '--dev-server-target=',
-        `--base-url=${url}`,
-      );
+      await executeBrowserTest({
+        baseUrl: url,
+        checkFn: (page) => browserCheck(page, lang),
+      });
     } finally {
       server.close();
     }


### PR DESCRIPTION
Replaces the Protractor-based `ng e2e` execution with the new Puppeteer `executeBrowserTest` utility in the i18n E2E test suite.

Refactors `setup.ts` to export a `browserCheck` helper function for verifying translated content, and removes the legacy Protractor spec file generation and configuration.

Updates the following tests to use the new infrastructure:
- ivy-localize-es2015-e2e
- ivy-localize-basehref
- ivy-localize-es2015
- ivy-localize-locale-data-augment
- ivy-localize-sub-path