### PR TITLE
refactor(@angular/build): expose dev-server options normalization function

### DIFF
--- a/packages/angular/build/src/private.ts
+++ b/packages/angular/build/src/private.ts
@@ -26,6 +26,10 @@ export { buildApplicationInternal } from './builders/application';
 export type { ApplicationBuilderInternalOptions } from './builders/application/options';
 export { type Result, type ResultFile, ResultKind } from './builders/application/results';
 export { serveWithVite } from './builders/dev-server/vite';
+export {
+  normalizeOptions as normalizeDevServerOptions,
+  type NormalizedDevServerOptions,
+} from './builders/dev-server/options';
 
 // Tools
 export * from './tools/babel/plugins';


### PR DESCRIPTION
The dev-server options normalization function and its associated type are being exposed from the internal API file. This allows other internal builders and tools within the package to leverage the same normalization logic.