### PR TITLE
feat(@angular/build): disable TestBed teardown during debugging in Vitest

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
@@ -17,6 +17,7 @@ import { RunnerOptions } from '../api';
 function createTestBedInitVirtualFile(
   providersFile: string | undefined,
   projectSourceRoot: string,
+  teardown: boolean,
   polyfills: string[] = [],
 ): string {
   const usesZoneJS = polyfills.includes('zone.js');
@@ -58,6 +59,7 @@ function createTestBedInitVirtualFile(
       getTestBed().initTestEnvironment([BrowserTestingModule, TestModule], platformBrowserTesting(), {
         errorOnUnknownElements: true,
         errorOnUnknownProperties: true,
+        ${teardown === false ? 'teardown: { destroyAfterEach: false },' : ''}
       });
     }
   `;
@@ -133,6 +135,7 @@ export async function getVitestBuildOptions(
   const testBedInitContents = createTestBedInitVirtualFile(
     providersFile,
     projectSourceRoot,
+    !options.debug,
     buildOptions.polyfills,
   );
 


### PR DESCRIPTION
When running unit tests in debug mode, it is beneficial to keep the component's DOM state intact after the test completes for inspection. This change disables the automatic TestBed teardown (destroyAfterEach) when the 'debug' option is enabled.

Closes #31733