### PR TITLE
test: migrate `app-shell-with-service-worker` E2E test to Puppeteer

### DIFF
--- a/tests/e2e/utils/puppeteer.ts
+++ b/tests/e2e/utils/puppeteer.ts
@@ -18,7 +18,7 @@ export async function executeBrowserTest(options: BrowserTestOptions = {}) {
     if (!url) {
       // Start serving and find address (1 - Webpack; 2 - Vite)
       const match = /(?:open your browser on|Local:)\s+(http:\/\/localhost:\d+\/)/;
-      const serveArgs = ['serve', '--port=0'];
+      const serveArgs = ['serve', '--port=0', '--no-watch', '--no-live-reload'];
       if (options.project) {
         serveArgs.push(options.project);
       }


### PR DESCRIPTION
Replaces the Protractor-based ng e2e execution with the new Puppeteer executeBrowserTest utility in `build/app-shell/app-shell-with-service-worker.ts` E2E test.