### PR TITLE
docs: release notes for the v20.3.16 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="20.3.16"></a>
+
+# 20.3.16 (2026-02-09)
+
+### @angular/cli
+
+| Commit                                                                                              | Type | Description                                            |
+| --------------------------------------------------------------------------------------------------- | ---- | ------------------------------------------------------ |
+| [656888a25](https://github.com/angular/angular-cli/commit/656888a250af060c110ae87024b0e475b079c23d) | fix  | update dependency @modelcontextprotocol/sdk to v1.26.0 |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="21.2.0-next.1"></a>
 
 # 21.2.0-next.1 (2026-02-05)


### PR DESCRIPTION
Cherry-picks the changelog from the "20.3.x" branch to the next branch (main).