### PR TITLE
refactor(@angular/build): export compiler plugin and stylesheet options types

### DIFF
--- a/packages/angular/build/src/private.ts
+++ b/packages/angular/build/src/private.ts
@@ -59,6 +59,7 @@ export function createCompilerPlugin(
   );
 }
 
+export type { CompilerPluginOptions, BundleStylesheetOptions };
 export type { AngularCompilation } from './tools/angular/compilation';
 export { DiagnosticModes } from './tools/angular/compilation';
 export { createAngularCompilation };


### PR DESCRIPTION
Exposes `CompilerPluginOptions` and `BundleStylesheetOptions` via the private API. These types are required for consumers of the `createCompilerPlugin` function to strictly type their configuration.