### PR TITLE
feat(@angular/build): run vitest browser with playwright with OS theme

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/browser-provider.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/browser-provider.ts
@@ -99,6 +99,17 @@ export async function setupBrowserConfiguration(
             launchOptions: {
               executablePath: process.env.CHROME_BIN,
             },
+            contextOptions: {
+              // Enables `prefer-color-scheme` for Vitest browser instead of `light`
+              colorScheme: null,
+            },
+          });
+        } else if (providerName === 'playwright') {
+          provider = providerFactory({
+            contextOptions: {
+              // Enables `prefer-color-scheme` for Vitest browser instead of `light`
+              colorScheme: null,
+            },
           });
         } else {
           provider = providerFactory();

--- a/packages/angular/build/src/builders/unit-test/runners/vitest/browser-provider_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/browser-provider_spec.ts
@@ -28,7 +28,7 @@ describe('setupBrowserConfiguration', () => {
     );
     await writeFile(
       join(playwrightPkgPath, 'index.js'),
-      'module.exports = { playwright: () => ({ name: "playwright" }) };',
+      'module.exports = { playwright: (options) => ({ name: "playwright", options }) };',
     );
   });
 
@@ -133,6 +133,25 @@ describe('setupBrowserConfiguration', () => {
         process.env['CI'] = originalCI;
       }
     }
+  });
+
+  // See: https://github.com/angular/angular-cli/issues/32469
+  it('should pass colorScheme=null to Playwright provider', async () => {
+    const { browser } = await setupBrowserConfiguration(
+      ['ChromeHeadless'],
+      undefined,
+      false,
+      workspaceRoot,
+      undefined,
+    );
+
+    expect(browser?.provider?.options).toEqual(
+      jasmine.objectContaining({
+        contextOptions: jasmine.objectContaining({
+          colorScheme: null,
+        }),
+      }),
+    );
   });
 
   it('should support Preview provider forcing headless false', async () => {


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [X] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #32469

Using Vitest with `@vitest/browser-playwright` will open browser with `light` mode every time when running tests, even if theme toggle is used.

<img width="311" height="121" alt="image" src="https://github.com/user-attachments/assets/a0c0c5d4-a098-4121-8c28-f43bc44e33f5" />


## What is the new behavior?

<!-- Please describe the new behavior that. -->

Using Vitest with `@vitest/browser-playwright` will open browser using `prefers-color-scheme` from OS over `light` default in Playwright.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Setting the value like this affects the entire browser, and not just the Vitest UI. If any components with styles runs expecting `light` but getting `dark` via `prefers-color-scheme`, then tests may fail if tests rely on `light` being the default.

An alternative approach could be to only modify the `vueuse-color-scheme` for `localhost:<port>` via [`contextOptions.storageState`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-storage-state) instead.

Another option would be to create an `angular.json` option for `@angular/build:unit-test` such that it's possible to opt-in to changing this default.

## Other information

I can create a test for this after feedback on which option would be best for this; current PR code, using `storageState`, or adding a `option` config value. 

Would it be best to modify the existing playwright test, or add a new one, when testing this? (https://github.com/angular/angular-cli/blob/main/tests/e2e/tests/vitest/browser-playwright.ts#L19)