### PR TITLE
feat(@angular/build): add headless option to unit-test builder

### DIFF
--- a/goldens/public-api/angular/build/index.api.md
+++ b/goldens/public-api/angular/build/index.api.md
@@ -231,6 +231,7 @@ export type UnitTestBuilderOptions = {
     dumpVirtualFiles?: boolean;
     exclude?: string[];
     filter?: string;
+    headless?: boolean;
     include?: string[];
     listTests?: boolean;
     outputFile?: string;

--- a/packages/angular/build/src/builders/unit-test/options.ts
+++ b/packages/angular/build/src/builders/unit-test/options.ts
@@ -96,6 +96,7 @@ export async function normalizeOptions(
     exclude: options.exclude,
     filter,
     runnerName: runner ?? Runner.Vitest,
+    headless: options.headless,
     coverage: {
       enabled: options.coverage,
       exclude: options.coverageExclude,

--- a/packages/angular/build/src/builders/unit-test/runners/karma/executor.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/karma/executor.ts
@@ -47,6 +47,12 @@ export class KarmaExecutor implements TestExecutor {
       );
     }
 
+    if (unitTestOptions.headless !== undefined) {
+      context.logger.warn(
+        'The "karma" test runner does not support the "headless" option. The option will be ignored.',
+      );
+    }
+
     const buildTargetOptions = (await context.validateOptions(
       await context.getTargetOptions(unitTestOptions.buildTarget),
       await context.getBuilderNameForTarget(unitTestOptions.buildTarget),

--- a/packages/angular/build/src/builders/unit-test/runners/vitest/browser-provider_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/browser-provider_spec.ts
@@ -39,6 +39,7 @@ describe('setupBrowserConfiguration', () => {
   it('should configure headless mode for specific browsers based on name', async () => {
     const { browser } = await setupBrowserConfiguration(
       ['ChromeHeadless', 'Firefox'],
+      undefined,
       false,
       workspaceRoot,
       undefined,
@@ -58,6 +59,7 @@ describe('setupBrowserConfiguration', () => {
     try {
       const { browser } = await setupBrowserConfiguration(
         ['Chrome', 'FirefoxHeadless'],
+        undefined,
         false,
         workspaceRoot,
         undefined,
@@ -85,6 +87,7 @@ describe('setupBrowserConfiguration', () => {
       // Case 1: All headless -> UI false
       let result = await setupBrowserConfiguration(
         ['ChromeHeadless'],
+        undefined,
         false,
         workspaceRoot,
         undefined,
@@ -94,6 +97,7 @@ describe('setupBrowserConfiguration', () => {
       // Case 2: Mixed -> UI true
       result = await setupBrowserConfiguration(
         ['ChromeHeadless', 'Firefox'],
+        undefined,
         false,
         workspaceRoot,
         undefined,
@@ -113,6 +117,7 @@ describe('setupBrowserConfiguration', () => {
     try {
       const { browser } = await setupBrowserConfiguration(
         ['Chrome'],
+        undefined,
         false,
         workspaceRoot,
         undefined,
@@ -151,6 +156,7 @@ describe('setupBrowserConfiguration', () => {
 
     const { browser } = await setupBrowserConfiguration(
       ['ChromeHeadless'],
+      undefined,
       false,
       workspaceRoot,
       undefined,
@@ -159,5 +165,35 @@ describe('setupBrowserConfiguration', () => {
     expect(browser?.provider).toBeDefined();
     // Preview forces headless false
     expect(browser?.instances?.[0].headless).toBeFalse();
+  });
+
+  it('should force headless mode when headless option is true', async () => {
+    const { browser, messages } = await setupBrowserConfiguration(
+      ['Chrome', 'Firefox'],
+      true,
+      false,
+      workspaceRoot,
+      undefined,
+    );
+
+    expect(browser?.instances).toEqual([
+      { browser: 'chrome', headless: true },
+      { browser: 'firefox', headless: true },
+    ]);
+    expect(messages).toEqual([]);
+  });
+
+  it('should return information message when headless option is redundant', async () => {
+    const { messages } = await setupBrowserConfiguration(
+      ['ChromeHeadless'],
+      true,
+      false,
+      workspaceRoot,
+      undefined,
+    );
+
+    expect(messages).toEqual([
+      'The "headless" option is unnecessary as all browsers are already configured to run in headless mode.',
+    ]);
   });
 });

--- a/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
@@ -192,12 +192,19 @@ export class VitestExecutor implements TestExecutor {
     // Setup vitest browser options if configured
     const browserOptions = await setupBrowserConfiguration(
       browsers,
+      this.options.headless,
       debug,
       projectSourceRoot,
       browserViewport,
     );
     if (browserOptions.errors?.length) {
       throw new Error(browserOptions.errors.join('\n'));
+    }
+
+    if (browserOptions.messages?.length) {
+      for (const message of browserOptions.messages) {
+        this.logger.info(message);
+      }
     }
 
     assert(

--- a/packages/angular/build/src/builders/unit-test/schema.json
+++ b/packages/angular/build/src/builders/unit-test/schema.json
@@ -60,6 +60,10 @@
       "type": "boolean",
       "description": "Enables watch mode, which re-runs tests when source files change. Defaults to `true` in TTY environments and `false` otherwise."
     },
+    "headless": {
+      "type": "boolean",
+      "description": "Forces all configured browsers to run in headless mode. When using the Vitest runner, this option is ignored if no browsers are configured. The Karma runner does not support this option."
+    },
     "debug": {
       "type": "boolean",
       "description": "Enables debugging mode for tests, allowing the use of the Node Inspector.",


### PR DESCRIPTION
This adds a new 'headless' option to the unit-test builder. When set to true, it forces all configured browsers to run in headless mode.

This option allows users to force headless execution in non-CI environments (where it is already the default) or to explicitly control the mode regardless of the browser name.

Informational messages are now logged when the option is redundant (e.g., all browsers are already headless), ignored (e.g., using the preview provider), or irrelevant (e.g., no browsers configured).

The 'karma' runner does not support this option and will log a warning if it is used.

Closes #31655