### PR TITLE
refactor(@angular/build): avoid secondary import wrapper in Vitest unless coverage is enabled

### DIFF
--- a/tests/e2e/tests/vitest/node-sourcemaps.ts
+++ b/tests/e2e/tests/vitest/node-sourcemaps.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { applyVitestBuilder } from '../../utils/vitest';
+import { ng, noSilentNg } from '../../utils/process';
+import { writeFile } from '../../utils/fs';
+import { stripVTControlCharacters } from 'node:util';
+
+export default async function (): Promise<void> {
+  await applyVitestBuilder();
+  await ng('generate', 'component', 'my-comp');
+
+  // Add a failing test to verify source map support
+  await writeFile(
+    'src/app/failing.spec.ts',
+    `
+      describe('Failing Test', () => {
+        it('should fail', () => {
+          expect(true).toBe(false);
+        });
+      });
+    `,
+  );
+
+  try {
+    await noSilentNg('test', '--no-watch');
+    throw new Error('Expected "ng test" to fail.');
+  } catch (error: any) {
+    const stdout = stripVTControlCharacters(error.stdout || error.message);
+    // We expect the failure from failing.spec.ts
+    assert.match(stdout, /1 failed/, 'Expected 1 test to fail.');
+    // Check that the stack trace points to the correct file
+    assert.match(
+      stdout,
+      /\bsrc[\/\\]app[\/\\]failing\.spec\.ts:4:\d+/,
+      'Expected stack trace to point to the source file.',
+    );
+  }
+}


### PR DESCRIPTION
This commit optimizes the Vitest test runner by removing the secondary import wrapper for test entry points when code coverage is not enabled. The wrapper is only necessary to support coverage exclusion of the test files themselves.

By capturing the resolved Vitest configuration within the `configureVitest` hook, the plugin can now determine if coverage is enabled and conditionally apply the wrapper. This simplifies the module graph for standard test runs.