### PR TITLE
fix(@schematics/angular): warn when production configuration is missing for service worker

### DIFF
--- a/packages/schematics/angular/service-worker/index.ts
+++ b/packages/schematics/angular/service-worker/index.ts
@@ -106,7 +106,7 @@ function getTsSourceFile(host: Tree, path: string): ts.SourceFile {
 }
 
 const serviceWorkerSchematic: RuleFactory<ServiceWorkerOptions> = createProjectSchematic(
-  async (options, { project, workspace, tree, logger }) => {
+  async (options, { project, workspace, tree, context: { logger } }) => {
     if (project.extensions.projectType !== 'application') {
       throw new SchematicsException(`Service worker requires a project type of "application".`);
     }


### PR DESCRIPTION


When adding service worker support to a project, the schematic attempts to add the `serviceWorker` option to the `production` build configuration. If the `production` configuration is missing, the schematic would previously do nothing and not inform the user.

This change adds a warning message to the console when the `production` configuration is not found, making it clear to the user why the `serviceWorker` option was not added.

Fixes #32399