### PR TITLE
feat(@schematics/angular): add a '.prettierrc' file to generated workspaces and add Prettier as dev dependency

### DIFF
--- a/packages/schematics/angular/utility/latest-versions/package.json
+++ b/packages/schematics/angular/utility/latest-versions/package.json
@@ -18,6 +18,7 @@
     "jsdom": "^27.1.0",
     "less": "^4.2.0",
     "postcss": "^8.5.3",
+    "prettier": "^3.8.1",
     "protractor": "~7.0.0",
     "rxjs": "~7.8.0",
     "tailwindcss": "^4.1.12",

--- a/packages/schematics/angular/workspace/files/.prettierrc
+++ b/packages/schematics/angular/workspace/files/.prettierrc
@@ -1,0 +1,12 @@
+{
+  "printWidth": 100,
+  "singleQuote": true,
+  "overrides": [
+    {
+      "files": "*.html",
+      "options": {
+        "parser": "angular"
+      }
+    }
+  ]
+}

--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -8,18 +8,6 @@
     "watch": "ng build --watch --configuration development"<% if (!minimal) { %>,
     "test": "ng test"<% } %>
   },
-  "prettier": {
-    "printWidth": 100,
-    "singleQuote": true,
-    "overrides": [
-      {
-        "files": "*.html",
-        "options": {
-          "parser": "angular"
-        }
-      }
-    ]
-  },
   "private": true,
   <% if (packageManagerWithVersion) { %>"packageManager": "<%= packageManagerWithVersion %>",<% } %>
   "dependencies": {
@@ -35,6 +23,7 @@
   "devDependencies": {
     "@angular/cli": "<%= '^' + version %>",
     "@angular/compiler-cli": "<%= latestVersions.Angular %>",
+    "prettier": "<%= latestVersions['prettier'] %>",
     "typescript": "<%= latestVersions['typescript'] %>"
   }
 }

--- a/packages/schematics/angular/workspace/index_spec.ts
+++ b/packages/schematics/angular/workspace/index_spec.ts
@@ -134,10 +134,4 @@ describe('Workspace Schematic', () => {
     const { tasks } = parseJson(tree.readContent('.vscode/tasks.json').toString());
     expect(tasks).not.toContain(jasmine.objectContaining({ type: 'npm', script: 'test' }));
   });
-
-  it('should include prettier config overrides for Angular templates', async () => {
-    const tree = await schematicRunner.runSchematic('workspace', defaultOptions);
-    const pkg = JSON.parse(tree.readContent('/package.json'));
-    expect(pkg.prettier).withContext('package.json#prettier is present').toBeTruthy();
-  });
 });


### PR DESCRIPTION


The config was added as JSON, as this is the preferred format over executable configuration.

'.prettierignore' was not added as the '.gitignore' rules are applied by default.

Closes #32216 and closes #32222