### PR TITLE
fix(@angular/cli): validate package manager version using `semver.valid` and throw an error if invalid

### DIFF
--- a/packages/angular/cli/src/package-managers/package-manager.ts
+++ b/packages/angular/cli/src/package-managers/package-manager.ts
@@ -371,7 +371,7 @@ export class PackageManager {
     this.#version = stdout.trim();
 
     if (!valid(this.#version)) {
-      throw new Error(`Invalid semver version for ${this.name}: ${this.#version}`);
+      throw new Error(`Invalid semver version for ${this.name}: "${this.#version}"`);
     }
 
     return this.#version;


### PR DESCRIPTION

Prior to this change an `An unhandled exception occurred: Invalid Version: ` was being thrown.
