### PR TITLE
fix(@angular/build): support TypeScript isolatedDeclarations option

### DIFF
--- a/packages/angular/build/src/tools/angular/compilation/angular-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/angular-compilation.ts
@@ -52,7 +52,6 @@ export abstract class AngularCompilation {
         suppressOutputPathCheck: true,
         outDir: undefined,
         sourceMap: false,
-        declaration: false,
         declarationMap: false,
         allowEmptyCodegenFiles: false,
         annotationsAs: 'decorators',

--- a/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
@@ -733,7 +733,9 @@ function createCompilerOptionsTransformer(
     return {
       ...compilerOptions,
       noEmitOnError: false,
-      composite: false,
+      // TypeScript requires either declaration or composite to be true when isolatedDeclarations is set
+      declaration: compilerOptions.isolatedDeclarations ? compilerOptions.declaration : false,
+      composite: compilerOptions.isolatedDeclarations ? compilerOptions.composite : false,
       inlineSources: !!pluginOptions.sourcemap,
       inlineSourceMap: !!pluginOptions.sourcemap,
       sourceMap: undefined,


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Recently, the Angular team said [on a panel](https://www.youtube.com/watch?v=OpprrzvyqEc&t=445s)  that `isolatedDeclarations` can make a huge difference in build times, but we currently can't test it in the CLI.

Angular CLI forcefully set both declaration and composite to false, which prevents the use of isolatedDeclarations as TypeScript requires at least one of these options to be true when isolatedDeclarations is set (TS5069 error):

```
✘ [ERROR] TS5069: Option 'isolatedDeclarations' cannot be specified without specifying option 'declaration' or option 'composite'. [plugin angular-compiler]
```

## What is the new behavior?

This change allows the use of TypeScript's isolatedDeclarations compiler option by conditionally preserving the declaration and composite options when isolatedDeclarations is enabled.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information