### PR TITLE
fix(@angular/build): allow application assets in workspace root

### DIFF
--- a/packages/angular/build/src/builders/application/tests/options/assets_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/assets_spec.ts
@@ -107,19 +107,19 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
         harness.expectFile('dist/browser/test.svg').toNotExist();
       });
 
-      it('fail if asset path is not within project source root', async () => {
-        await harness.writeFile('test.svg', '<svg></svg>');
+      it('copies an asset from project root (outside source root)', async () => {
+        await harness.writeFile('extra.txt', 'extra');
 
         harness.useTarget('build', {
           ...BASE_OPTIONS,
-          assets: ['test.svg'],
+          assets: ['extra.txt'],
         });
 
-        const { error } = await harness.executeOnce({ outputLogsOnException: false });
+        const { result } = await harness.executeOnce();
 
-        expect(error?.message).toMatch('path must start with the project source root');
+        expect(result?.success).toBe(true);
 
-        harness.expectFile('dist/browser/test.svg').toNotExist();
+        harness.expectFile('dist/browser/extra.txt').content.toBe('extra');
       });
     });
 
@@ -357,6 +357,17 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
         expect(result?.success).toBe(true);
 
         harness.expectFile('dist/browser/subdirectory/test.svg').content.toBe('<svg></svg>');
+      });
+
+      it('fails if asset path is outside workspace root', async () => {
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          assets: ['../outside.txt'],
+        });
+
+        const { error } = await harness.executeOnce({ outputLogsOnException: false });
+
+        expect(error?.message).toMatch('asset path must be within the workspace root');
       });
 
       it('fails if output option is not within project output path', async () => {

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/assets_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/assets_spec.ts
@@ -106,21 +106,6 @@ describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
 
         harness.expectFile('dist/test.svg').toNotExist();
       });
-
-      it('fail if asset path is not within project source root', async () => {
-        await harness.writeFile('test.svg', '<svg></svg>');
-
-        harness.useTarget('build', {
-          ...BASE_OPTIONS,
-          assets: ['test.svg'],
-        });
-
-        const { error } = await harness.executeOnce({ outputLogsOnException: false });
-
-        expect(error?.message).toMatch('path must start with the project source root');
-
-        harness.expectFile('dist/test.svg').toNotExist();
-      });
     });
 
     describe('longhand syntax', () => {


### PR DESCRIPTION
This commit refactors `normalizeAssetPatterns` to:
1. Allow asset paths located in the workspace root or project root, relaxing the previous strict requirement of being within the source root.
2. Determine the output path by calculating the relative path from the most specific root (source, project, or workspace) to the asset input.
3. Remove the unused `MissingAssetSourceRootException` class in favor of a standard `Error` with a clear message.

This enables users to include workspace-level assets (like `LICENSE` or `README.md`) using the shorthand string syntax without errors.

Closes: #32305