### PR TITLE
build: configure Jasmine to allow duplicate describe block names

### DIFF
--- a/modules/testing/builder/src/jasmine-helpers.ts
+++ b/modules/testing/builder/src/jasmine-helpers.ts
@@ -40,6 +40,9 @@ export function describeBuilder<T>(
     optionSchema,
   });
 
+  // This is needed as there are multiple describe calls for the same builder.
+  jasmine.getEnv().configure({ forbidDuplicateNames: false });
+
   describe(options.name || builderHandler.name, () => {
     beforeEach(async () => {
       harness.resetProjectMetadata();


### PR DESCRIPTION
This is needed as there are duplicate describe calls for the same builder, which is not allowed in Jasmine 6.
