### PR TITLE
fix(@angular/build): correctly resolve absolute setup file paths in Vitest

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
@@ -229,7 +229,17 @@ export function createVitestPlugins(pluginOptions: PluginOptions): VitestPlugins
         }
 
         // Construct the full, absolute path and normalize it to POSIX format.
-        const fullPath = toPosixPath(path.join(baseDir, id));
+        let fullPath: string;
+        if (path.isAbsolute(id)) {
+          const relativeId = path.relative(baseDir, id);
+          fullPath =
+            !relativeId.startsWith('..') && !path.isAbsolute(relativeId)
+              ? id
+              : path.join(baseDir, id);
+        } else {
+          fullPath = path.join(baseDir, id);
+        }
+        fullPath = toPosixPath(fullPath);
 
         if (testFileToEntryPoint.has(fullPath)) {
           return fullPath;


### PR DESCRIPTION
The `resolveId` hook in the Vitest runner plugins now correctly handles absolute paths. Previously, the logic would blindly join the base directory with the file ID, which caused issues when the ID was already a fully qualified absolute path within the workspace. The updated logic now checks if the ID is absolute and located within the base directory before deciding whether to join paths, ensuring compatibility with both absolute paths and Vitest's short-form root-relative paths.