### PR TITLE
feat(@schematics/angular): add prettier dependency by default with --skip-prettier flag added to skip prettier install

### DIFF
--- a/packages/schematics/angular/utility/latest-versions/package.json
+++ b/packages/schematics/angular/utility/latest-versions/package.json
@@ -18,6 +18,7 @@
     "jsdom": "^27.1.0",
     "less": "^4.2.0",
     "postcss": "^8.5.3",
+    "prettier": "^3.7.4",
     "protractor": "~7.0.0",
     "rxjs": "~7.8.0",
     "tailwindcss": "^4.1.12",

--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development"<% if (!minimal) { %>,
     "test": "ng test"<% } %>
-  },
+  },<% if (!skipPrettier) { %>
   "prettier": {
     "printWidth": 100,
     "singleQuote": true,
@@ -19,7 +19,7 @@
         }
       }
     ]
-  },
+  },<% } %>
   "private": true,
   <% if (packageManagerWithVersion) { %>"packageManager": "<%= packageManagerWithVersion %>",<% } %>
   "dependencies": {
@@ -34,7 +34,8 @@
   },
   "devDependencies": {
     "@angular/cli": "<%= '^' + version %>",
-    "@angular/compiler-cli": "<%= latestVersions.Angular %>",
+    "@angular/compiler-cli": "<%= latestVersions.Angular %>",<% if (!skipPrettier) { %>
+    "prettier": "<%= latestVersions['prettier'] %>",<% } %>
     "typescript": "<%= latestVersions['typescript'] %>"
   }
 }

--- a/packages/schematics/angular/workspace/index_spec.ts
+++ b/packages/schematics/angular/workspace/index_spec.ts
@@ -135,9 +135,24 @@ describe('Workspace Schematic', () => {
     expect(tasks).not.toContain(jasmine.objectContaining({ type: 'npm', script: 'test' }));
   });
 
-  it('should include prettier config overrides for Angular templates', async () => {
+  it('should include prettier config and dependency by default', async () => {
     const tree = await schematicRunner.runSchematic('workspace', defaultOptions);
     const pkg = JSON.parse(tree.readContent('/package.json'));
     expect(pkg.prettier).withContext('package.json#prettier is present').toBeTruthy();
+    expect(pkg.devDependencies['prettier'])
+      .withContext('prettier is in devDependencies')
+      .toEqual(latestVersions['prettier']);
+  });
+
+  it('should not include prettier config and dependency when skipPrettier is true', async () => {
+    const tree = await schematicRunner.runSchematic('workspace', {
+      ...defaultOptions,
+      skipPrettier: true,
+    });
+    const pkg = JSON.parse(tree.readContent('/package.json'));
+    expect(pkg.prettier).withContext('package.json#prettier should not be present').toBeUndefined();
+    expect(pkg.devDependencies['prettier'])
+      .withContext('prettier should not be in devDependencies')
+      .toBeUndefined();
   });
 });

--- a/packages/schematics/angular/workspace/schema.json
+++ b/packages/schematics/angular/workspace/schema.json
@@ -44,6 +44,11 @@
       "$default": {
         "$source": "packageManager"
       }
+    },
+    "skipPrettier": {
+      "description": "Skip adding Prettier configuration and dependency to the workspace.",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": ["name", "version"]


### PR DESCRIPTION
Add prettier as a devDependency by default when creating a new workspace since the prettier configuration is already being added to package.json.

Users can opt-out using the --skip-prettier flag which will skip both the prettier configuration and dependency.



## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently, prettier configuration are added but prettier is not installed.

Issue Number: #32216

## What is the new behavior?

Prettier will be installed by default and  --skip-prettier flag will skip installation and adding the configuration

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
