### PR TITLE
fix(@angular/build): loosen Vitest dependency checks when runnerConfig is used

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/index.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/index.ts
@@ -22,6 +22,15 @@ const VitestTestRunner: TestRunner = {
     const checker = new DependencyChecker(options.projectSourceRoot);
     checker.check('vitest');
 
+    // If a runnerConfig is present, only check for 'vitest' itself.
+    // Custom configuration may include unknown browsers or other setup
+    // that doesn't follow the default dependency requirements.
+    if (options.runnerConfig) {
+      checker.report();
+
+      return;
+    }
+
     if (options.browsers?.length) {
       if (process.versions.webcontainer) {
         checker.check('@vitest/browser-preview');


### PR DESCRIPTION
When a Vitest configuration file is provided via the `runnerConfig` option, the builder now only validates that the `vitest` package itself is installed. Checks for specific browser providers, DOM environments (jsdom/happy-dom), and coverage providers are skipped, as the custom configuration may handle these or use alternative setups that the builder cannot predict.