### PR TITLE
refactor(@angular-devkit/schematics): support `isolatedDeclarations` for tree classes

### DIFF
--- a/goldens/public-api/angular_devkit/schematics/index.api.md
+++ b/goldens/public-api/angular_devkit/schematics/index.api.md
@@ -203,9 +203,13 @@ export interface CreateFileAction extends ActionBase {
 }
 
 // @public (undocumented)
+export interface DelegateTree {
+}
+
+// @public (undocumented)
 export class DelegateTree implements Tree_2 {
     // (undocumented)
-    [TreeSymbol]: () => this;
+    [TreeSymbol]: () => DelegateTree;
     constructor(_other: Tree_2);
     // (undocumented)
     get actions(): Action[];
@@ -517,9 +521,13 @@ export class HostSink extends SimpleSinkBase {
 }
 
 // @public (undocumented)
+export interface HostTree {
+}
+
+// @public (undocumented)
 export class HostTree implements Tree_2 {
     // (undocumented)
-    [TreeSymbol]: () => this;
+    [TreeSymbol]: () => HostTree;
     constructor(_backend?: virtualFs.ReadonlyHost<{}>);
     // (undocumented)
     get actions(): Action[];

--- a/packages/angular_devkit/schematics/src/tree/delegate.ts
+++ b/packages/angular_devkit/schematics/src/tree/delegate.ts
@@ -18,8 +18,19 @@ import {
   UpdateRecorder,
 } from './interface';
 
+// Workaround for "error TS9038: Computed property names on class or object literals cannot be inferred with --isolatedDeclarations."
+// When this is fixed within TypeScript, the method can be added back directly to the class.
+// See: https://github.com/microsoft/TypeScript/issues/61892
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface DelegateTree {
+  [TreeSymbol](): DelegateTree;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class DelegateTree implements Tree {
-  constructor(protected _other: Tree) {}
+  constructor(protected _other: Tree) {
+    this[TreeSymbol] = () => this;
+  }
 
   branch(): Tree {
     return this._other.branch();
@@ -82,9 +93,5 @@ export class DelegateTree implements Tree {
   }
   get actions(): Action[] {
     return this._other.actions;
-  }
-
-  [TreeSymbol]() {
-    return this;
   }
 }

--- a/packages/angular_devkit/schematics/src/tree/host-tree.ts
+++ b/packages/angular_devkit/schematics/src/tree/host-tree.ts
@@ -98,6 +98,15 @@ export class HostDirEntry implements DirEntry {
   }
 }
 
+// Workaround for "error TS9038: Computed property names on class or object literals cannot be inferred with --isolatedDeclarations."
+// When this is fixed within TypeScript, the method can be added back directly to the class.
+// See: https://github.com/microsoft/TypeScript/issues/61892
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface HostTree {
+  [TreeSymbol](): HostTree;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class HostTree implements Tree {
   private readonly _id = --_uniqueId;
   private _record: virtualFs.CordHost;
@@ -105,10 +114,6 @@ export class HostTree implements Tree {
   private _ancestry = new Set<number>();
 
   private _dirCache = new Map<Path, HostDirEntry>();
-
-  [TreeSymbol](): this {
-    return this;
-  }
 
   static isHostTree(tree: Tree): tree is HostTree {
     if (tree instanceof HostTree) {
@@ -123,6 +128,7 @@ export class HostTree implements Tree {
   }
 
   constructor(protected _backend: virtualFs.ReadonlyHost<{}> = new virtualFs.Empty()) {
+    this[TreeSymbol] = () => this;
     this._record = new virtualFs.CordHost(new virtualFs.SafeReadonlyHost(_backend));
     this._recordSync = new virtualFs.SyncDelegateHost(this._record);
   }

--- a/packages/angular_devkit/schematics/src/tree/null.ts
+++ b/packages/angular_devkit/schematics/src/tree/null.ts
@@ -46,9 +46,18 @@ export class NullTreeDirEntry implements DirEntry {
   visit(): void {}
 }
 
+// Workaround for "error TS9038: Computed property names on class or object literals cannot be inferred with --isolatedDeclarations."
+// When this is fixed within TypeScript, the method can be added back directly to the class.
+// See: https://github.com/microsoft/TypeScript/issues/61892
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface NullTree {
+  [TreeSymbol](): NullTree;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class NullTree implements Tree {
-  [TreeSymbol](): this {
-    return this;
+  constructor() {
+    this[TreeSymbol] = () => this;
   }
 
   branch(): Tree {

--- a/packages/angular_devkit/schematics/src/tree/scoped.ts
+++ b/packages/angular_devkit/schematics/src/tree/scoped.ts
@@ -89,6 +89,15 @@ class ScopedDirEntry implements DirEntry {
   }
 }
 
+// Workaround for "error TS9038: Computed property names on class or object literals cannot be inferred with --isolatedDeclarations."
+// When this is fixed within TypeScript, the method can be added back directly to the class.
+// See: https://github.com/microsoft/TypeScript/issues/61892
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface ScopedTree {
+  [TreeSymbol](): ScopedTree;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class ScopedTree implements Tree {
   readonly _root: ScopedDirEntry;
 
@@ -96,6 +105,7 @@ export class ScopedTree implements Tree {
     private _base: Tree,
     scope: string,
   ) {
+    this[TreeSymbol] = () => this;
     const normalizedScope = normalize('/' + scope);
     this._root = new ScopedDirEntry(this._base.getDir(normalizedScope), normalizedScope);
   }
@@ -195,10 +205,6 @@ export class ScopedTree implements Tree {
     }
 
     return scopedActions;
-  }
-
-  [TreeSymbol](): this {
-    return this;
   }
 
   private _fullPath(path: string): Path {


### PR DESCRIPTION
This commit refactors several Tree implementations (`DelegateTree`, `HostTree`, `NullTree`, `ScopedTree`) to support the TypeScript `isolatedDeclarations` compiler option. It uses declaration merging to define the `[TreeSymbol]` method on an interface and assigns it in the constructor to avoid TS9038 errors regarding computed property names inference.