### PR TITLE
refactor(@angular/build): extract sourcemap adjustment logic in Vitest plugin

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
@@ -217,20 +217,6 @@ export function createVitestPlugins(pluginOptions: PluginOptions): VitestPlugins
           }
         }
 
-        if (importer && (id[0] === '.' || id[0] === '/')) {
-          let fullPath;
-          if (testFileToEntryPoint.has(importer)) {
-            fullPath = toPosixPath(path.join(workspaceRoot, id));
-          } else {
-            fullPath = toPosixPath(path.join(path.dirname(importer), id));
-          }
-
-          const relativePath = path.relative(workspaceRoot, fullPath);
-          if (buildResultFiles.has(toPosixPath(relativePath))) {
-            return fullPath;
-          }
-        }
-
         // Determine the base directory for resolution.
         let baseDir: string;
         if (importer) {


### PR DESCRIPTION
This commit refactors the sourcemap source adjustment logic within the Vitest plugin into a standalone helper function, `adjustSourcemapSources`. This improves the readability of the `load` hook and isolates the logic for verifying and updating sourcemap paths.