### PR TITLE
fix(@angular/cli): use dedicated cache directory for temporary package installs

### DIFF
--- a/packages/angular/cli/src/commands/add/cli.ts
+++ b/packages/angular/cli/src/commands/add/cli.ts
@@ -33,6 +33,7 @@ import {
 import { assertIsError } from '../../utilities/error';
 import { isTTY } from '../../utilities/tty';
 import { VERSION } from '../../utilities/version';
+import { getCacheConfig } from '../cache/utilities';
 
 class CommandError extends Error {}
 
@@ -299,7 +300,8 @@ export default class AddCommandModule
     task: AddCommandTaskWrapper,
   ): Promise<void> {
     context.packageManager = await createPackageManager({
-      cwd: this.context.root,
+      cacheDirectory: getCacheConfig(this.context.workspace).path,
+      root: this.context.root,
       logger: this.context.logger,
       dryRun: context.dryRun,
     });

--- a/packages/angular/cli/src/commands/update/cli.ts
+++ b/packages/angular/cli/src/commands/update/cli.ts
@@ -30,6 +30,7 @@ import {
   getProjectDependencies,
   readPackageJson,
 } from '../../utilities/package-tree';
+import { getCacheConfig } from '../cache/utilities';
 import {
   checkCLIVersion,
   coerceVersionNumber,
@@ -172,7 +173,8 @@ export default class UpdateCommandModule extends CommandModule<UpdateCommandArgs
     const { logger } = this.context;
     // Instantiate the package manager
     const packageManager = await createPackageManager({
-      cwd: this.context.root,
+      root: this.context.root,
+      cacheDirectory: getCacheConfig(this.context.workspace).path,
       logger,
       configuredPackageManager: this.context.packageManager.name,
     });

--- a/packages/angular/cli/src/package-managers/factory.ts
+++ b/packages/angular/cli/src/package-managers/factory.ts
@@ -8,7 +8,7 @@
 
 import { major } from 'semver';
 import { discover } from './discovery';
-import { Host, NodeJS_HOST } from './host';
+import { Host, createNodeJsHost } from './host';
 import { Logger } from './logger';
 import { PackageManager } from './package-manager';
 import { PackageManagerName, SUPPORTED_PACKAGE_MANAGERS } from './package-manager-descriptor';
@@ -106,13 +106,14 @@ async function determinePackageManager(
  * @returns A promise that resolves to a new `PackageManager` instance.
  */
 export async function createPackageManager(options: {
-  cwd: string;
+  root: string;
+  cacheDirectory: string;
   configuredPackageManager?: PackageManagerName;
   logger?: Logger;
   dryRun?: boolean;
 }): Promise<PackageManager> {
-  const { cwd, configuredPackageManager, logger, dryRun } = options;
-  const host = NodeJS_HOST;
+  const { root: cwd, cacheDirectory, configuredPackageManager, logger, dryRun } = options;
+  const host = createNodeJsHost(cwd, cacheDirectory);
 
   const { name, source } = await determinePackageManager(
     host,

--- a/packages/angular/cli/src/package-managers/package-manager.ts
+++ b/packages/angular/cli/src/package-managers/package-manager.ts
@@ -546,9 +546,11 @@ export class PackageManager {
     // Writing an empty package.json file beforehand prevents this.
     await this.host.writeFile(join(workingDirectory, 'package.json'), '{}');
 
-    const flags = [options.ignoreScripts ? this.descriptor.ignoreScriptsFlag : ''].filter(
-      (flag) => flag,
-    );
+    const flags = [];
+    if (options.ignoreScripts) {
+      flags.push(this.descriptor.ignoreScriptsFlag);
+    }
+
     const args: readonly string[] = [this.descriptor.addCommand, specifier, ...flags];
 
     try {

--- a/tests/e2e/utils/registry.ts
+++ b/tests/e2e/utils/registry.ts
@@ -70,30 +70,21 @@ export async function createNpmConfigForAuthentication(
   const token = invalidToken ? `invalid=` : VALID_TOKEN;
   const registry = (getGlobalVariable('package-secure-registry') as string).replace(/^\w+:/, '');
 
+  // `always-auth is required for yarn classic.
+  // See: https://www.verdaccio.org/docs/setup-yarn#yarn-classic-1x
   await writeFile(
     '.npmrc',
     scopedAuthentication
       ? `
-${registry}/:_auth="${token}"
-registry=http:${registry}
-`
+  ${registry}/:_auth="${token}"
+  registry=http:${registry}
+  always-auth = true
+  `
       : `
-_auth="${token}"
-registry=http:${registry}
-`,
-  );
-
-  await writeFile(
-    '.yarnrc',
-    scopedAuthentication
-      ? `
-${registry}/:_auth "${token}"
-registry http:${registry}
-`
-      : `
-_auth "${token}"
-registry http:${registry}
-`,
+  _auth="${token}"
+  registry=http:${registry}
+  always-auth = true
+  `,
   );
 }
 


### PR DESCRIPTION

Relocates temporary package installations to a dedicated cache directory. This ensures that the project's `.npmrc` is correctly respected, as the installer does relies on the current working directory (CWD) rather than flags like `--prefix`.
