### PR TITLE
refactor: remove deprecated compiler option

### DIFF
--- a/modules/testing/builder/projects/hello-world-app/src/tsconfig.server.json
+++ b/modules/testing/builder/projects/hello-world-app/src/tsconfig.server.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.app.json",
   "compilerOptions": {
     "outDir": "../dist-server",
-    "baseUrl": "./",
     "types": ["@angular/localize", "node"]
   },
   "files": [

--- a/modules/testing/builder/projects/hello-world-app/tsconfig.json
+++ b/modules/testing/builder/projects/hello-world-app/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "sourceMap": true,
     "declaration": false,
@@ -17,7 +16,6 @@
     ]
   },
   "angularCompilerOptions": {
-    "enableIvy": true,
     "disableTypeScriptVersionCheck": true,
     "strictTemplates": true
   }

--- a/packages/angular/build/src/builders/application/tests/behavior/typescript-path-mapping_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/typescript-path-mapping_spec.ts
@@ -81,7 +81,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       await harness.modifyFile('tsconfig.json', (content) => {
         const tsconfig = JSON.parse(content);
         tsconfig.compilerOptions.paths = {
-          'app-module': ['a.js'],
+          'app-module': ['./a.js'],
         };
 
         return JSON.stringify(tsconfig);

--- a/packages/angular/build/src/builders/application/tests/options/allowed-common-js-dependencies_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/allowed-common-js-dependencies_spec.ts
@@ -130,14 +130,13 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
     it('should not show warning in JIT for templateUrl and styleUrl when using paths', async () => {
       await harness.modifyFile('tsconfig.json', (content) => {
         return content.replace(
-          /"baseUrl": ".\/",/,
-          `
-            "baseUrl": "./",
-            "paths": {
-              "@app/*": [
-                "src/app/*"
-              ]
-            },
+          /"compilerOptions": {/,
+          `"compilerOptions": {
+              "paths": {
+                "@app/*": [
+                  "./src/app/*"
+                ]
+              },
           `,
         );
       });

--- a/packages/angular/build/src/builders/karma/tests/options/code-coverage_spec.ts
+++ b/packages/angular/build/src/builders/karma/tests/options/code-coverage_spec.ts
@@ -67,10 +67,10 @@ describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget) => {
 
     it(`should collect coverage from paths in 'sourceRoot'`, async () => {
       await harness.writeFiles({
-        './dist/my-lib/index.d.ts': `
+        './node_modules/my-lib/index.d.ts': `
           export declare const title = 'app';
         `,
-        './dist/my-lib/index.js': `
+        './node_modules/my-lib/index.js': `
           export const title = 'app';
         `,
         './src/app/app.component.ts': `
@@ -88,20 +88,6 @@ describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget) => {
           }
         `,
       });
-      await harness.modifyFile('tsconfig.json', (content) =>
-        content.replace(
-          /"baseUrl": ".\/",/,
-          `
-            "baseUrl": "./",
-            "paths": {
-              "my-lib": [
-                "./dist/my-lib"
-              ]
-            },
-          `,
-        ),
-      );
-
       harness.useTarget('test', {
         ...BASE_OPTIONS,
         codeCoverage: true,

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/tsconfig-paths_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/tsconfig-paths_spec.ts
@@ -21,16 +21,20 @@ describe('Browser Builder tsconfig paths', () => {
 
   it('works', async () => {
     host.replaceInFile('src/app/app.module.ts', './app.component', '@root/app/app.component');
+
+    // TODO(crisbeto): the `baseUrl` here will trigger a deprecation error in TS6. We may
+    // have to opt out of it for this test since Webpack seems to depend on the `baseUrl`.
     host.replaceInFile(
       'tsconfig.json',
-      /"baseUrl": ".\/",/,
+      /"compilerOptions": {/,
       `
-      "baseUrl": "./",
-      "paths": {
-        "@root/*": [
-          "./src/*"
-        ]
-      },
+      "compilerOptions": {
+        "baseUrl": "./",
+        "paths": {
+          "@root/*": [
+            "./src/*"
+          ]
+        },
     `,
     );
 
@@ -43,23 +47,27 @@ describe('Browser Builder tsconfig paths', () => {
       'src/app/shared/meaning.ts': 'export var meaning = 42;',
       'src/app/shared/index.ts': `export * from './meaning'`,
     });
+
+    // TODO(crisbeto): the `baseUrl` here will trigger a deprecation error in TS6. We may
+    // have to opt out of it for this test since Webpack seems to depend on the `baseUrl`.
     host.replaceInFile(
       'tsconfig.json',
-      /"baseUrl": ".\/",/,
+      /"compilerOptions": {/,
       `
-      "baseUrl": "./",
-      "paths": {
-        "@shared": [
-          "src/app/shared"
-        ],
-        "@shared/*": [
-          "src/app/shared/*"
-        ],
-        "*": [
-          "*",
-          "src/app/shared/*"
-        ]
-      },
+      "compilerOptions": {
+        "baseUrl": "./",
+        "paths": {
+          "@shared": [
+            "./src/app/shared"
+          ],
+          "@shared/*": [
+            "./src/app/shared/*"
+          ],
+          "*": [
+            "*",
+            "./src/app/shared/*"
+          ]
+        },
     `,
     );
     host.appendToFile(

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/options/allowed-common-js-dependencies_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/options/allowed-common-js-dependencies_spec.ts
@@ -120,12 +120,14 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
     it('should not show warning in JIT for templateUrl and styleUrl when using paths', async () => {
       await harness.modifyFile('tsconfig.json', (content) => {
         return content.replace(
-          /"baseUrl": ".\/",/,
-          `
+          /"compilerOptions": {/,
+          // TODO(crisbeto): the `baseUrl` here will trigger a deprecation error in TS6. We may
+          // have to opt out of it for this test since Webpack seems to depend on the `baseUrl`.
+          `"compilerOptions": {
             "baseUrl": "./",
             "paths": {
               "@app/*": [
-                "src/app/*"
+                "./src/app/*"
               ]
             },
           `,

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/code-coverage_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/code-coverage_spec.ts
@@ -67,10 +67,10 @@ describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget) => {
 
     it(`should collect coverage from paths in 'sourceRoot'`, async () => {
       await harness.writeFiles({
-        './dist/my-lib/index.d.ts': `
+        './node_modules/my-lib/index.d.ts': `
           export declare const title = 'app';
         `,
-        './dist/my-lib/index.js': `
+        './node_modules/my-lib/index.js': `
           export const title = 'app';
         `,
         './src/app/app.component.ts': `
@@ -88,20 +88,6 @@ describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget) => {
           }
         `,
       });
-      await harness.modifyFile('tsconfig.json', (content) =>
-        content.replace(
-          /"baseUrl": ".\/",/,
-          `
-            "baseUrl": "./",
-            "paths": {
-              "my-lib": [
-                "./dist/my-lib"
-              ]
-            },
-          `,
-        ),
-      );
-
       harness.useTarget('test', {
         ...BASE_OPTIONS,
         codeCoverage: true,

--- a/packages/angular_devkit/build_angular/test/hello-world-lib/tsconfig.json
+++ b/packages/angular_devkit/build_angular/test/hello-world-lib/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "sourceMap": true,
     "declaration": false,
@@ -16,7 +15,6 @@
     ]
   },
   "angularCompilerOptions": {
-    "enableIvy": true,
     "disableTypeScriptVersionCheck": true
   }
 }

--- a/packages/angular_devkit/build_webpack/test/angular-app/tsconfig.json
+++ b/packages/angular_devkit/build_webpack/test/angular-app/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "sourceMap": true,
     "declaration": false,
@@ -12,7 +11,6 @@
     "lib": ["es2022", "dom"]
   },
   "angularCompilerOptions": {
-    "enableIvy": true,
     "disableTypeScriptVersionCheck": true
   }
 }

--- a/packages/angular_devkit/build_webpack/test/basic-app/tsconfig.json
+++ b/packages/angular_devkit/build_webpack/test/basic-app/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "sourceMap": true,
     "declaration": false,

--- a/packages/angular_devkit/schematics_cli/blank/project-files/tsconfig.json
+++ b/packages/angular_devkit/schematics_cli/blank/project-files/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": "tsconfig",
     "lib": ["es2018", "dom"],
     "declaration": true,
     "module": "commonjs",

--- a/packages/angular_devkit/schematics_cli/schematic/files/tsconfig.json
+++ b/packages/angular_devkit/schematics_cli/schematic/files/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": "tsconfig",
     "lib": ["es2018", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",

--- a/tests/e2e/assets/ssr-project-webpack/tsconfig.json
+++ b/tests/e2e/assets/ssr-project-webpack/tsconfig.json
@@ -2,7 +2,6 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "strict": true,
     "noImplicitOverride": true,


### PR DESCRIPTION
Removes usages of the `baseUrl` compiler option which is deprecated and will start throwing an error in TypeScript 6.
