### PR TITLE
test: remove global Protractor/E2E setup from E2E utilities

### DIFF
--- a/tests/e2e/tests/misc/browsers.ts
+++ b/tests/e2e/tests/misc/browsers.ts
@@ -10,6 +10,8 @@ export default async function () {
     throw new Error('SauceLabs is not configured.');
   }
 
+  await ng('generate', 'private-e2e', '--related-app-name', 'test-project');
+
   // Workaround for https://github.com/angular/angular/issues/32192
   await replaceInFile('src/app/app.html', /class="material-icons"/g, '');
 
@@ -43,6 +45,7 @@ export default async function () {
     await ng(
       'e2e',
       'test-project',
+      '--no-webdriver-update',
       '--protractor-config=e2e/protractor-saucelabs.conf.js',
       '--dev-server-target=',
     );

--- a/tests/e2e/tests/protractor/test-fails.ts
+++ b/tests/e2e/tests/protractor/test-fails.ts
@@ -1,11 +1,15 @@
-import { execAndCaptureError } from '../../utils/process';
+import { execAndCaptureError, ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
 
 export default async function () {
-  // Revert the `private-protractor` builder name back to the previous `protractor`.
+  // Setup `protractor` builder.
   await updateJsonFile('angular.json', (config) => {
-    config.projects['test-project'].architect['e2e'].builder =
-      '@angular-devkit/build-angular:protractor';
+    config.projects['test-project'].architect['e2e'] = {
+      builder: '@angular-devkit/build-angular:protractor',
+      options: {
+        protractorConfig: '',
+      },
+    };
   });
 
   const error = await execAndCaptureError('ng', ['e2e']);

--- a/tests/e2e/utils/project.ts
+++ b/tests/e2e/utils/project.ts
@@ -52,9 +52,7 @@ export async function prepareProjectForE2e(name: string) {
 
   console.log(`Project ${name} created... Installing packages.`);
   await installWorkspacePackages();
-  await ng('generate', 'private-e2e', '--related-app-name', name);
 
-  await useCIChrome(name, 'e2e');
   await useCIChrome(name, '');
   await useCIDefaults(name);
 
@@ -137,12 +135,6 @@ export function useCIDefaults(projectName = 'test-project'): Promise<void> {
     const appTargets = project.targets || project.architect;
     appTargets.build.options.progress = false;
     appTargets.test.options.progress = false;
-    if (appTargets.e2e) {
-      // Disable auto-updating webdriver in e2e.
-      appTargets.e2e.options.webdriverUpdate = false;
-      // Use a random port in e2e.
-      appTargets.e2e.options.port = 0;
-    }
 
     if (appTargets.serve) {
       // Use a random port in serve.
@@ -153,25 +145,6 @@ export function useCIDefaults(projectName = 'test-project'): Promise<void> {
 }
 
 export async function useCIChrome(projectName: string, projectDir = ''): Promise<void> {
-  const protractorConf = path.join(projectDir, 'protractor.conf.js');
-  if (fs.existsSync(protractorConf)) {
-    // Ensure the headless sandboxed chrome is configured in the protractor config
-    await replaceInFile(
-      protractorConf,
-      `browserName: 'chrome'`,
-      `browserName: 'chrome',
-      chromeOptions: {
-        args: ['--headless', '--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage'],
-        binary: String.raw\`${process.env.CHROME_BIN}\`,
-      }`,
-    );
-    await replaceInFile(
-      protractorConf,
-      'directConnect: true,',
-      `directConnect: true, chromeDriver: String.raw\`${process.env.CHROMEDRIVER_BIN}\`,`,
-    );
-  }
-
   const karmaConf = path.join(projectDir, 'karma.conf.js');
   if (fs.existsSync(karmaConf)) {
     // Ensure the headless sandboxed chrome is configured in the karma config


### PR DESCRIPTION
Since most E2E tests have been migrated away from Protractor, this change removes the automatic generation of the 'private-e2e' schematic and its associated configuration from the global 'prepareProjectForE2e' and 'useCIChrome' utilities. The setup is now explicitly handled within the 'browsers' test which still requires it, resulting in cleaner and faster initialization for the majority of the E2E suite.