### PR TITLE
feat(@angular/cli): standardize MCP tools around workspace/project options

### DIFF
--- a/packages/angular/cli/src/commands/mcp/shared-options.ts
+++ b/packages/angular/cli/src/commands/mcp/shared-options.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { z } from 'zod';
+
+export const workspaceAndProjectOptions = {
+  workspace: z
+    .string()
+    .optional()
+    .describe(
+      'The path to the workspace directory (containing angular.json). If not provided, uses the current directory.',
+    ),
+  project: z
+    .string()
+    .optional()
+    .describe(
+      'Which project to target in a monorepo context. If not provided, targets the default project.',
+    ),
+};

--- a/packages/angular/cli/src/commands/mcp/testing/test-utils.ts
+++ b/packages/angular/cli/src/commands/mcp/testing/test-utils.ts
@@ -42,6 +42,13 @@ export interface MockContextOptions {
 }
 
 /**
+ * Same as McpToolContext, just with guaranteed nonnull workspace.
+ */
+export interface MockMcpToolContext extends McpToolContext {
+  workspace: AngularWorkspace;
+}
+
+/**
  * Creates a comprehensive mock for the McpToolContext, including a mock Host,
  * an AngularWorkspace, and a ProjectDefinitionCollection. This simplifies testing
  * MCP tools by providing a consistent and configurable testing environment.
@@ -50,15 +57,14 @@ export interface MockContextOptions {
  */
 export function createMockContext(options: MockContextOptions = {}): {
   host: MockHost;
-  context: McpToolContext;
+  context: MockMcpToolContext;
   projects: workspaces.ProjectDefinitionCollection;
-  workspace: AngularWorkspace;
 } {
   const host = options.host ?? createMockHost();
   const projects = new workspaces.ProjectDefinitionCollection(options.projects);
   const workspace = new AngularWorkspace({ projects, extensions: {} }, '/test/angular.json');
 
-  const context: McpToolContext = {
+  const context: MockMcpToolContext = {
     server: {} as unknown as McpServer,
     workspace,
     logger: { warn: () => {} },
@@ -66,7 +72,7 @@ export function createMockContext(options: MockContextOptions = {}): {
     host,
   };
 
-  return { host, context, projects, workspace };
+  return { host, context, projects };
 }
 
 /**

--- a/packages/angular/cli/src/commands/mcp/tools/modernize_spec.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/modernize_spec.ts
@@ -6,38 +6,30 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { Stats } from 'fs';
-import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
-import { tmpdir } from 'os';
-import { join } from 'path';
 import { CommandError } from '../host';
 import type { MockHost } from '../testing/mock-host';
+import {
+  MockMcpToolContext,
+  addProjectToWorkspace,
+  createMockContext,
+} from '../testing/test-utils';
 import { type ModernizeOutput, runModernization } from './modernize';
 
 describe('Modernize Tool', () => {
-  let projectDir: string;
   let mockHost: MockHost;
+  let mockContext: MockMcpToolContext;
 
-  beforeEach(async () => {
-    // Create a temporary directory and a fake angular.json to satisfy the tool's project root search.
-    projectDir = await mkdtemp(join(tmpdir(), 'angular-modernize-test-'));
-    await writeFile(join(projectDir, 'angular.json'), JSON.stringify({ version: 1, projects: {} }));
+  beforeEach(() => {
+    const mock = createMockContext();
+    mockHost = mock.host;
+    mockContext = mock.context;
 
-    mockHost = {
-      runCommand: jasmine.createSpy('runCommand').and.resolveTo({ stdout: '', stderr: '' }),
-      stat: jasmine.createSpy('stat').and.resolveTo({ isDirectory: () => true } as Stats),
-      existsSync: jasmine.createSpy('existsSync').and.callFake((p: string) => {
-        return p === join(projectDir, 'angular.json');
-      }),
-    } as MockHost;
-  });
-
-  afterEach(async () => {
-    await rm(projectDir, { recursive: true, force: true });
+    addProjectToWorkspace(mock.projects, 'my-app');
+    mockContext.workspace.extensions['defaultProject'] = 'my-app';
   });
 
   it('should return instructions if no transformations are provided', async () => {
-    const { structuredContent } = (await runModernization({}, mockHost)) as {
+    const { structuredContent } = (await runModernization({}, mockContext)) as {
       structuredContent: ModernizeOutput;
     };
 
@@ -48,134 +40,71 @@ describe('Modernize Tool', () => {
     ]);
   });
 
-  it('should return instructions if no directories are provided', async () => {
-    const { structuredContent } = (await runModernization(
-      {
-        transformations: ['control-flow'],
-      },
-      mockHost,
-    )) as {
-      structuredContent: ModernizeOutput;
-    };
-
-    expect(mockHost.runCommand).not.toHaveBeenCalled();
-    expect(structuredContent?.instructions).toEqual([
-      'Provide this tool with a list of directory paths in your workspace ' +
-        'to run the modernization on.',
-    ]);
-  });
-
   it('can run a single transformation', async () => {
     const { structuredContent } = (await runModernization(
       {
-        directories: [projectDir],
         transformations: ['self-closing-tag'],
       },
-      mockHost,
+      mockContext,
     )) as { structuredContent: ModernizeOutput };
 
     expect(mockHost.runCommand).toHaveBeenCalledOnceWith(
       'ng',
-      ['generate', '@angular/core:self-closing-tag', '--path', '.'],
-      { cwd: projectDir },
+      ['generate', '@angular/core:self-closing-tag', '--project', 'my-app'],
+      { cwd: '/test' },
     );
     expect(structuredContent?.instructions).toEqual([
-      'Migration self-closing-tag on directory . completed successfully.',
+      'Migration self-closing-tag completed successfully.',
+    ]);
+  });
+
+  it('can run a single transformation with path', async () => {
+    const { structuredContent } = (await runModernization(
+      {
+        transformations: ['self-closing-tag'],
+        path: '.',
+      },
+      mockContext,
+    )) as { structuredContent: ModernizeOutput };
+
+    expect(mockHost.runCommand).toHaveBeenCalledOnceWith(
+      'ng',
+      ['generate', '@angular/core:self-closing-tag', '--project', 'my-app', '--path', '.'],
+      { cwd: '/test' },
+    );
+    expect(structuredContent?.instructions).toEqual([
+      'Migration self-closing-tag completed successfully.',
     ]);
   });
 
   it('can run multiple transformations', async () => {
     const { structuredContent } = (await runModernization(
       {
-        directories: [projectDir],
         transformations: ['control-flow', 'self-closing-tag'],
       },
-      mockHost,
+      mockContext,
     )) as { structuredContent: ModernizeOutput };
 
     expect(mockHost.runCommand).toHaveBeenCalledTimes(2);
     expect(mockHost.runCommand).toHaveBeenCalledWith(
       'ng',
-      ['generate', '@angular/core:control-flow', '--path', '.'],
+      ['generate', '@angular/core:control-flow', '--project', 'my-app'],
       {
-        cwd: projectDir,
+        cwd: '/test',
       },
     );
     expect(mockHost.runCommand).toHaveBeenCalledWith(
       'ng',
-      ['generate', '@angular/core:self-closing-tag', '--path', '.'],
-      { cwd: projectDir },
+      ['generate', '@angular/core:self-closing-tag', '--project', 'my-app'],
+      { cwd: '/test' },
     );
-    expect(structuredContent?.logs).toBeUndefined();
+    expect(structuredContent?.logs).toEqual([]);
     expect(structuredContent?.instructions).toEqual(
       jasmine.arrayWithExactContents([
-        'Migration control-flow on directory . completed successfully.',
-        'Migration self-closing-tag on directory . completed successfully.',
+        'Migration control-flow completed successfully.',
+        'Migration self-closing-tag completed successfully.',
       ]),
     );
-  });
-
-  it('can run multiple transformations across multiple directories', async () => {
-    const subfolder1 = join(projectDir, 'subfolder1');
-    const subfolder2 = join(projectDir, 'subfolder2');
-    await mkdir(subfolder1);
-    await mkdir(subfolder2);
-
-    const { structuredContent } = (await runModernization(
-      {
-        directories: [subfolder1, subfolder2],
-        transformations: ['control-flow', 'self-closing-tag'],
-      },
-      mockHost,
-    )) as { structuredContent: ModernizeOutput };
-
-    expect(mockHost.runCommand).toHaveBeenCalledTimes(4);
-    expect(mockHost.runCommand).toHaveBeenCalledWith(
-      'ng',
-      ['generate', '@angular/core:control-flow', '--path', 'subfolder1'],
-      { cwd: projectDir },
-    );
-    expect(mockHost.runCommand).toHaveBeenCalledWith(
-      'ng',
-      ['generate', '@angular/core:self-closing-tag', '--path', 'subfolder1'],
-      { cwd: projectDir },
-    );
-    expect(mockHost.runCommand).toHaveBeenCalledWith(
-      'ng',
-      ['generate', '@angular/core:control-flow', '--path', 'subfolder2'],
-      { cwd: projectDir },
-    );
-    expect(mockHost.runCommand).toHaveBeenCalledWith(
-      'ng',
-      ['generate', '@angular/core:self-closing-tag', '--path', 'subfolder2'],
-      { cwd: projectDir },
-    );
-    expect(structuredContent?.logs).toBeUndefined();
-    expect(structuredContent?.instructions).toEqual(
-      jasmine.arrayWithExactContents([
-        'Migration control-flow on directory subfolder1 completed successfully.',
-        'Migration self-closing-tag on directory subfolder1 completed successfully.',
-        'Migration control-flow on directory subfolder2 completed successfully.',
-        'Migration self-closing-tag on directory subfolder2 completed successfully.',
-      ]),
-    );
-  });
-
-  it('should return an error if angular.json is not found', async () => {
-    mockHost.existsSync.and.returnValue(false);
-
-    const { structuredContent } = (await runModernization(
-      {
-        directories: [projectDir],
-        transformations: ['self-closing-tag'],
-      },
-      mockHost,
-    )) as { structuredContent: ModernizeOutput };
-
-    expect(mockHost.runCommand).not.toHaveBeenCalled();
-    expect(structuredContent?.instructions).toEqual([
-      'Could not find an angular.json file in the current or parent directories.',
-    ]);
   });
 
   it('should report errors from transformations', async () => {
@@ -186,20 +115,17 @@ describe('Modernize Tool', () => {
 
     const { structuredContent } = (await runModernization(
       {
-        directories: [projectDir],
         transformations: ['self-closing-tag'],
       },
-      mockHost,
+      mockContext,
     )) as { structuredContent: ModernizeOutput };
 
     expect(mockHost.runCommand).toHaveBeenCalledOnceWith(
       'ng',
-      ['generate', '@angular/core:self-closing-tag', '--path', '.'],
-      { cwd: projectDir },
+      ['generate', '@angular/core:self-closing-tag', '--project', 'my-app'],
+      { cwd: '/test' },
     );
     expect(structuredContent?.logs).toEqual(['some logs', 'Command failed with error']);
-    expect(structuredContent?.instructions).toEqual([
-      'Migration self-closing-tag on directory . failed.',
-    ]);
+    expect(structuredContent?.instructions).toEqual(['Migration self-closing-tag failed.']);
   });
 });

--- a/packages/angular/cli/src/commands/mcp/tools/onpush-zoneless-migration/migrate-test-file.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/onpush-zoneless-migration/migrate-test-file.ts
@@ -10,7 +10,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { glob } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import type { SourceFile } from 'typescript';
-import { findAngularJsonDir } from '../../utils';
+import { findAngularJsonDir } from '../../workspace-utils';
 import { createFixResponseForZoneTests, createProvideZonelessForTestsSetupPrompt } from './prompts';
 import { loadTypescript } from './ts-utils';
 import { MigrationResponse } from './types';

--- a/packages/angular/cli/src/commands/mcp/utils.ts
+++ b/packages/angular/cli/src/commands/mcp/utils.ts
@@ -11,10 +11,7 @@
  * Utility functions shared across MCP tools.
  */
 
-import { workspaces } from '@angular-devkit/core';
-import { dirname, join } from 'node:path';
-import { CommandError, LocalWorkspaceHost } from './host';
-import { McpToolContext } from './tools/tool-registry';
+import { CommandError } from './host';
 
 /**
  * Returns simple structured content output from an MCP tool.
@@ -26,74 +23,6 @@ export function createStructuredContentOutput<OutputType>(structuredContent: Out
     content: [{ type: 'text' as const, text: JSON.stringify(structuredContent, null, 2) }],
     structuredContent,
   };
-}
-
-/**
- * Searches for an angular.json file by traversing up the directory tree from a starting directory.
- *
- * @param startDir The directory path to start searching from
- * @param host The workspace host instance used to check file existence. Defaults to LocalWorkspaceHost
- * @returns The absolute path to the directory containing angular.json, or null if not found
- *
- * @remarks
- * This function performs an upward directory traversal starting from `startDir`.
- * It checks each directory for the presence of an angular.json file until either:
- * - The file is found (returns the directory path)
- * - The root of the filesystem is reached (returns null)
- */
-export function findAngularJsonDir(startDir: string, host = LocalWorkspaceHost): string | null {
-  let currentDir = startDir;
-  while (true) {
-    if (host.existsSync(join(currentDir, 'angular.json'))) {
-      return currentDir;
-    }
-    const parentDir = dirname(currentDir);
-    if (parentDir === currentDir) {
-      return null;
-    }
-    currentDir = parentDir;
-  }
-}
-
-/**
- * Searches for a project in the current workspace, by name.
- */
-export function getProject(
-  context: McpToolContext,
-  name: string,
-): workspaces.ProjectDefinition | undefined {
-  const projects = context.workspace?.projects;
-  if (!projects) {
-    return undefined;
-  }
-
-  return projects.get(name);
-}
-
-/**
- * Returns the name of the default project in the current workspace, or undefined if none exists.
- *
- * If no default project is defined but there's only a single project in the workspace, its name will
- * be returned.
- */
-export function getDefaultProjectName(context: McpToolContext): string | undefined {
-  const projects = context.workspace?.projects;
-
-  if (!projects) {
-    return undefined;
-  }
-
-  const defaultProjectName = context.workspace?.extensions['defaultProject'] as string | undefined;
-  if (defaultProjectName) {
-    return defaultProjectName;
-  }
-
-  // No default project defined? This might still be salvageable if only a single project exists.
-  if (projects.size === 1) {
-    return Array.from(projects.keys())[0];
-  }
-
-  return undefined;
 }
 
 /**

--- a/packages/angular/cli/src/commands/mcp/utils_spec.ts
+++ b/packages/angular/cli/src/commands/mcp/utils_spec.ts
@@ -6,16 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { join } from 'node:path';
-import { CommandError, LocalWorkspaceHost } from './host';
-import { addProjectToWorkspace, createMockContext } from './testing/test-utils';
-import {
-  createStructuredContentOutput,
-  findAngularJsonDir,
-  getCommandErrorLogs,
-  getDefaultProjectName,
-  getProject,
-} from './utils';
+import { CommandError } from './host';
+import { createStructuredContentOutput, getCommandErrorLogs } from './utils';
 
 describe('MCP Utils', () => {
   describe('createStructuredContentOutput', () => {
@@ -25,85 +17,6 @@ describe('MCP Utils', () => {
 
       expect(output.structuredContent).toEqual(data);
       expect(output.content).toEqual([{ type: 'text', text: JSON.stringify(data, null, 2) }]);
-    });
-  });
-
-  describe('findAngularJsonDir', () => {
-    let mockHost: typeof LocalWorkspaceHost;
-
-    beforeEach(() => {
-      mockHost = {
-        existsSync: jasmine.createSpy('existsSync'),
-      } as unknown as typeof LocalWorkspaceHost;
-    });
-
-    it('should return dir if angular.json exists in it', () => {
-      (mockHost.existsSync as jasmine.Spy).and.callFake(
-        (path: string) => path === join('/app', 'angular.json'),
-      );
-      expect(findAngularJsonDir('/app', mockHost)).toBe('/app');
-    });
-
-    it('should traverse up directory tree', () => {
-      (mockHost.existsSync as jasmine.Spy).and.callFake(
-        (path: string) => path === join('/app', 'angular.json'),
-      );
-      expect(findAngularJsonDir('/app/src/app', mockHost)).toBe('/app');
-    });
-
-    it('should return null if not found', () => {
-      (mockHost.existsSync as jasmine.Spy).and.returnValue(false);
-      expect(findAngularJsonDir('/app', mockHost)).toBeNull();
-    });
-  });
-
-  describe('getProject', () => {
-    it('should return undefined if workspace has no projects', () => {
-      const { context } = createMockContext();
-      const emptyContext = { ...context };
-      expect(getProject(emptyContext, 'app')).toBeUndefined();
-    });
-
-    it('should return undefined if project not found', () => {
-      const { context, projects } = createMockContext();
-      addProjectToWorkspace(projects, 'existing-app', {}, 'root');
-      expect(getProject(context, 'non-existent')).toBeUndefined();
-    });
-
-    it('should return project definition if found', () => {
-      const { context, projects } = createMockContext();
-      addProjectToWorkspace(projects, 'app', {}, 'root');
-
-      const project = getProject(context, 'app');
-      expect(project).toBeDefined();
-      expect(project?.root).toBe('root');
-    });
-  });
-
-  describe('getDefaultProjectName', () => {
-    it('should return undefined if workspace is missing', () => {
-      const { context } = createMockContext();
-      const emptyContext = { ...context, workspace: undefined };
-      expect(getDefaultProjectName(emptyContext)).toBeUndefined();
-    });
-
-    it('should return defaultProject from extensions', () => {
-      const { context, workspace } = createMockContext();
-      workspace.extensions['defaultProject'] = 'my-app';
-      expect(getDefaultProjectName(context)).toBe('my-app');
-    });
-
-    it('should return single project name if only one exists and no defaultProject', () => {
-      const { context, projects } = createMockContext();
-      addProjectToWorkspace(projects, 'only-app', {}, '');
-      expect(getDefaultProjectName(context)).toBe('only-app');
-    });
-
-    it('should return undefined if multiple projects exist and no defaultProject', () => {
-      const { context, projects } = createMockContext();
-      addProjectToWorkspace(projects, 'app1', {}, '');
-      addProjectToWorkspace(projects, 'app2', {}, '');
-      expect(getDefaultProjectName(context)).toBeUndefined();
     });
   });
 

--- a/packages/angular/cli/src/commands/mcp/workspace-utils.ts
+++ b/packages/angular/cli/src/commands/mcp/workspace-utils.ts
@@ -1,0 +1,178 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { workspaces } from '@angular-devkit/core';
+import { dirname, join } from 'node:path';
+import { AngularWorkspace } from '../../utilities/config';
+import { type Host, LocalWorkspaceHost } from './host';
+import { McpToolContext } from './tools/tool-registry';
+
+/**
+ * Searches for an angular.json file by traversing up the directory tree from a starting directory.
+ *
+ * @param startDir The directory path to start searching from
+ * @param host The workspace host instance used to check file existence. Defaults to LocalWorkspaceHost
+ * @returns The absolute path to the directory containing angular.json, or null if not found
+ *
+ * @remarks
+ * This function performs an upward directory traversal starting from `startDir`.
+ * It checks each directory for the presence of an angular.json file until either:
+ * - The file is found (returns the directory path)
+ * - The root of the filesystem is reached (returns null)
+ */
+export function findAngularJsonDir(startDir: string, host = LocalWorkspaceHost): string | null {
+  let currentDir = startDir;
+  while (true) {
+    if (host.existsSync(join(currentDir, 'angular.json'))) {
+      return currentDir;
+    }
+    const parentDir = dirname(currentDir);
+    if (parentDir === currentDir) {
+      return null;
+    }
+    currentDir = parentDir;
+  }
+}
+
+/**
+ * Searches for a project in the current workspace, by name.
+ */
+export function getProject(
+  context: McpToolContext,
+  name: string,
+): workspaces.ProjectDefinition | undefined {
+  const projects = context.workspace?.projects;
+  if (!projects) {
+    return undefined;
+  }
+
+  return projects.get(name);
+}
+
+/**
+ * Returns the name of the default project in the current workspace, or undefined if none exists.
+ *
+ * If no default project is defined but there's only a single project in the workspace, its name will
+ * be returned.
+ */
+export function getDefaultProjectName(workspace: AngularWorkspace | undefined): string | undefined {
+  const projects = workspace?.projects;
+
+  if (!projects) {
+    return undefined;
+  }
+
+  const defaultProjectName = workspace?.extensions['defaultProject'] as string | undefined;
+  if (defaultProjectName) {
+    return defaultProjectName;
+  }
+
+  // No default project defined? This might still be salvageable if only a single project exists.
+  if (projects.size === 1) {
+    return Array.from(projects.keys())[0];
+  }
+
+  return undefined;
+}
+
+/**
+ * Resolves workspace and project for tools to operate on.
+ *
+ * If `workspacePathInput` is absent, uses the MCP's configured workspace. If none is configured, use the
+ * current directory as the workspace.
+ * If `projectNameInput` is absent, uses the default project in the workspace.
+ */
+export async function resolveWorkspaceAndProject({
+  host,
+  workspacePathInput,
+  projectNameInput,
+  mcpWorkspace,
+}: {
+  host: Host;
+  workspacePathInput?: string;
+  projectNameInput?: string;
+  mcpWorkspace?: AngularWorkspace;
+}): Promise<{
+  workspace: AngularWorkspace;
+  workspacePath: string;
+  projectName: string;
+}> {
+  let workspacePath: string;
+  let workspace: AngularWorkspace;
+
+  if (workspacePathInput) {
+    if (!host.existsSync(workspacePathInput)) {
+      throw new Error(
+        `Workspace path does not exist: ${workspacePathInput}. ` +
+          "You can use 'list_projects' to find available workspaces.",
+      );
+    }
+    if (!host.existsSync(join(workspacePathInput, 'angular.json'))) {
+      throw new Error(
+        `No angular.json found at ${workspacePathInput}. ` +
+          "You can use 'list_projects' to find available workspaces.",
+      );
+    }
+    workspacePath = workspacePathInput;
+    const configPath = join(workspacePath, 'angular.json');
+    try {
+      workspace = await AngularWorkspace.load(configPath);
+    } catch (e) {
+      throw new Error(
+        `Failed to load workspace configuration at ${configPath}: ${
+          e instanceof Error ? e.message : e
+        }`,
+      );
+    }
+  } else if (mcpWorkspace) {
+    workspace = mcpWorkspace;
+    workspacePath = workspace.basePath;
+  } else {
+    const found = findAngularJsonDir(process.cwd(), host);
+
+    if (!found) {
+      throw new Error(
+        'Could not find an Angular workspace (angular.json) in the current directory. ' +
+          "You can use 'list_projects' to find available workspaces.",
+      );
+    }
+    workspacePath = found;
+    const configPath = join(workspacePath, 'angular.json');
+    try {
+      workspace = await AngularWorkspace.load(configPath);
+    } catch (e) {
+      throw new Error(
+        `Failed to load workspace configuration at ${configPath}: ${
+          e instanceof Error ? e.message : e
+        }`,
+      );
+    }
+  }
+
+  let projectName = projectNameInput;
+  if (projectName) {
+    if (!workspace.projects.has(projectName)) {
+      throw new Error(
+        `Project '${projectName}' not found in workspace path ${workspacePath}. ` +
+          "You can use 'list_projects' to find available projects.",
+      );
+    }
+  } else {
+    projectName = getDefaultProjectName(workspace);
+  }
+
+  if (!projectName) {
+    throw new Error(
+      `No project name provided and no default project found in workspace path ${workspacePath}. ` +
+        'Please provide a project name or set a default project in angular.json. ' +
+        "You can use 'list_projects' to find available projects.",
+    );
+  }
+
+  return { workspace, workspacePath, projectName };
+}

--- a/packages/angular/cli/src/commands/mcp/workspace-utils_spec.ts
+++ b/packages/angular/cli/src/commands/mcp/workspace-utils_spec.ts
@@ -1,0 +1,243 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { workspaces } from '@angular-devkit/core';
+import { join } from 'node:path';
+import { AngularWorkspace } from '../../utilities/config';
+import { LocalWorkspaceHost } from './host';
+import { addProjectToWorkspace, createMockContext, createMockHost } from './testing/test-utils';
+import {
+  findAngularJsonDir,
+  getDefaultProjectName,
+  getProject,
+  resolveWorkspaceAndProject,
+} from './workspace-utils';
+
+describe('MCP Workspace Utils', () => {
+  describe('findAngularJsonDir', () => {
+    let mockHost: typeof LocalWorkspaceHost;
+
+    beforeEach(() => {
+      mockHost = {
+        existsSync: jasmine.createSpy('existsSync'),
+      } as unknown as typeof LocalWorkspaceHost;
+    });
+
+    it('should return dir if angular.json exists in it', () => {
+      (mockHost.existsSync as jasmine.Spy).and.callFake(
+        (path: string) => path === join('/app', 'angular.json'),
+      );
+      expect(findAngularJsonDir('/app', mockHost)).toBe('/app');
+    });
+
+    it('should traverse up directory tree', () => {
+      (mockHost.existsSync as jasmine.Spy).and.callFake(
+        (path: string) => path === join('/app', 'angular.json'),
+      );
+      expect(findAngularJsonDir('/app/src/app', mockHost)).toBe('/app');
+    });
+
+    it('should return null if not found', () => {
+      (mockHost.existsSync as jasmine.Spy).and.returnValue(false);
+      expect(findAngularJsonDir('/app', mockHost)).toBeNull();
+    });
+  });
+
+  describe('getProject', () => {
+    it('should return undefined if workspace has no projects', () => {
+      const { context } = createMockContext();
+      const emptyContext = { ...context };
+      expect(getProject(emptyContext, 'app')).toBeUndefined();
+    });
+
+    it('should return undefined if project not found', () => {
+      const { context, projects } = createMockContext();
+      addProjectToWorkspace(projects, 'existing-app', {}, 'root');
+      expect(getProject(context, 'non-existent')).toBeUndefined();
+    });
+
+    it('should return project definition if found', () => {
+      const { context, projects } = createMockContext();
+      addProjectToWorkspace(projects, 'app', {}, 'root');
+
+      const project = getProject(context, 'app');
+      expect(project).toBeDefined();
+      expect(project?.root).toBe('root');
+    });
+  });
+
+  describe('getDefaultProjectName', () => {
+    it('should return undefined if workspace is missing', () => {
+      const { context } = createMockContext();
+      const emptyContext = { ...context, workspace: undefined };
+      expect(getDefaultProjectName(emptyContext.workspace)).toBeUndefined();
+    });
+
+    it('should return defaultProject from extensions', () => {
+      const { context } = createMockContext();
+      context.workspace.extensions['defaultProject'] = 'my-app';
+      expect(getDefaultProjectName(context.workspace)).toBe('my-app');
+    });
+
+    it('should return single project name if only one exists and no defaultProject', () => {
+      const { context, projects } = createMockContext();
+      addProjectToWorkspace(projects, 'only-app', {}, '');
+      expect(getDefaultProjectName(context.workspace)).toBe('only-app');
+    });
+
+    it('should return undefined if multiple projects exist and no defaultProject', () => {
+      const { context, projects } = createMockContext();
+      addProjectToWorkspace(projects, 'app1', {}, '');
+      addProjectToWorkspace(projects, 'app2', {}, '');
+      expect(getDefaultProjectName(context.workspace)).toBeUndefined();
+    });
+  });
+
+  describe('resolveWorkspaceAndProject', () => {
+    let mockHost: ReturnType<typeof createMockHost>;
+    let mockWorkspace: AngularWorkspace;
+    const cwd = './';
+
+    beforeEach(() => {
+      mockHost = createMockHost();
+      spyOn(process, 'cwd').and.returnValue(cwd);
+
+      // Setup default mocks
+      mockHost.existsSync.and.callFake((p) => {
+        // Mock presence of angular.json in CWD
+        if (p === join(cwd, 'angular.json')) {
+          return true;
+        }
+        // Mock presence of specific workspace
+        if (p === '/my/workspace') {
+          return true;
+        }
+        if (p === '/my/workspace/angular.json') {
+          return true;
+        }
+
+        return false;
+      });
+
+      const projects = new workspaces.ProjectDefinitionCollection();
+      projects.set('app', {
+        root: 'app',
+        extensions: {},
+        targets: new workspaces.TargetDefinitionCollection(),
+      });
+
+      mockWorkspace = {
+        projects,
+        extensions: { defaultProject: 'app' },
+        basePath: cwd,
+        filePath: join(cwd, 'angular.json'),
+      } as unknown as AngularWorkspace;
+
+      spyOn(AngularWorkspace, 'load').and.resolveTo(mockWorkspace);
+    });
+
+    it('should resolve workspace from CWD if not provided and mcpWorkspace is absent', async () => {
+      const result = await resolveWorkspaceAndProject({
+        host: mockHost,
+      });
+      expect(result.workspacePath).toBe(cwd);
+      expect(result.projectName).toBe('app');
+      expect(AngularWorkspace.load).toHaveBeenCalledWith(join(cwd, 'angular.json'));
+    });
+
+    it('should use mcpWorkspace if provided and no input path', async () => {
+      const result = await resolveWorkspaceAndProject({
+        host: mockHost,
+        mcpWorkspace: mockWorkspace,
+      });
+      expect(result.workspace).toBe(mockWorkspace);
+      expect(result.workspacePath).toBe(mockWorkspace.basePath);
+      expect(AngularWorkspace.load).not.toHaveBeenCalled();
+    });
+
+    it('should prefer workspacePathInput over mcpWorkspace', async () => {
+      const result = await resolveWorkspaceAndProject({
+        host: mockHost,
+        workspacePathInput: '/my/workspace',
+        mcpWorkspace: mockWorkspace,
+      });
+      expect(result.workspacePath).toBe('/my/workspace');
+      expect(AngularWorkspace.load).toHaveBeenCalledWith('/my/workspace/angular.json');
+    });
+
+    it('should resolve provided workspace', async () => {
+      const result = await resolveWorkspaceAndProject({
+        host: mockHost,
+        workspacePathInput: '/my/workspace',
+      });
+      expect(result.workspacePath).toBe('/my/workspace');
+      expect(AngularWorkspace.load).toHaveBeenCalledWith('/my/workspace/angular.json');
+    });
+
+    it('should throw if provided workspace does not exist', async () => {
+      mockHost.existsSync.and.returnValue(false);
+      await expectAsync(
+        resolveWorkspaceAndProject({
+          host: mockHost,
+          workspacePathInput: '/bad/path',
+        }),
+      ).toBeRejectedWithError(/Workspace path does not exist: \/bad\/path/);
+    });
+
+    it('should throw if provided workspace has no angular.json', async () => {
+      mockHost.existsSync.and.callFake((p) => p === '/path');
+      await expectAsync(
+        resolveWorkspaceAndProject({
+          host: mockHost,
+          workspacePathInput: '/path',
+        }),
+      ).toBeRejectedWithError(/No angular.json found at \/path/);
+    });
+
+    it('should resolve provided project', async () => {
+      const result = await resolveWorkspaceAndProject({
+        host: mockHost,
+        projectNameInput: 'app',
+      });
+      expect(result.projectName).toBe('app');
+    });
+
+    it('should throw if provided project does not exist', async () => {
+      await expectAsync(
+        resolveWorkspaceAndProject({
+          host: mockHost,
+          projectNameInput: 'bad-app',
+        }),
+      ).toBeRejectedWithError(/Project 'bad-app' not found in workspace path/);
+    });
+
+    it('should throw if no project resolved', async () => {
+      mockWorkspace.extensions['defaultProject'] = undefined;
+      mockWorkspace.projects.set('app2', {
+        root: 'app2',
+        extensions: {},
+        targets: new workspaces.TargetDefinitionCollection(),
+      });
+
+      await expectAsync(
+        resolveWorkspaceAndProject({
+          host: mockHost,
+        }),
+      ).toBeRejectedWithError(/No project name provided and no default project found/);
+    });
+
+    it('should throw if mcpWorkspace is absent and no workspace found in CWD', async () => {
+      mockHost.existsSync.and.returnValue(false);
+      await expectAsync(
+        resolveWorkspaceAndProject({
+          host: mockHost,
+        }),
+      ).toBeRejectedWithError(/Could not find an Angular workspace/);
+    });
+  });
+});


### PR DESCRIPTION
- Many tools now have `workspace` and `project` options that make them better suited to monorepo scenarios.
- Many errors now reported as exceptions instead of regular messages. They all have informative error messages.
- The above now uses shared implementation across tools.
- Tests are now simplified and more consistent.

Tested manually with Gemini-CLI, both in an Angular directory and in a non-Angular parent directory.