### PR TITLE
refactor(@angular/cli): decouple `AnalyticsCollector` from `CommandContext`

### DIFF
--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -32,10 +32,6 @@
     "packages/angular/build/src/utils/server-rendering/manifest.ts"
   ],
   [
-    "packages/angular/cli/src/analytics/analytics-collector.ts",
-    "packages/angular/cli/src/command-builder/command-module.ts"
-  ],
-  [
     "packages/angular/cli/src/analytics/analytics.ts",
     "packages/angular/cli/src/command-builder/command-module.ts"
   ]

--- a/packages/angular/cli/src/command-builder/command-module.ts
+++ b/packages/angular/cli/src/command-builder/command-module.ts
@@ -60,8 +60,10 @@ export interface CommandContext {
 
 export type OtherOptions = Record<string, unknown>;
 
-export interface CommandModuleImplementation<T extends {} = {}>
-  extends Omit<YargsCommandModule<{}, T>, 'builder' | 'handler'> {
+export interface CommandModuleImplementation<T extends {} = {}> extends Omit<
+  YargsCommandModule<{}, T>,
+  'builder' | 'handler'
+> {
   /** Scope in which the command can be executed in. */
   scope: CommandScope;
 
@@ -187,7 +189,12 @@ export abstract class CommandModule<T extends {} = {}> implements CommandModuleI
       ['version', 'update', 'analytics'].includes(this.commandName),
     );
 
-    return userId ? new AnalyticsCollector(this.context, userId) : undefined;
+    return userId
+      ? new AnalyticsCollector(this.context.logger, userId, {
+          name: this.context.packageManager.name,
+          version: this.context.packageManager.version,
+        })
+      : undefined;
   }
 
   /**


### PR DESCRIPTION
The `AnalyticsCollector` class is made more modular and easier to test by removing its direct dependency on the `CommandContext`. Instead of accepting the entire context object, the constructor now receives only the specific dependencies it requires: the logger, user ID, and package manager information.
Also removes a circular reference:
`packages/angular/cli/src/analytics/analytics-collector.ts` → `packages/angular/cli/src/command-builder/command-module.ts`