### PR TITLE
feat(@schematics/angular): add watch script for SSR in `package.json`

### DIFF
--- a/packages/schematics/angular/ssr/index.ts
+++ b/packages/schematics/angular/ssr/index.ts
@@ -125,6 +125,7 @@ function addScriptsRule({ project }: SSROptions, isUsingApplicationBuilder: bool
       const { base, server } = await getApplicationBuilderOutputPaths(host, project);
       pkg.scripts ??= {};
       pkg.scripts[`serve:ssr:${project}`] = `node ${join(base, server)}/server.mjs`;
+      pkg.scripts[`watch:ssr:${project}`] = `node --watch ${join(base, server)}/server.mjs`;
     } else {
       const serverDist = await getLegacyOutputPaths(host, project, 'server');
       pkg.scripts = {
@@ -376,13 +377,13 @@ const ssrSchematic: RuleFactory<SSROptions> = createProjectSchematic(
       }),
       ...(usingApplicationBuilder
         ? [
-            updateApplicationBuilderWorkspaceConfigRule(sourceRoot, options, context),
-            updateApplicationBuilderTsConfigRule(options),
-          ]
+          updateApplicationBuilderWorkspaceConfigRule(sourceRoot, options, context),
+          updateApplicationBuilderTsConfigRule(options),
+        ]
         : [
-            updateWebpackBuilderServerTsConfigRule(options),
-            updateWebpackBuilderWorkspaceConfigRule(sourceRoot, options),
-          ]),
+          updateWebpackBuilderServerTsConfigRule(options),
+          updateWebpackBuilderWorkspaceConfigRule(sourceRoot, options),
+        ]),
       addServerFile(sourceRoot, options, isStandalone),
       addScriptsRule(options, usingApplicationBuilder),
       addDependencies(options, usingApplicationBuilder),

--- a/packages/schematics/angular/ssr/index_spec.ts
+++ b/packages/schematics/angular/ssr/index_spec.ts
@@ -124,6 +124,7 @@ describe('SSR Schematic', () => {
       const { scripts } = tree.readJson('/package.json') as { scripts: Record<string, string> };
 
       expect(scripts['serve:ssr:test-app']).toBe(`node dist/test-app/server/server.mjs`);
+      expect(scripts['watch:ssr:test-app']).toBe(`node --watch dist/test-app/server/server.mjs`);
     });
 
     it('works when using a custom "outputPath.browser" and "outputPath.server" values', async () => {


### PR DESCRIPTION
Add a watch script to run node in listen mode similar to the watch script for the client application.

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
