### PR TITLE
docs: release notes for the v21.1.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="21.1.4"></a>
+
+# 21.1.4 (2026-02-11)
+
+### @angular/build
+
+| Commit                                                                                              | Type | Description                                           |
+| --------------------------------------------------------------------------------------------------- | ---- | ----------------------------------------------------- |
+| [7a9dd6b47](https://github.com/angular/angular-cli/commit/7a9dd6b47e2191862c64355b10abaeead189759f) | fix  | correctly resolve absolute setup file paths in Vitest |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="20.3.16"></a>
 
 # 20.3.16 (2026-02-09)


### PR DESCRIPTION
Cherry-picks the changelog from the "21.1.x" branch to the next branch (main).