### PR TITLE
fix(@angular/ssr): introduce DI token to signal route discovery process

### DIFF
--- a/goldens/public-api/angular/ssr/index.api.md
+++ b/goldens/public-api/angular/ssr/index.api.md
@@ -6,6 +6,7 @@
 
 import { DefaultExport } from '@angular/router';
 import { EnvironmentProviders } from '@angular/core';
+import { InjectionToken } from '@angular/core';
 import { Provider } from '@angular/core';
 import { Type } from '@angular/core';
 
@@ -25,6 +26,9 @@ export interface AngularAppEngineOptions {
 
 // @public
 export function createRequestHandler(handler: RequestHandlerFunction): RequestHandlerFunction;
+
+// @public
+export const IS_DISCOVERING_ROUTES: InjectionToken<boolean>;
 
 // @public
 export enum PrerenderFallback {

--- a/packages/angular/ssr/public_api.ts
+++ b/packages/angular/ssr/public_api.ts
@@ -24,3 +24,5 @@ export {
   type ServerRouteServer,
   type ServerRouteCommon,
 } from './src/routes/route-config';
+
+export { IS_DISCOVERING_ROUTES } from './src/routes/ng-routes';

--- a/packages/angular/ssr/src/routes/ng-routes.ts
+++ b/packages/angular/ssr/src/routes/ng-routes.ts
@@ -11,6 +11,7 @@ import {
   ApplicationRef,
   Compiler,
   EnvironmentInjector,
+  InjectionToken,
   Injector,
   createEnvironmentInjector,
   runInInjectionContext,
@@ -23,6 +24,7 @@ import {
   Router,
   ɵloadChildren as loadChildrenHelper,
 } from '@angular/router';
+
 import { ServerAssets } from '../assets';
 import { Console } from '../console';
 import { AngularAppManifest, getAngularAppManifest } from '../manifest';
@@ -38,6 +40,22 @@ import {
   ServerRoutesConfig,
 } from './route-config';
 import { RouteTree, RouteTreeNodeMetadata } from './route-tree';
+
+/**
+ * A DI token that indicates whether the application is in the process of discovering routes.
+ *
+ * This token is provided with the value `true` when route discovery is active, allowing other
+ * parts of the application to conditionally execute logic. For example, it can be used to
+ * disable features or behaviors that are not necessary or might interfere with the route
+ * discovery process.
+ */
+export const IS_DISCOVERING_ROUTES = new InjectionToken<boolean>(
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'IS_DISCOVERING_ROUTES' : '',
+  {
+    providedIn: 'platform',
+    factory: () => false,
+  },
+);
 
 interface Route extends AngularRoute {
   ɵentryName?: string;
@@ -622,6 +640,10 @@ export async function getRoutesFromAngularRouterConfig(
     {
       provide: ɵENABLE_ROOT_COMPONENT_BOOTSTRAP,
       useValue: false,
+    },
+    {
+      provide: IS_DISCOVERING_ROUTES,
+      useValue: true,
     },
   ]);
 

--- a/packages/angular/ssr/test/routes/ng-routes_spec.ts
+++ b/packages/angular/ssr/test/routes/ng-routes_spec.ts
@@ -18,7 +18,7 @@ import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
 } from '@angular/router';
-import { extractRoutesAndCreateRouteTree } from '../../src/routes/ng-routes';
+import { IS_DISCOVERING_ROUTES, extractRoutesAndCreateRouteTree } from '../../src/routes/ng-routes';
 import { PrerenderFallback, RenderMode } from '../../src/routes/route-config';
 import { setAngularAppTestingManifest } from '../testing-utils';
 
@@ -789,5 +789,27 @@ describe('extractRoutesAndCreateRouteTree', () => {
       { route: '/', renderMode: RenderMode.Server },
       { route: '/home', renderMode: RenderMode.Server },
     ]);
+  });
+
+  it('should provide `IS_DISCOVERING_ROUTES` as `true` during route discovery', async () => {
+    let isDiscoveringRoutes: boolean | undefined;
+
+    setAngularAppTestingManifest(
+      [
+        {
+          path: 'lazy',
+          loadChildren: () => {
+            isDiscoveringRoutes = inject(IS_DISCOVERING_ROUTES);
+
+            return [];
+          },
+        },
+      ],
+      [{ path: '**', renderMode: RenderMode.Server }],
+    );
+
+    await extractRoutesAndCreateRouteTree({ url });
+
+    expect(isDiscoveringRoutes).toBeTrue();
   });
 });


### PR DESCRIPTION
A new DI token, `IS_DISCOVERING_ROUTES`, is introduced to provide a clear signal for when the application is operating in route discovery mode. This token is provided with the value `true` within the route extraction providers. Other services and components can inject this token to conditionally alter their behavior, for instance, to disable functionality that is not required or could interfere with the route discovery process.

Closes #32474