### PR TITLE
fix(@angular/build): ensure the JIT compiler is available for Vitest tests that use providersFile.

### DIFF
--- a/packages/angular/build/src/builders/unit-test/options.ts
+++ b/packages/angular/build/src/builders/unit-test/options.ts
@@ -135,6 +135,18 @@ export async function normalizeOptions(
   };
 }
 
-export function injectTestingPolyfills(polyfills: string[] = []): string[] {
-  return polyfills.includes('zone.js') ? [...polyfills, 'zone.js/testing'] : polyfills;
+export function injectTestingPolyfills(
+  polyfills: string[] = [],
+  runner?: Runner,
+  hasProvidersFile?: boolean,
+): string[] {
+  const testPolyfills = polyfills.includes('zone.js')
+    ? [...polyfills, 'zone.js/testing']
+    : polyfills;
+
+  if (runner === Runner.Vitest && hasProvidersFile) {
+    testPolyfills.push('@angular/compiler');
+  }
+
+  return testPolyfills;
 }

--- a/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
@@ -11,6 +11,7 @@ import { toPosixPath } from '../../../../utils/path';
 import type { ApplicationBuilderInternalOptions } from '../../../application/options';
 import { OutputHashing } from '../../../application/schema';
 import { NormalizedUnitTestBuilderOptions, injectTestingPolyfills } from '../../options';
+import { Runner } from '../../schema';
 import { findTests, getTestEntrypoints } from '../../test-discovery';
 import { RunnerOptions } from '../api';
 
@@ -130,7 +131,11 @@ export async function getVitestBuildOptions(
     externalDependencies,
   };
 
-  buildOptions.polyfills = injectTestingPolyfills(buildOptions.polyfills);
+  buildOptions.polyfills = injectTestingPolyfills(
+    buildOptions.polyfills,
+    Runner.Vitest,
+    !!providersFile,
+  );
 
   const testBedInitContents = createTestBedInitVirtualFile(
     providersFile,

--- a/packages/angular/build/src/builders/unit-test/tests/options/providers-file_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/providers-file_spec.ts
@@ -60,5 +60,61 @@ describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
       const { result } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
     });
+
+    it('should work with providers that inject services requiring JIT compilation', async () => {
+      // This test reproduces the issue from https://github.com/angular/angular-cli/issues/31993
+      // where using providersFile with a service that injects Router causes JIT compilation errors
+      await harness.writeFiles({
+        'src/test.service.ts': `
+          import { Injectable, inject } from '@angular/core';
+          import { Router } from '@angular/router';
+
+          @Injectable({ providedIn: 'root' })
+          export class TestService {
+            router = inject(Router);
+          }
+        `,
+        'src/test.providers.ts': `
+          import { TestService } from './test.service';
+          export default [TestService];
+        `,
+        'src/app/app.component.spec.ts': `
+          import { TestBed } from '@angular/core/testing';
+          import { AppComponent } from './app.component';
+          import { TestService } from '../test.service';
+          import { describe, expect, it } from 'vitest';
+
+          describe('AppComponent', () => {
+            it('should create the app and inject TestService', () => {
+              TestBed.configureTestingModule({
+                declarations: [AppComponent],
+              });
+              const fixture = TestBed.createComponent(AppComponent);
+              const app = fixture.componentInstance;
+              const testService = TestBed.inject(TestService);
+              expect(app).toBeTruthy();
+              expect(testService).toBeTruthy();
+              expect(testService.router).toBeTruthy();
+            });
+          });
+        `,
+      });
+      await harness.modifyFile('src/tsconfig.spec.json', (content) => {
+        const tsConfig = JSON.parse(content);
+        tsConfig.files ??= [];
+        tsConfig.files.push('test.service.ts', 'test.providers.ts');
+
+        return JSON.stringify(tsConfig);
+      });
+
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        providersFile: 'src/test.providers.ts',
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBeTrue();
+    });
   });
 });


### PR DESCRIPTION
Fixes #31993

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Compilation issue when used providerFile with Vitest

Issue Number: #31993 

## What is the new behavior?

Fixes the compilation issue by addding `@angular/compiler`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
