### PR TITLE
fix(@angular/cli): quote complex range specifiers in package manager

### DIFF
--- a/packages/angular/cli/src/package-managers/host.ts
+++ b/packages/angular/cli/src/package-managers/host.ts
@@ -25,6 +25,12 @@ import { PackageManagerError } from './error';
  */
 export interface Host {
   /**
+   * Whether shell quoting is required for package manager specifiers.
+   * This is typically true on Windows, where commands are executed in a shell.
+   */
+  readonly requiresQuoting?: boolean;
+
+  /**
    * Creates a directory.
    * @param path The path to the directory.
    * @param options Options for the directory creation.
@@ -101,6 +107,7 @@ export interface Host {
  */
 export const NodeJS_HOST: Host = {
   stat,
+  requiresQuoting: platform() === 'win32',
   mkdir,
   readFile: (path: string) => readFile(path, { encoding: 'utf8' }),
   copyFile: (src, dest) => copyFile(src, dest, constants.COPYFILE_FICLONE),

--- a/packages/angular/cli/src/package-managers/package-manager.ts
+++ b/packages/angular/cli/src/package-managers/package-manager.ts
@@ -34,7 +34,7 @@ const METADATA_FIELDS = ['name', 'dist-tags', 'versions', 'time'] as const;
  * This is a performance optimization to avoid downloading unnecessary data.
  * These fields are the ones required by the CLI for operations like `ng add` and `ng update`.
  */
-const MANIFEST_FIELDS = [
+export const MANIFEST_FIELDS = [
   'name',
   'version',
   'deprecated',
@@ -444,7 +444,9 @@ export class PackageManager {
     version: string,
     options: { timeout?: number; registry?: string; bypassCache?: boolean } = {},
   ): Promise<PackageManifest | null> {
-    const specifier = `${packageName}@${version}`;
+    const specifier = this.host.requiresQuoting
+      ? `"${packageName}@${version}"`
+      : `${packageName}@${version}`;
     const commandArgs = [...this.descriptor.getManifestCommand, specifier];
     const formatter = this.descriptor.viewCommandFieldArgFormatter;
     if (formatter) {

--- a/packages/angular/cli/src/package-managers/testing/mock-host.ts
+++ b/packages/angular/cli/src/package-managers/testing/mock-host.ts
@@ -14,6 +14,7 @@ import { Host } from '../host';
  * This class allows for simulating a file system in memory.
  */
 export class MockHost implements Host {
+  readonly requiresQuoting = false;
   private readonly fs = new Map<string, string[] | true>();
 
   constructor(files: Record<string, string[] | true> = {}) {


### PR DESCRIPTION
Complex range specifiers that include shell special characters (e.g., '>', '<') can be misinterpreted when not quoted. This change ensures that version ranges are always enclosed in quotes to prevent such issues.