### PR TITLE
fix(@angular/build): support merging coverage thresholds with Vitest runnerConfig

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
@@ -85,6 +85,11 @@ export class VitestExecutor implements TestExecutor {
 
     updateExternalMetadata(buildResult, this.externalMetadata, undefined, true);
 
+    // Reset the exit code to allow for a clean state.
+    // This is necessary because Vitest may set the exit code on failure, which can
+    // affect subsequent runs in watch mode or when running multiple builders.
+    process.exitCode = 0;
+
     // Initialize Vitest if not already present.
     this.vitest ??= await this.initializeVitest();
     const vitest = this.vitest;
@@ -122,7 +127,17 @@ export class VitestExecutor implements TestExecutor {
     // Check if all the tests pass to calculate the result
     const testModules = testResults?.testModules ?? this.vitest.state.getTestModules();
 
-    yield { success: testModules.every((testModule) => testModule.ok()) };
+    let success = testModules.every((testModule) => testModule.ok());
+    // Vitest does not return a failure result when coverage thresholds are not met.
+    // Instead, it sets the process exit code to 1.
+    // We check this exit code to determine if the test run should be considered a failure.
+    if (success && process.exitCode === 1) {
+      success = false;
+      // Reset the exit code to prevent it from carrying over to subsequent runs/builds
+      process.exitCode = 0;
+    }
+
+    yield { success };
   }
 
   async [Symbol.asyncDispose](): Promise<void> {

--- a/packages/angular/build/src/builders/unit-test/tests/options/runner-config-coverage_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/runner-config-coverage_spec.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { execute } from '../../index';
+import {
+  BASE_OPTIONS,
+  describeBuilder,
+  UNIT_TEST_BUILDER_INFO,
+  setupApplicationTarget,
+} from '../setup';
+
+describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
+  describe('Option: "runnerConfig" Coverage Merging', () => {
+    beforeEach(() => {
+      setupApplicationTarget(harness);
+    });
+
+    describe('Vitest Runner', () => {
+      it('should preserve thresholds from Vitest config when not overridden by CLI', async () => {
+        harness.writeFile(
+          'vitest-base.config.ts',
+          `
+          import { defineConfig } from 'vitest/config';
+          export default defineConfig({
+            test: {
+              coverage: {
+                thresholds: {
+                  branches: 100
+                }
+              }
+            }
+          });
+        `,
+        );
+
+        harness.useTarget('test', {
+          ...BASE_OPTIONS,
+          runnerConfig: true,
+          coverage: true,
+        });
+
+        const { result } = await harness.executeOnce();
+
+        // Should fail because branches are not 100%
+        expect(result?.success).toBeFalse();
+      });
+
+      it('should override Vitest config thresholds with CLI thresholds', async () => {
+        harness.writeFile(
+          'vitest-base.config.ts',
+          `
+          import { defineConfig } from 'vitest/config';
+          export default defineConfig({
+            test: {
+              coverage: {
+                thresholds: {
+                  branches: 100
+                }
+              }
+            }
+          });
+        `,
+        );
+
+        harness.useTarget('test', {
+          ...BASE_OPTIONS,
+          runnerConfig: true,
+          coverage: true,
+          coverageThresholds: {
+            branches: 0,
+          },
+        });
+
+        const { result } = await harness.executeOnce();
+
+        // Should pass because CLI overrides threshold to 0
+        expect(result?.success).toBeTrue();
+      });
+
+      it('should merge partial CLI thresholds with Vitest config thresholds', async () => {
+        harness.writeFile(
+          'vitest-base.config.ts',
+          `
+          import { defineConfig } from 'vitest/config';
+          export default defineConfig({
+            test: {
+              coverage: {
+                thresholds: {
+                  statements: 100,
+                  branches: 100
+                }
+              }
+            }
+          });
+        `,
+        );
+
+        harness.useTarget('test', {
+          ...BASE_OPTIONS,
+          runnerConfig: true,
+          coverage: true,
+          coverageThresholds: {
+            statements: 0,
+            // branches is undefined here, should remain 100 from config
+          },
+        });
+
+        const { result } = await harness.executeOnce();
+
+        // Should still fail because branches threshold (100) is not met
+        expect(result?.success).toBeFalse();
+      });
+    });
+  });
+});


### PR DESCRIPTION
The Vitest unit test builder now correctly merges coverage thresholds and watermarks from a user's Vitest configuration with CLI-provided options. Previously, providing any CLI thresholds would completely replace the configuration's thresholds. Now, partial CLI thresholds are merged, allowing users to override specific metrics while keeping others from their config.

This change also ensures that the builder correctly reports failure when Vitest coverage thresholds are not met by monitoring `process.exitCode`.