### PR TITLE
fix(@angular/build): bundle setup files in unit-test builder for Vitest

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
@@ -98,6 +98,20 @@ export async function getVitestBuildOptions(
     workspaceRoot,
     removeTestExtension: true,
   });
+
+  if (options.setupFiles?.length) {
+    const setupEntryPoints = getTestEntrypoints(options.setupFiles, {
+      projectSourceRoot,
+      workspaceRoot,
+      removeTestExtension: false,
+      prefix: 'setup',
+    });
+
+    for (const [entryPoint, setupFile] of setupEntryPoints) {
+      entryPoints.set(entryPoint, setupFile);
+    }
+  }
+
   entryPoints.set('init-testbed', 'angular:test-bed-init');
 
   // The 'vitest' package is always external for testing purposes

--- a/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
@@ -240,6 +240,15 @@ export class VitestExecutor implements TestExecutor {
       project = `${projectName} (${browserOptions.browser.instances[0].browser})`;
     }
 
+    // Filter internal entries and setup files from the include list
+    const internalEntries = ['angular:'];
+    const setupFileSet = new Set(testSetupFiles);
+    const include = [...this.testFileToEntryPoint.keys()].filter((entry) => {
+      return (
+        !internalEntries.some((internal) => entry.startsWith(internal)) && !setupFileSet.has(entry)
+      );
+    });
+
     return startVitest(
       'test',
       undefined,
@@ -272,10 +281,7 @@ export class VitestExecutor implements TestExecutor {
             reporters,
             setupFiles: testSetupFiles,
             projectPlugins,
-            include: [...this.testFileToEntryPoint.keys()].filter(
-              // Filter internal entries
-              (entry) => !entry.startsWith('angular:'),
-            ),
+            include,
           }),
         ],
       },

--- a/tests/e2e/tests/vitest/browser-playwright.ts
+++ b/tests/e2e/tests/vitest/browser-playwright.ts
@@ -3,6 +3,7 @@ import { applyVitestBuilder } from '../../utils/vitest';
 import { ng } from '../../utils/process';
 import { installPackage } from '../../utils/packages';
 import { writeFile } from '../../utils/fs';
+import { updateJsonFile } from '../../utils/project';
 
 export default async function (): Promise<void> {
   await applyVitestBuilder();
@@ -18,6 +19,10 @@ export default async function (): Promise<void> {
       getTestBed().configureTestingModule({});
     `,
   );
+
+  await updateJsonFile('tsconfig.spec.json', (json) => {
+    json.include = [...(json.include || []), 'src/setup1.ts'];
+  });
 
   const { stdout } = await ng(
     'test',

--- a/tests/e2e/tests/vitest/browser-webdriverio.ts
+++ b/tests/e2e/tests/vitest/browser-webdriverio.ts
@@ -3,6 +3,7 @@ import { applyVitestBuilder } from '../../utils/vitest';
 import { ng } from '../../utils/process';
 import { installPackage } from '../../utils/packages';
 import { writeFile } from '../../utils/fs';
+import { updateJsonFile } from '../../utils/project';
 
 export default async function (): Promise<void> {
   await applyVitestBuilder();
@@ -19,6 +20,10 @@ export default async function (): Promise<void> {
     getTestBed().configureTestingModule({});
   `,
   );
+
+  await updateJsonFile('tsconfig.spec.json', (json) => {
+    json.include = [...(json.include || []), 'src/setup1.ts'];
+  });
 
   const { stdout } = await ng(
     'test',


### PR DESCRIPTION
This change updates the Vitest runner in the unit-test builder to bundle 'setupFiles' through the application build pipeline, similar to test files. This ensures that setup files are processed with the same transformations and environment as the application code.

Note: Only setup files specified in the 'setupFiles' builder option are bundled. Setup files referenced solely within a custom Vitest configuration file (via 'runnerConfig') will not be bundled by the Angular CLI and will be processed directly by Vitest.

Closes #31732
Closes #31921