### PR TITLE
docs: release notes for the v21.0.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="21.0.6"></a>
+
+# 21.0.6 (2026-01-14)
+
+### @angular/ssr
+
+| Commit                                                                                              | Type | Description                                  |
+| --------------------------------------------------------------------------------------------------- | ---- | -------------------------------------------- |
+| [730ae6609](https://github.com/angular/angular-cli/commit/730ae6609b847802124a5c6e12c77522af54b967) | fix  | handle platform destruction during rendering |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="21.1.0-rc.0"></a>
 
 # 21.1.0-rc.0 (2026-01-08)


### PR DESCRIPTION
Cherry-picks the changelog from the "21.0.x" branch to the next branch (main).