### PR TITLE
refactor(@angular/cli): implement lazy validation for package manager

### DIFF
--- a/packages/angular/cli/src/package-managers/factory.ts
+++ b/packages/angular/cli/src/package-managers/factory.ts
@@ -145,17 +145,18 @@ export async function createPackageManager(options: {
   }
 
   // Do not verify if the package manager is installed during a dry run.
+  let initializationError: Error | undefined;
   if (!dryRun && !version) {
     try {
       version = await getPackageManagerVersion(host, cwd, name, logger);
     } catch {
       if (source === 'default') {
-        throw new Error(
+        initializationError = new Error(
           `'${DEFAULT_PACKAGE_MANAGER}' was selected as the default package manager, but it is not installed or` +
             ` cannot be found in the PATH. Please install '${DEFAULT_PACKAGE_MANAGER}' to continue.`,
         );
       } else {
-        throw new Error(
+        initializationError = new Error(
           `The project is configured to use '${name}', but it is not installed or cannot be` +
             ` found in the PATH. Please install '${name}' to continue.`,
         );
@@ -168,6 +169,7 @@ export async function createPackageManager(options: {
     logger,
     tempDirectory,
     version,
+    initializationError,
   });
 
   logger?.debug(`Successfully created PackageManager for '${name}'.`);


### PR DESCRIPTION
This changes the package manager initialization to only throw errors when the binary is actually required for an operation. This allows CLI commands that do not depend on the package manager binary to function even if the configured package manager is missing.