### PR TITLE
fix(@angular/build): ensure correct project targeting during Vitest debugging

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/index.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/index.ts
@@ -67,7 +67,7 @@ const VitestTestRunner: TestRunner = {
       context.logger.info('Automatically searching for and using Vitest configuration file.');
     }
 
-    return new VitestExecutor(projectName, options, testEntryPointMappings);
+    return new VitestExecutor(projectName, options, testEntryPointMappings, context.logger);
   },
 };
 


### PR DESCRIPTION
This addresses issue #31652 where debugging failed to target the correct project instance. When running browser tests, Vitest appends the browser name to the project identifier. This change updates the CLI to match that naming convention when initiating a debug session, ensuring the correct project is selected.

Fixes #31652