### PR TITLE
fix(@schematics/angular): update application schematics for module-based apps to use 'provideZoneChangeDetection'

### DIFF
--- a/packages/schematics/angular/application/files/module-files/src/app/app__typeSeparator__module.ts.template
+++ b/packages/schematics/angular/application/files/module-files/src/app/app__typeSeparator__module.ts.template
@@ -1,4 +1,4 @@
-import { NgModule, provideBrowserGlobalErrorListeners } from '@angular/core';
+import { NgModule, provideBrowserGlobalErrorListeners<% if(!zoneless) { %>, provideZoneChangeDetection<% } %> } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 <% if (routing) { %>
 import { AppRoutingModule } from './app-routing<%= typeSeparator %>module';<% } %>
@@ -13,7 +13,8 @@ import { App } from './app<%= suffix %>';
     AppRoutingModule<% } %>
   ],
   providers: [
-    provideBrowserGlobalErrorListeners()
+    provideBrowserGlobalErrorListeners(),<% if(!zoneless) { %>
+    provideZoneChangeDetection({ eventCoalescing: true }),<% } %>
   ],
   bootstrap: [App]
 })

--- a/packages/schematics/angular/application/files/module-files/src/main.ts.template
+++ b/packages/schematics/angular/application/files/module-files/src/main.ts.template
@@ -1,10 +1,8 @@
 <% if(!!viewEncapsulation) { %>import { ViewEncapsulation } from '@angular/core';
-<% }%><% if(!zoneless) { %>import { provideZoneChangeDetection } from '@angular/core';
 <% }%>import { platformBrowser } from '@angular/platform-browser';
 import { AppModule } from './app/app<%= typeSeparator %>module';
 
 platformBrowser().bootstrapModule(AppModule, {
-  <% if(!zoneless) { %> applicationProviders: [provideZoneChangeDetection({ eventCoalescing: true })], <% } %>
   <% if(!!viewEncapsulation) { %> defaultEncapsulation: ViewEncapsulation.<%= viewEncapsulation %><% } %>
 })
   .catch(err => console.error(err));

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -698,10 +698,8 @@ describe('Application Schematic', () => {
         workspaceTree,
       );
 
-      const content = tree.readContent('/projects/foo/src/main.ts');
-      expect(content).toContain(
-        'applicationProviders: [provideZoneChangeDetection({ eventCoalescing: true })]',
-      );
+      const content = tree.readContent('/projects/foo/src/app/app-module.ts');
+      expect(content).toContain('provideZoneChangeDetection({ eventCoalescing: true })');
     });
 
     it(`should set 'defaultEncapsulation' in main.ts when 'ViewEncapsulation' is provided`, async () => {
@@ -892,6 +890,17 @@ describe('Application Schematic', () => {
     });
 
     describe('standalone: false', () => {
+      it('should add the provideZoneChangeDetection with event coalescing option by default with zone.js apps', async () => {
+        const options = {
+          ...defaultOptions,
+          standalone: false,
+          zoneless: false,
+          fileNameStyleGuide: '2016' as const,
+        };
+        const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+        const content = tree.readContent('/projects/foo/src/app/app.module.ts');
+        expect(content).toContain('provideZoneChangeDetection({ eventCoalescing: true })');
+      });
       it('should create a component with the correct template and style urls', async () => {
         const options = {
           ...defaultOptions,

--- a/packages/schematics/angular/utility/standalone/rules_spec.ts
+++ b/packages/schematics/angular/utility/standalone/rules_spec.ts
@@ -422,7 +422,7 @@ describe('standalone utilities', () => {
       assertContains(content, `import { SOME_TOKEN } from '@my/module';`);
       assertContains(
         content,
-        `providers: [provideBrowserGlobalErrorListeners(),{ provide: SOME_TOKEN, useValue: 123 }]`,
+        `providers: [provideBrowserGlobalErrorListeners(),{ provide: SOME_TOKEN, useValue: 123 },]`,
       );
     });
 


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the new behavior?

This PR provides changes in scaffolding module-based apps that removes usage of deprecated `ngZoneEventCoalescing` and adds `provideZoneChangeDetection({ eventCoalescing: true })` in root module, to be in line with changes from https://github.com/angular/angular-cli/pull/30718.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
