### PR TITLE
build: add 'update' option for Vitest runner and corresponding tests

### DIFF
--- a/goldens/public-api/angular/build/index.api.md
+++ b/goldens/public-api/angular/build/index.api.md
@@ -242,6 +242,7 @@ export type UnitTestBuilderOptions = {
     setupFiles?: string[];
     tsConfig?: string;
     ui?: boolean;
+    update?: boolean;
     watch?: boolean;
 };
 

--- a/packages/angular/build/src/builders/unit-test/options.ts
+++ b/packages/angular/build/src/builders/unit-test/options.ts
@@ -54,10 +54,14 @@ export async function normalizeOptions(
   const buildTargetSpecifier = options.buildTarget ?? `::development`;
   const buildTarget = targetFromTargetString(buildTargetSpecifier, projectName, 'build');
 
-  const { runner, browsers, progress, filter, browserViewport, ui, runnerConfig } = options;
+  const { runner, browsers, progress, filter, browserViewport, ui, runnerConfig, update } = options;
 
   if (ui && runner !== Runner.Vitest) {
     throw new Error('The "ui" option is only available for the "vitest" runner.');
+  }
+
+  if (update && runner !== Runner.Vitest) {
+    throw new Error('The "update" option is only available for the "vitest" runner.');
   }
 
   const [width, height] = browserViewport?.split('x').map(Number) ?? [];
@@ -132,6 +136,7 @@ export async function normalizeOptions(
           ? true
           : path.resolve(workspaceRoot, runnerConfig)
         : runnerConfig,
+    update: update ?? false,
   };
 }
 

--- a/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
@@ -238,6 +238,7 @@ export class VitestExecutor implements TestExecutor {
         watch,
         ...(typeof ui === 'boolean' ? { ui } : {}),
         ...debugOptions,
+        update: this.options.update,
       },
       {
         // Note `.vitest` is auto appended to the path.

--- a/packages/angular/build/src/builders/unit-test/schema.json
+++ b/packages/angular/build/src/builders/unit-test/schema.json
@@ -269,6 +269,11 @@
       "description": "Dumps build output files to the `.angular/cache` directory for debugging purposes.",
       "default": false,
       "visible": false
+    },
+    "update": {
+      "type": "boolean",
+      "description": "Updates test snapshots to match the current test output. This option is only available for the Vitest runner.",
+      "default": false
     }
   },
   "additionalProperties": false,

--- a/packages/angular/build/src/builders/unit-test/tests/options/update_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/update_spec.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { execute } from '../../index';
+import {
+  BASE_OPTIONS,
+  describeBuilder,
+  UNIT_TEST_BUILDER_INFO,
+  setupApplicationTarget,
+} from '../setup';
+
+describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
+  describe('Option: "update"', () => {
+    beforeEach(() => {
+      setupApplicationTarget(harness);
+    });
+
+    it('should work with update flag enabled', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        update: true,
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBeTrue();
+    });
+
+    it('should work with update flag disabled', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        update: false,
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBeTrue();
+    });
+
+    it('should work without update flag (default)', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBeTrue();
+    });
+  });
+});


### PR DESCRIPTION
Fixes #32218

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

We cannot pass `--update` option while running tests in Vitest

Issue Number: #32218

## What is the new behavior?

<!-- Please describe the new behavior that. -->

We can pass `--update` option while running tests in Vitest

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
