### PR TITLE
refactor: improve `findUp` utility correctness and performance

### DIFF
--- a/packages/angular/cli/src/utilities/project.ts
+++ b/packages/angular/cli/src/utilities/project.ts
@@ -10,7 +10,7 @@ import { normalize } from '@angular-devkit/core';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { findUp } from './find-up';
+import { findUpSync } from './find-up';
 
 interface PackageDependencies {
   dependencies?: Record<string, string>;
@@ -19,7 +19,7 @@ interface PackageDependencies {
 
 export function findWorkspaceFile(currentDirectory = process.cwd()): string | null {
   const possibleConfigFiles = ['angular.json', '.angular.json'];
-  const configFilePath = findUp(possibleConfigFiles, currentDirectory);
+  const configFilePath = findUpSync(possibleConfigFiles, currentDirectory);
   if (configFilePath === null) {
     return null;
   }

--- a/packages/angular_devkit/architect/bin/architect.ts
+++ b/packages/angular_devkit/architect/bin/architect.ts
@@ -16,21 +16,23 @@ import { Architect } from '../index';
 import { WorkspaceNodeModulesArchitectHost } from '../node/index';
 
 function findUp(names: string | string[], from: string) {
-  if (!Array.isArray(names)) {
-    names = [names];
-  }
-  const root = path.parse(from).root;
+  const filenames = Array.isArray(names) ? names : [names];
 
-  let currentDir = from;
-  while (currentDir && currentDir !== root) {
-    for (const name of names) {
+  let currentDir = path.resolve(from);
+  while (true) {
+    for (const name of filenames) {
       const p = path.join(currentDir, name);
       if (existsSync(p)) {
         return p;
       }
     }
 
-    currentDir = path.dirname(currentDir);
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      break;
+    }
+
+    currentDir = parentDir;
   }
 
   return null;

--- a/packages/angular_devkit/schematics_cli/bin/schematics.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics.ts
@@ -177,21 +177,23 @@ function _createPromptProvider(): schema.PromptProvider {
 }
 
 function findUp(names: string | string[], from: string) {
-  if (!Array.isArray(names)) {
-    names = [names];
-  }
-  const root = path.parse(from).root;
+  const filenames = Array.isArray(names) ? names : [names];
 
-  let currentDir = from;
-  while (currentDir && currentDir !== root) {
-    for (const name of names) {
+  let currentDir = path.resolve(from);
+  while (true) {
+    for (const name of filenames) {
       const p = path.join(currentDir, name);
       if (existsSync(p)) {
         return p;
       }
     }
 
-    currentDir = path.dirname(currentDir);
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      break;
+    }
+
+    currentDir = parentDir;
   }
 
   return null;


### PR DESCRIPTION
This change modernizes the `findUp` utility across the codebase. Replaced `path.parse().root` with `path.dirname(dir) === dir` check. Introduced an asynchronous version (`findUp`) in the CLI utility and renamed the synchronous version to `findUpSync` to align with Node.js conventions. Updated `packages/angular/cli/src/utilities/config.ts` to use the asynchronous `findUp` for non-blocking configuration discovery.