### PR TITLE
fix(@schematics/angular): remove special characters from jasmine-vitest report filename

### DIFF
--- a/packages/schematics/angular/refactor/jasmine-vitest/index.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/index.ts
@@ -132,7 +132,10 @@ export default function (options: Schema): Rule {
 
     if (options.report) {
       const reportContent = reporter.generateReportContent();
-      tree.create(`jasmine-vitest-${new Date().toISOString()}.md`, reportContent);
+      tree.create(
+        `jasmine-vitest-${new Date().toISOString().replaceAll(/[-:.]/g, '')}.md`,
+        reportContent,
+      );
     }
 
     reporter.printSummary(options.verbose);


### PR DESCRIPTION
This commit removes hyphens, colons, and periods from the ISO date string used in the jasmine-vitest report filename to ensure the resulting filename is more compact and file-system-friendly.

Closes #32323