### PR TITLE
 fix(@angular/ssr): prevent open redirect via X-Forwarded-Prefix header 

### DIFF
--- a/packages/angular/ssr/src/utils/url.ts
+++ b/packages/angular/ssr/src/utils/url.ts
@@ -95,26 +95,32 @@ export function addTrailingSlash(url: string): string {
  * ```
  */
 export function joinUrlParts(...parts: string[]): string {
-  const normalizeParts: string[] = [];
+  const normalizedParts: string[] = [];
+
   for (const part of parts) {
     if (part === '') {
       // Skip any empty parts
       continue;
     }
 
-    let normalizedPart = part;
-    if (part[0] === '/') {
-      normalizedPart = normalizedPart.slice(1);
+    let start = 0;
+    let end = part.length;
+
+    // Use "Pointers" to avoid intermediate slices
+    while (start < end && part[start] === '/') {
+      start++;
     }
-    if (part.at(-1) === '/') {
-      normalizedPart = normalizedPart.slice(0, -1);
+
+    while (end > start && part[end - 1] === '/') {
+      end--;
     }
-    if (normalizedPart !== '') {
-      normalizeParts.push(normalizedPart);
+
+    if (start < end) {
+      normalizedParts.push(part.slice(start, end));
     }
   }
 
-  return addLeadingSlash(normalizeParts.join('/'));
+  return addLeadingSlash(normalizedParts.join('/'));
 }
 
 /**

--- a/packages/angular/ssr/src/utils/validation.ts
+++ b/packages/angular/ssr/src/utils/validation.ts
@@ -27,6 +27,11 @@ const VALID_PROTO_REGEX = /^https?$/i;
 const VALID_HOST_REGEX = /^[a-z0-9.:-]+$/i;
 
 /**
+ * Regular expression to validate that the prefix is valid.
+ */
+const INVALID_PREFIX_REGEX = /^[/\\]{2}|(?:^|[/\\])\.\.?(?:[/\\]|$)/;
+
+/**
  * Extracts the first value from a multi-value header string.
  *
  * @param value - A string or an array of strings representing the header values.
@@ -252,5 +257,12 @@ function validateHeaders(request: Request): void {
   const xForwardedProto = getFirstHeaderValue(headers.get('x-forwarded-proto'));
   if (xForwardedProto && !VALID_PROTO_REGEX.test(xForwardedProto)) {
     throw new Error('Header "x-forwarded-proto" must be either "http" or "https".');
+  }
+
+  const xForwardedPrefix = getFirstHeaderValue(headers.get('x-forwarded-prefix'));
+  if (xForwardedPrefix && INVALID_PREFIX_REGEX.test(xForwardedPrefix)) {
+    throw new Error(
+      'Header "x-forwarded-prefix" must not start with multiple "/" or "\\" or contain ".", ".." path segments.',
+    );
   }
 }

--- a/packages/angular/ssr/test/utils/url_spec.ts
+++ b/packages/angular/ssr/test/utils/url_spec.ts
@@ -100,6 +100,18 @@ describe('URL Utils', () => {
     it('should handle an all-empty URL parts', () => {
       expect(joinUrlParts('', '')).toBe('/');
     });
+
+    it('should normalize parts with multiple leading and trailing slashes', () => {
+      expect(joinUrlParts('//path//', '///to///', '//resource//')).toBe('/path/to/resource');
+    });
+
+    it('should handle a single part', () => {
+      expect(joinUrlParts('path')).toBe('/path');
+    });
+
+    it('should handle parts containing only slashes', () => {
+      expect(joinUrlParts('//', '///')).toBe('/');
+    });
   });
 
   describe('stripIndexHtmlFromURL', () => {


### PR DESCRIPTION
This change addresses a security vulnerability where `joinUrlParts()` in `packages/angular/ssr/src/utils/url.ts` only stripped one leading slash from URL parts.

When the `X-Forwarded-Prefix` header contains multiple leading slashes (e.g., `///evil.com`), the function previously produced a protocol-relative URL (e.g., `//evil.com/home`). If the application issues a redirect (e.g., via a generic redirect route), the browser interprets this 'Location' header as an external redirect to `https://evil.com/home`.

This vulnerability poses a risk as open redirects can be used in phishing attacks. Additionally, since the redirect response may lack `Cache-Control` headers, intermediate CDNs could cache the poisoned redirect, serving it to other users.

This commit fixes the issue by:
1. Updating `joinUrlParts` to internally strip *all* leading and trailing slashes from URL segments, preventing the formation of protocol-relative URLs from malicious input.
2. Adding strict validation for the `X-Forwarded-Prefix` header to immediately reject requests with values starting with multiple slashes.

Closes https://github.com/angular/angular-cli/issues/32501