### PR TITLE
fix(@angular/ssr): validate host headers to prevent header-based SSRF [LTS 19]

### DIFF
--- a/goldens/public-api/angular/ssr/node/index.api.md
+++ b/goldens/public-api/angular/ssr/node/index.api.md
@@ -20,12 +20,13 @@ export class AngularNodeAppEngine {
 
 // @public
 export class CommonEngine {
-    constructor(options?: CommonEngineOptions | undefined);
+    constructor(options: CommonEngineOptions);
     render(opts: CommonEngineRenderOptions): Promise<string>;
 }
 
 // @public (undocumented)
 export interface CommonEngineOptions {
+    allowedHosts: readonly string[];
     bootstrap?: Type<{}> | ((context: BootstrapContext) => Promise<ApplicationRef>);
     enablePerformanceProfiler?: boolean;
     providers?: StaticProvider[];

--- a/packages/angular/build/src/builders/application/execute-build.ts
+++ b/packages/angular/build/src/builders/application/execute-build.ts
@@ -56,6 +56,7 @@ export async function executeBuild(
     verbose,
     colors,
     jsonLogs,
+    security,
   } = options;
 
   // TODO: Consider integrating into watch mode. Would require full rebuild on target changes.
@@ -263,7 +264,7 @@ export async function executeBuild(
   if (serverEntryPoint) {
     executionResult.addOutputFile(
       SERVER_APP_ENGINE_MANIFEST_FILENAME,
-      generateAngularServerAppEngineManifest(i18nOptions, baseHref),
+      generateAngularServerAppEngineManifest(i18nOptions, security.allowedHosts, baseHref),
       BuildOutputFileType.ServerRoot,
     );
   }

--- a/packages/angular/build/src/builders/application/options.ts
+++ b/packages/angular/build/src/builders/application/options.ts
@@ -388,8 +388,9 @@ export async function normalizeOptions(
     }
   }
 
-  const autoCsp = options.security?.autoCsp;
+  const { autoCsp, allowedHosts = [] } = options.security ?? {};
   const security = {
+    allowedHosts,
     autoCsp: autoCsp
       ? {
           unsafeEval: autoCsp === true ? false : !!autoCsp.unsafeEval,

--- a/packages/angular/build/src/builders/application/schema.json
+++ b/packages/angular/build/src/builders/application/schema.json
@@ -52,6 +52,14 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "allowedHosts": {
+          "description": "A list of hostnames that are allowed to access the server-side application. For more information, see https://angular.dev/guide/ssr#configuring-allowed-hosts.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
         "autoCsp": {
           "description": "Enables automatic generation of a hash-based Strict Content Security Policy (https://web.dev/articles/strict-csp#choose-hash) based on scripts in index.html. Will default to true once we are out of experimental/preview phases.",
           "default": false,

--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -115,6 +115,7 @@ export async function* serveWithVite(
   // Disable auto CSP.
   browserOptions.security = {
     autoCsp: false,
+    allowedHosts: Array.isArray(serverOptions.allowedHosts) ? serverOptions.allowedHosts : [],
   };
 
   // Disable JSON build stats.

--- a/packages/angular/build/src/utils/server-rendering/manifest.ts
+++ b/packages/angular/build/src/utils/server-rendering/manifest.ts
@@ -53,11 +53,13 @@ function escapeUnsafeChars(str: string): string {
  *
  * @param i18nOptions - The internationalization options for the application build. This
  * includes settings for inlining locales and determining the output structure.
+ * @param allowedHosts - A list of hosts that are allowed to access the server-side application.
  * @param baseHref - The base HREF for the application. This is used to set the base URL
  * for all relative URLs in the application.
  */
 export function generateAngularServerAppEngineManifest(
   i18nOptions: NormalizedApplicationBuildOptions['i18nOptions'],
+  allowedHosts: string[],
   baseHref: string | undefined,
 ): string {
   const entryPoints: Record<string, string> = {};
@@ -84,6 +86,7 @@ export function generateAngularServerAppEngineManifest(
   const manifestContent = `
 export default {
   basePath: '${basePath}',
+  allowedHosts: ${JSON.stringify(allowedHosts, undefined, 2)},
   supportedLocales: ${JSON.stringify(supportedLocales, undefined, 2)},
   entryPoints: {
     ${Object.entries(entryPoints)

--- a/packages/angular/ssr/node/src/common-engine/common-engine.ts
+++ b/packages/angular/ssr/node/src/common-engine/common-engine.ts
@@ -12,6 +12,7 @@ import { renderApplication, renderModule, ɵSERVER_CONTEXT } from '@angular/plat
 import * as fs from 'node:fs';
 import { dirname, join, normalize, resolve } from 'node:path';
 import { URL } from 'node:url';
+import { isHostAllowed } from '../../../src/utils/validation';
 import { CommonEngineInlineCriticalCssProcessor } from './inline-css-processor';
 import {
   noopRunMethodAndMeasurePerf,
@@ -30,6 +31,9 @@ export interface CommonEngineOptions {
 
   /** Enable request performance profiling data collection and printing the results in the server console. */
   enablePerformanceProfiler?: boolean;
+
+  /** A set of hostnames that are allowed to access the server. */
+  allowedHosts: readonly string[];
 }
 
 export interface CommonEngineRenderOptions {
@@ -63,14 +67,21 @@ export class CommonEngine {
   private readonly templateCache = new Map<string, string>();
   private readonly inlineCriticalCssProcessor = new CommonEngineInlineCriticalCssProcessor();
   private readonly pageIsSSG = new Map<string, boolean>();
+  private readonly allowedHosts: ReadonlySet<string>;
 
-  constructor(private options?: CommonEngineOptions) {}
+  constructor(private options: CommonEngineOptions) {
+    this.allowedHosts = new Set(options.allowedHosts);
+  }
 
   /**
    * Render an HTML document for a specific URL with specified
    * render options
    */
   async render(opts: CommonEngineRenderOptions): Promise<string> {
+    if (opts.url) {
+      this.validateHost(opts.url);
+    }
+
     const enablePerformanceProfiler = this.options?.enablePerformanceProfiler;
 
     const runMethod = enablePerformanceProfiler
@@ -97,6 +108,19 @@ export class CommonEngine {
     }
 
     return html;
+  }
+
+  private validateHost(url: string): void {
+    if (!URL.canParse(url)) {
+      throw new Error(`URL "${url}" is invalid.`);
+    }
+
+    const hostname = new URL(url).hostname;
+    if (!isHostAllowed(hostname, this.allowedHosts)) {
+      throw new Error(
+        `Host ${hostname} is not allowed. Please provide a list of allowed hosts in the "allowedHosts" option.`,
+      );
+    }
   }
 
   private inlineCriticalCss(html: string, opts: CommonEngineRenderOptions): Promise<string> {

--- a/packages/angular/ssr/node/src/request.ts
+++ b/packages/angular/ssr/node/src/request.ts
@@ -8,6 +8,7 @@
 
 import type { IncomingHttpHeaders, IncomingMessage } from 'node:http';
 import type { Http2ServerRequest } from 'node:http2';
+import { getFirstHeaderValue } from '../../src/utils/validation';
 
 /**
  * A set containing all the pseudo-headers defined in the HTTP/2 specification.
@@ -101,22 +102,4 @@ export function createRequestUrl(nodeRequest: IncomingMessage | Http2ServerReque
   }
 
   return new URL(`${protocol}://${hostnameWithPort}${originalUrl ?? url}`);
-}
-
-/**
- * Extracts the first value from a multi-value header string.
- *
- * @param value - A string or an array of strings representing the header values.
- *                           If it's a string, values are expected to be comma-separated.
- * @returns The first trimmed value from the multi-value header, or `undefined` if the input is invalid or empty.
- *
- * @example
- * ```typescript
- * getFirstHeaderValue("value1, value2, value3"); // "value1"
- * getFirstHeaderValue(["value1", "value2"]); // "value1"
- * getFirstHeaderValue(undefined); // undefined
- * ```
- */
-function getFirstHeaderValue(value: string | string[] | undefined): string | undefined {
-  return value?.toString().split(',', 1)[0]?.trim();
 }

--- a/packages/angular/ssr/src/manifest.ts
+++ b/packages/angular/ssr/src/manifest.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import type { BootstrapContext } from '@angular/platform-browser';
 import type { SerializableRouteTreeNode } from './routes/route-tree';
 import { AngularBootstrap } from './utils/ng';
 
@@ -74,6 +73,11 @@ export interface AngularAppEngineManifest {
    * - `value`: The url segment associated with that locale.
    */
   readonly supportedLocales: Readonly<Record<string, string | undefined>>;
+
+  /**
+   * A readonly array of allowed hostnames.
+   */
+  readonly allowedHosts: Readonly<string[]>;
 }
 
 /**

--- a/packages/angular/ssr/src/utils/validation.ts
+++ b/packages/angular/ssr/src/utils/validation.ts
@@ -1,0 +1,193 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+/**
+ * Regular expression to validate that the port is a numeric value.
+ */
+const VALID_PORT_REGEX = /^\d+$/;
+
+/**
+ * Regular expression to validate that the protocol is either http or https (case-insensitive).
+ */
+const VALID_PROTO_REGEX = /^https?$/i;
+
+/**
+ * Regular expression to match path separators.
+ */
+const PATH_SEPARATOR_REGEX = /[/\\]/;
+
+/**
+ * Set of hostnames that are always allowed.
+ */
+const DEFAULT_ALLOWED_HOSTS: ReadonlySet<string> = new Set([
+  '*.localhost',
+  'localhost',
+  '127.0.0.1',
+  '::1',
+  '[::1]',
+]);
+
+/**
+ * Extracts the first value from a multi-value header string.
+ *
+ * @param value - A string or an array of strings representing the header values.
+ *                If it's a string, values are expected to be comma-separated.
+ * @returns The first trimmed value from the multi-value header, or `undefined` if the input is invalid or empty.
+ *
+ * @example
+ * ```typescript
+ * getFirstHeaderValue("value1, value2, value3"); // "value1"
+ * getFirstHeaderValue(["value1", "value2"]); // "value1"
+ * getFirstHeaderValue(undefined); // undefined
+ * ```
+ */
+export function getFirstHeaderValue(
+  value: string | string[] | undefined | null,
+): string | undefined {
+  return value?.toString().split(',', 1)[0]?.trim();
+}
+
+/**
+ * Validates a request.
+ *
+ * @param request - The incoming `Request` object to validate.
+ * @param allowedHosts - A set of allowed hostnames.
+ * @throws Error if any of the validated headers contain invalid values.
+ */
+export function validateRequest(request: Request, allowedHosts: ReadonlySet<string>): void {
+  validateHeaders(request, allowedHosts);
+  validateUrl(new URL(request.url), allowedHosts);
+}
+
+/**
+ * Validates that the hostname of a given URL is allowed.
+ *
+ * @param url - The URL object to validate.
+ * @param allowedHosts - A set of allowed hostnames.
+ * @throws Error if the hostname is not in the allowlist.
+ */
+export function validateUrl(url: URL, allowedHosts: ReadonlySet<string>): void {
+  if (!isHostAllowed(url.hostname, allowedHosts)) {
+    let errorMessage = `URL with hostname "${url.hostname}" is not allowed.`;
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      errorMessage +=
+        '\n\nAction Required: Update your "angular.json" to include this hostname. ' +
+        'Path: "projects.[project-name].architect.build.options.security.allowedHosts".' +
+        '\n\nFor more information, see https://angular.dev/guide/ssr#configuring-allowed-hosts';
+    }
+
+    throw new Error(errorMessage);
+  }
+}
+
+/**
+ * Validates a specific host header value against the allowed hosts.
+ *
+ * @param headerName - The name of the header to validate (e.g., 'host', 'x-forwarded-host').
+ * @param headers - The `Headers` object from the request.
+ * @param allowedHosts - A set of allowed hostnames.
+ * @throws Error if the header value is invalid or the hostname is not in the allowlist.
+ */
+function validateHostHeaders(
+  headerName: string,
+  headers: Headers,
+  allowedHosts: ReadonlySet<string>,
+): void {
+  const value = getFirstHeaderValue(headers.get(headerName));
+  if (!value) {
+    return;
+  }
+
+  // Reject any hostname containing path separators - they're invalid.
+  if (PATH_SEPARATOR_REGEX.test(value)) {
+    throw new Error(`Header "${headerName}" contains path separators which is not allowed.`);
+  }
+
+  const url = `http://${value}`;
+  if (!URL.canParse(url)) {
+    throw new Error(`Header "${headerName}" contains an invalid value.`);
+  }
+
+  const { hostname } = new URL(url);
+  if (!isHostAllowed(hostname, allowedHosts)) {
+    let errorMessage = `Header "${headerName}" with value "${value}" is not allowed.`;
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      errorMessage +=
+        '\n\nAction Required: Update your "angular.json" to include this hostname. ' +
+        'Path: "projects.[project-name].architect.build.options.security.allowedHosts".' +
+        '\n\nFor more information, see https://angular.dev/guide/ssr#configuring-allowed-hosts';
+    }
+
+    throw new Error(errorMessage);
+  }
+}
+
+/**
+ * Checks if the hostname is allowed.
+ * @param hostname - The hostname to check.
+ * @param allowedHosts - A set of allowed hostnames.
+ * @returns `true` if the hostname is allowed, `false` otherwise.
+ */
+export function isHostAllowed(hostname: string, allowedHosts: ReadonlySet<string>): boolean {
+  return (
+    // Check the provided allowed hosts first.
+    allowedHosts.has(hostname) ||
+    checkWildcardHostnames(hostname, allowedHosts) ||
+    // Check the default allowed hosts last this is the fallback and should be rarely if ever used in production.
+    DEFAULT_ALLOWED_HOSTS.has(hostname) ||
+    checkWildcardHostnames(hostname, DEFAULT_ALLOWED_HOSTS)
+  );
+}
+
+/**
+ * Checks if the hostname matches any of the wildcard hostnames in the allowlist.
+ * @param hostname - The hostname to check.
+ * @param allowedHosts - A set of allowed hostnames.
+ * @returns `true` if the hostname matches any of the wildcard hostnames, `false` otherwise.
+ */
+function checkWildcardHostnames(hostname: string, allowedHosts: ReadonlySet<string>): boolean {
+  for (const allowedHost of allowedHosts) {
+    if (!allowedHost.startsWith('*.')) {
+      continue;
+    }
+
+    const domain = allowedHost.slice(1);
+    if (hostname.endsWith(domain)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Validates the headers of an incoming request.
+ *
+ * This function checks for the validity of critical headers such as `x-forwarded-host`,
+ *  `host`, `x-forwarded-port`, and `x-forwarded-proto`.
+ * It ensures that the hostnames match the allowed hosts and that ports and protocols adhere to expected formats.
+ *
+ * @param request - The incoming `Request` object containing the headers to validate.
+ * @param allowedHosts - A set of allowed hostnames.
+ * @throws Error if any of the validated headers contain invalid values.
+ */
+function validateHeaders(request: Request, allowedHosts: ReadonlySet<string>): void {
+  const headers = request.headers;
+  validateHostHeaders('x-forwarded-host', headers, allowedHosts);
+  validateHostHeaders('host', headers, allowedHosts);
+
+  const xForwardedPort = getFirstHeaderValue(headers.get('x-forwarded-port'));
+  if (xForwardedPort && !VALID_PORT_REGEX.test(xForwardedPort)) {
+    throw new Error('Header "x-forwarded-port" must be a numeric value.');
+  }
+
+  const xForwardedProto = getFirstHeaderValue(headers.get('x-forwarded-proto'));
+  if (xForwardedProto && !VALID_PROTO_REGEX.test(xForwardedProto)) {
+    throw new Error('Header "x-forwarded-proto" must be either "http" or "https".');
+  }
+}

--- a/packages/angular/ssr/test/utils/validation_spec.ts
+++ b/packages/angular/ssr/test/utils/validation_spec.ts
@@ -1,0 +1,200 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { validateRequest, validateUrl } from '../../src/utils/validation';
+
+describe('validateRequest', () => {
+  const allowedHosts = new Set(['example.com', 'sub.example.com']);
+
+  it('should pass valid headers with allowed host', () => {
+    const request = new Request('https://example.com', {
+      headers: {
+        'host': 'example.com',
+        'x-forwarded-host': 'sub.example.com',
+        'x-forwarded-port': '443',
+        'x-forwarded-proto': 'https',
+      },
+    });
+
+    expect(() => validateRequest(request, allowedHosts)).not.toThrow();
+  });
+
+  it('should pass valid headers with localhost (default allowed)', () => {
+    const request = new Request('https://localhost', {
+      headers: {
+        'host': 'localhost',
+      },
+    });
+
+    expect(() => validateRequest(request, allowedHosts)).not.toThrow();
+  });
+
+  it('should throw error for disallowed host', () => {
+    const request = new Request('https://evil.com', {
+      headers: {
+        'host': 'evil.com',
+      },
+    });
+
+    expect(() => validateRequest(request, allowedHosts)).toThrowError(
+      /Header "host" with value "evil\.com" is not allowed/,
+    );
+  });
+
+  // ...
+
+  it('should throw error for disallowed x-forwarded-host', () => {
+    const request = new Request('https://example.com', {
+      headers: {
+        'host': 'example.com',
+        'x-forwarded-host': 'evil.com',
+      },
+    });
+
+    expect(() => validateRequest(request, allowedHosts)).toThrowError(
+      /Header "x-forwarded-host" with value "evil\.com" is not allowed/,
+    );
+  });
+
+  it('should throw error for invalid x-forwarded-host containing path separators', () => {
+    const request = new Request('https://example.com', {
+      headers: {
+        'host': 'example.com',
+        'x-forwarded-host': 'example.com/evil',
+      },
+    });
+
+    expect(() => validateRequest(request, allowedHosts)).toThrowError(
+      'Header "x-forwarded-host" contains path separators which is not allowed.',
+    );
+  });
+
+  it('should throw error for invalid x-forwarded-port (non-numeric)', () => {
+    const request = new Request('https://example.com', {
+      headers: {
+        'host': 'example.com',
+        'x-forwarded-port': 'abc',
+      },
+    });
+
+    expect(() => validateRequest(request, allowedHosts)).toThrowError(
+      'Header "x-forwarded-port" must be a numeric value.',
+    );
+  });
+
+  it('should throw error for invalid x-forwarded-proto', () => {
+    const request = new Request('https://example.com', {
+      headers: {
+        'host': 'example.com',
+        'x-forwarded-proto': 'ftp',
+      },
+    });
+
+    expect(() => validateRequest(request, allowedHosts)).toThrowError(
+      'Header "x-forwarded-proto" must be either "http" or "https".',
+    );
+  });
+
+  it('should pass for valid x-forwarded-proto (case insensitive)', () => {
+    const request = new Request('https://example.com', {
+      headers: {
+        'host': 'example.com',
+        'x-forwarded-proto': 'HTTP',
+      },
+    });
+
+    expect(() => validateRequest(request, allowedHosts)).not.toThrow();
+  });
+
+  it('should ignore port in host validation', () => {
+    const request = new Request('https://example.com:8080', {
+      headers: {
+        'host': 'example.com:8080',
+      },
+    });
+
+    expect(() => validateRequest(request, allowedHosts)).not.toThrow();
+  });
+
+  it('should throw if host header is completely malformed url', () => {
+    const request = new Request('https://example.com', {
+      headers: {
+        'host': '[',
+      },
+    });
+
+    expect(() => validateRequest(request, allowedHosts)).toThrowError(
+      'Header "host" contains an invalid value.',
+    );
+  });
+
+  describe('wildcard allowed hosts', () => {
+    const wildcardHosts = new Set(['*.example.com']);
+
+    it('should match subdomain', () => {
+      const request = new Request('https://sub.example.com', {
+        headers: {
+          'host': 'sub.example.com',
+        },
+      });
+
+      expect(() => validateRequest(request, wildcardHosts)).not.toThrow();
+    });
+
+    it('should match nested subdomain', () => {
+      const request = new Request('https://deep.sub.example.com', {
+        headers: {
+          'host': 'deep.sub.example.com',
+        },
+      });
+
+      expect(() => validateRequest(request, wildcardHosts)).not.toThrow();
+    });
+
+    it('should not match base domain', () => {
+      const request = new Request('https://example.com', {
+        headers: {
+          'host': 'example.com',
+        },
+      });
+
+      expect(() => validateRequest(request, wildcardHosts)).toThrowError(
+        /Header "host" with value "example\.com" is not allowed/,
+      );
+    });
+
+    it('should not match other domain', () => {
+      const request = new Request('https://evil.com', {
+        headers: {
+          'host': 'evil.com',
+        },
+      });
+
+      expect(() => validateRequest(request, wildcardHosts)).toThrowError(
+        /Header "host" with value "evil\.com" is not allowed/,
+      );
+    });
+  });
+
+  it('should pass valid URL with allowed host', () => {
+    const request = new Request('https://example.com/path');
+    expect(() => validateRequest(request, allowedHosts)).not.toThrow();
+  });
+
+  it('should pass valid URL with allowed sub-domain', () => {
+    const request = new Request('https://sub.example.com/path');
+    expect(() => validateRequest(request, allowedHosts)).not.toThrow();
+  });
+
+  it('should throw error for disallowed host', () => {
+    const request = new Request('https://evil.com/path');
+    expect(() => validateRequest(request, allowedHosts)).toThrowError(
+      /URL with hostname "evil\.com" is not allowed/,
+    );
+  });
+});

--- a/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/specs/ssl_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/specs/ssl_spec.ts
@@ -34,7 +34,7 @@ describe('Serve SSR Builder', () => {
           const server = express();
           const distFolder = resolve(__dirname, '../dist');
           const indexHtml = join(distFolder, 'index.html');
-          const commonEngine = new CommonEngine();
+          const commonEngine = new CommonEngine({ allowedHosts: [] });
 
           server.set('view engine', 'html');
           server.set('views', distFolder);
@@ -44,11 +44,12 @@ describe('Serve SSR Builder', () => {
           }));
 
           server.get('*', (req, res, next) => {
+            const { protocol, originalUrl, baseUrl, headers } = req;
             commonEngine
               .render({
                 bootstrap: AppServerModule,
                 documentFilePath: indexHtml,
-                url: req.originalUrl,
+                url: \`\${protocol}://\${headers.host}\${originalUrl}\`,
                 publicPath: distFolder,
               })
               .then((html) => res.send(html))

--- a/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/specs/works_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/specs/works_spec.ts
@@ -33,7 +33,7 @@ describe('Serve SSR Builder', () => {
         const server = express();
         const distFolder = resolve(__dirname, '../dist');
         const indexHtml = join(distFolder, 'index.html');
-        const commonEngine = new CommonEngine();
+        const commonEngine = new CommonEngine({ allowedHosts: [] });
 
         server.set('view engine', 'html');
         server.set('views', distFolder);
@@ -43,11 +43,12 @@ describe('Serve SSR Builder', () => {
         }));
 
         server.get('*', (req, res, next) => {
+          const { protocol, originalUrl, baseUrl, headers } = req;
           commonEngine
             .render({
               bootstrap: AppServerModule,
               documentFilePath: indexHtml,
-              url: req.originalUrl,
+              url: \`\${protocol}://\${headers.host}\${originalUrl}\`,
               publicPath: distFolder,
             })
             .then((html) => res.send(html))

--- a/packages/schematics/angular/ssr/files/application-builder-common-engine/server.ts.template
+++ b/packages/schematics/angular/ssr/files/application-builder-common-engine/server.ts.template
@@ -10,7 +10,9 @@ const browserDistFolder = resolve(serverDistFolder, '../<%= browserDistDirectory
 const indexHtml = join(serverDistFolder, 'index.server.html');
 
 const app = express();
-const commonEngine = new CommonEngine();
+const commonEngine = new CommonEngine({
+  allowedHosts: [/* Provide a list of allowed hosts. */],
+});
 
 /**
  * Example Express Rest API endpoints can be defined here.

--- a/packages/schematics/angular/ssr/files/server-builder/server.ts.template
+++ b/packages/schematics/angular/ssr/files/server-builder/server.ts.template
@@ -15,7 +15,9 @@ export function app(): express.Express {
     ? join(distFolder, 'index.original.html')
     : join(distFolder, 'index.html');
 
-  const commonEngine = new CommonEngine();
+  const commonEngine = new CommonEngine({
+    allowedHosts: [/* Provide a list of allowed hosts. */],
+  });
 
   server.set('view engine', 'html');
   server.set('views', distFolder);

--- a/packages/schematics/angular/ssr/index.ts
+++ b/packages/schematics/angular/ssr/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { isJsonObject, join, normalize, strings } from '@angular-devkit/core';
+import { JsonObject, isJsonObject, join, normalize, strings } from '@angular-devkit/core';
 import {
   Rule,
   SchematicContext,
@@ -201,6 +201,10 @@ function updateApplicationBuilderWorkspaceConfigRule(
 
     buildTarget.options = {
       ...buildTarget.options,
+      security: {
+        ...((buildTarget.options?.security as JsonObject | undefined) ?? {}),
+        allowedHosts: [],
+      },
       outputPath,
       outputMode: options.serverRouting ? 'server' : undefined,
       prerender: options.serverRouting ? undefined : true,

--- a/tests/legacy-cli/e2e/assets/18-ssr-project-webpack/server.ts
+++ b/tests/legacy-cli/e2e/assets/18-ssr-project-webpack/server.ts
@@ -15,7 +15,7 @@ export function app(): express.Express {
     ? join(distFolder, 'index.original.html')
     : join(distFolder, 'index.html');
 
-  const commonEngine = new CommonEngine();
+  const commonEngine = new CommonEngine({ allowedHosts: [] });
 
   server.set('view engine', 'html');
   server.set('views', distFolder);

--- a/tests/legacy-cli/e2e/utils/project.ts
+++ b/tests/legacy-cli/e2e/utils/project.ts
@@ -226,7 +226,7 @@ export function updateServerFileForWebpack(filepath: string): Promise<void> {
       const browserDistFolder = resolve(serverDistFolder, '../browser');
       const indexHtml = join(serverDistFolder, 'index.server.html');
 
-      const commonEngine = new CommonEngine();
+      const commonEngine = new CommonEngine({ allowedHosts: [] });
 
       server.set('view engine', 'html');
       server.set('views', browserDistFolder);
@@ -239,7 +239,6 @@ export function updateServerFileForWebpack(filepath: string): Promise<void> {
       // All regular routes use the Angular engine
       server.get('**', (req, res, next) => {
         const { protocol, originalUrl, baseUrl, headers } = req;
-
         commonEngine
           .render({
             bootstrap,


### PR DESCRIPTION
This change introduces strict validation for `Host`, `X-Forwarded-Host`, `X-Forwarded-Proto`, and `X-Forwarded-Port` headers in the Angular SSR request handling pipeline, including `CommonEngine` and `AngularAppEngine`.

Previously, the application engine constructed the base URL for server-side rendering using these headers without validation. This could allow an attacker to manipulate the headers to steer relative `HttpClient` requests to arbitrary internal or external hosts (SSRF).

With this change:
- The `Host` and `X-Forwarded-Host` headers are validated against a strict allowlist.
- `localhost` and loopback addresses (e.g., `127.0.0.1`, `[::1]`) are allowed by default.
- `X-Forwarded-Port` must be numeric.
- `X-Forwarded-Proto` must be `http` or `https`.
- Requests with invalid or disallowed headers will now be rejected with a `400 Bad Request` status code.

BREAKING CHANGE:

Server-side requests will now fail with a `400 Bad Request` error if the `Host` header does not match a customized allowlist (or localhost).

**AngularAppEngine Users:**
To resolve this, you must configure the `allowedHosts` option in your `angular.json` to include all domain names where your application is deployed.

Example configuration in `angular.json`:

```json
"architect": {
  "build": {
    "options": {
      "security": {
        "allowedHosts": ["example.com", "*.trusted-example.com"]
      }
    }
  }
}
```

**CommonEngine Users:**
If you are using `CommonEngine`,  you must now provide the `allowedHosts` option when initializing or rendering your application.

Example:
```typescript
const commonEngine = new CommonEngine({
  allowedHosts: [“example.com”, “*.trusted-example.com"]
});
```