### PR TITLE
build: remove `@modelcontextprotocol/sdk` from the `minimumReleaseAgeExclude` list in `pnpm-workspace.yaml`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,6 @@ minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - '@angular-devkit/*'
   - '@angular/*'
-  - '@modelcontextprotocol/sdk@1.25.2' # Fix: https://www.cve.org/CVERecord?id=CVE-2026-0621
   - '@ngtools/webpack'
   - '@schematics/*'
   - 'ng-packagr'


### PR DESCRIPTION

This is no longer needed.
