### PR TITLE
refactor(@angular/build): Expose codeBundleCache to buildApplicationInternal

### DIFF
--- a/packages/angular/build/src/builders/unit-test/options.ts
+++ b/packages/angular/build/src/builders/unit-test/options.ts
@@ -47,8 +47,7 @@ export async function normalizeOptions(
   const { projectRoot, projectSourceRoot } = getProjectRootPaths(workspaceRoot, projectMetadata);
 
   // Gather persistent caching option and provide a project specific cache location
-  const cacheOptions = normalizeCacheOptions(projectMetadata, workspaceRoot);
-  cacheOptions.path = path.join(cacheOptions.path, projectName);
+  const cacheOptions = normalizeCacheOptions(projectMetadata, workspaceRoot, projectName);
 
   // Target specifier defaults to the current project's build target using a development configuration
   const buildTargetSpecifier = options.buildTarget ?? `::development`;

--- a/packages/angular/build/src/utils/normalize-cache.ts
+++ b/packages/angular/build/src/utils/normalize-cache.ts
@@ -42,6 +42,7 @@ function hasCacheMetadata(value: unknown): value is { cli: { cache: CacheMetadat
 export function normalizeCacheOptions(
   projectMetadata: unknown,
   worspaceRoot: string,
+  projectName?: string,
 ): NormalizedCachedOptions {
   const cacheMetadata = hasCacheMetadata(projectMetadata) ? projectMetadata.cli.cache : {};
 
@@ -67,9 +68,11 @@ export function normalizeCacheOptions(
 
   const cacheBasePath = resolve(worspaceRoot, path);
 
+  const cachePath = join(cacheBasePath, VERSION, projectName ?? '');
+
   return {
     enabled: cacheEnabled,
     basePath: cacheBasePath,
-    path: join(cacheBasePath, VERSION),
+    path: cachePath,
   };
 }


### PR DESCRIPTION
First off, thanks for having a look at this!

This PR exposes the `codeBundleCache` used in executeBuild part of the `buildApplicationInternal` to allow for performant multi-builder setups (because they can share the TS cache).

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Right now the `SourceFileCache` is initialized locally in the `executeBuild()` function. 

Issue Number: N/A

## What is the new behavior?

The `SourceFileCache` is now part of the `InternalOptions`, allowing tools that use this builder to (optionally) provide a shared cache that can be re-used over multiple builds. As fallback it will create the default cache object.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

We (native-federation) need this feature to speed up our builder. This way we can share the cache between the ESBuild plugin and main builder which decreases our build time drastically:

If interested, find the changes on our end here (it's a proof-of-concept): https://github.com/native-federation/angular-adapter/pull/4/changes#diff-6508a5b483eb2d55fd58361931d864832b5ba20178c796d07be21f9e8ac327ae