### PR TITLE
fix(@schematics/angular): prevent adding test dependencies when minimal option is enabled

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -187,7 +187,7 @@ function addDependenciesToPackageJson(options: ApplicationOptions): Rule {
     );
   }
 
-  if (!options.skipTests) {
+  if (!options.skipTests && !options.minimal) {
     rules.push(...addTestRunnerDependencies(options.testRunner, !!options.skipInstall));
   }
 

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -167,6 +167,18 @@ describe('Application Schematic', () => {
     );
   });
 
+  it(`should not add test dependencies with "minimal" enabled`, async () => {
+    const tree = await schematicRunner.runSchematic(
+      'application',
+      { ...defaultOptions, minimal: true },
+      workspaceTree,
+    );
+
+    const packageJson = JSON.parse(tree.readContent('package.json'));
+    expect(packageJson.devDependencies['vitest']).toBeUndefined();
+    expect(packageJson.devDependencies['jsdom']).toBeUndefined();
+  });
+
   it('should install npm dependencies when `skipInstall` is false', async () => {
     await schematicRunner.runSchematic(
       'application',


### PR DESCRIPTION
…

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

If creating an application in minimal mode default test dependencies like `vitest`or `jsdom` are installed.

Issue Number: https://github.com/angular/angular-cli/issues/32531

## What is the new behavior?

If creating an application in minimal mode no test dependencies are installed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
