### PR TITLE
perf(@angular/cli): optimize package manager discovery with stat-based probing

### DIFF
--- a/packages/angular/cli/src/package-managers/discovery_spec.ts
+++ b/packages/angular/cli/src/package-managers/discovery_spec.ts
@@ -64,14 +64,6 @@ describe('discover', () => {
     expect(result).toBeNull();
   });
 
-  it('should handle file system errors during readdir gracefully', async () => {
-    const host = new MockHost({});
-    host.readdir = () => Promise.reject(new Error('Permission denied'));
-
-    const result = await discover(host, '/project');
-    expect(result).toBeNull();
-  });
-
   it('should handle file system errors during stat gracefully', async () => {
     const host = new MockHost({ '/project': ['.git'] });
     host.stat = () => Promise.reject(new Error('Permission denied'));

--- a/packages/angular/cli/src/package-managers/host.ts
+++ b/packages/angular/cli/src/package-managers/host.ts
@@ -40,13 +40,6 @@ export interface Host {
   stat(path: string): Promise<Stats>;
 
   /**
-   * Reads the contents of a directory.
-   * @param path The path to the directory.
-   * @returns A promise that resolves to an array of file and directory names.
-   */
-  readdir(path: string): Promise<string[]>;
-
-  /**
    * Reads the content of a file.
    * @param path The path to the file.
    * @returns A promise that resolves to the file content as a string.
@@ -108,7 +101,6 @@ export interface Host {
  */
 export const NodeJS_HOST: Host = {
   stat,
-  readdir,
   mkdir,
   readFile: (path: string) => readFile(path, { encoding: 'utf8' }),
   copyFile: (src, dest) => copyFile(src, dest, constants.COPYFILE_FICLONE),


### PR DESCRIPTION
This refactors the package manager discovery logic to use 'stat' instead of 'readdir', significantly improving performance in directories with many files. It also simplifies the internal host abstraction by removing the now unused 'readdir' method.