### PR TITLE
fix(@angular/cli): handle `oneOf` when converting schema to yargs options

### DIFF
--- a/packages/angular/cli/src/command-builder/utilities/json-schema.ts
+++ b/packages/angular/cli/src/command-builder/utilities/json-schema.ts
@@ -130,21 +130,22 @@ function isStringMap(node: json.JsonObject): boolean {
   );
 }
 
-const SUPPORTED_PRIMITIVE_TYPES = new Set(['boolean', 'number', 'string']);
+const SUPPORTED_PRIMITIVE_TYPES = new Set(['boolean', 'number', 'string'] as const);
+type SupportedPrimitiveType = Parameters<typeof SUPPORTED_PRIMITIVE_TYPES.add>[0];
 
 /**
  * Checks if a string is a supported primitive type.
  * @param value The string to check.
  * @returns `true` if the string is a supported primitive type, otherwise `false`.
  */
-function isSupportedPrimitiveType(value: string): boolean {
-  return SUPPORTED_PRIMITIVE_TYPES.has(value);
+function isSupportedPrimitiveType(value: string): value is SupportedPrimitiveType {
+  return SUPPORTED_PRIMITIVE_TYPES.has(value as any);
 }
 
 /**
  * Recursively checks if a JSON schema for an array's items is a supported primitive type.
  * It supports `oneOf` and `anyOf` keywords.
- * @param schema The JSON schema for the array's items.
+ * @param schema The JSON schema to check.
  * @returns `true` if the schema is a supported primitive type, otherwise `false`.
  */
 function isSupportedArrayItemSchema(schema: json.JsonObject): boolean {
@@ -154,6 +155,10 @@ function isSupportedArrayItemSchema(schema: json.JsonObject): boolean {
 
   if (json.isJsonArray(schema.enum)) {
     return true;
+  }
+
+  if (isJsonObject(schema.items)) {
+    return isSupportedArrayItemSchema(schema.items);
   }
 
   if (json.isJsonArray(schema.items)) {
@@ -178,6 +183,40 @@ function isSupportedArrayItemSchema(schema: json.JsonObject): boolean {
 }
 
 /**
+ * Recursively finds the first supported array primitive type for the given JSON schema.
+ * It supports `oneOf` and `anyOf` keywords.
+ * @param schema The JSON schema to inspect.
+ * @returns The supported primitive type or 'string' if none is found.
+ */
+function getSupportedArrayType(schema: json.JsonObject): SupportedPrimitiveType {
+  if (typeof schema.type === 'string' && isSupportedPrimitiveType(schema.type)) {
+    return schema.type;
+  }
+
+  if (json.isJsonArray(schema.enum)) {
+    return 'string';
+  }
+
+  if (isJsonObject(schema.items)) {
+    const result = getSupportedArrayType(schema.items);
+    if (result) return result;
+  }
+
+  for (const key of ['items', 'oneOf', 'anyOf']) {
+    if (json.isJsonArray(schema[key])) {
+      for (const item in schema[key]) {
+        if (isJsonObject(item)) {
+          const result = getSupportedArrayType(item);
+          if (result) return result;
+        }
+      }
+    }
+  }
+
+  return 'string';
+}
+
+/**
  * Gets the supported types for a JSON schema node.
  * @param current The JSON schema node to get the supported types for.
  * @returns An array of supported types.
@@ -198,7 +237,7 @@ function getSupportedTypes(
       case 'string':
         return true;
       case 'array':
-        return isJsonObject(current.items) && isSupportedArrayItemSchema(current.items);
+        return isSupportedArrayItemSchema(current);
       case 'object':
         return isStringMap(current);
       default:
@@ -377,9 +416,13 @@ export async function parseJsonSchemaToOptions(
             type: 'array',
             itemValueType: 'string',
           }
-        : {
-            type,
-          }),
+        : type === 'array'
+          ? {
+              type: getSupportedArrayType(current),
+            }
+          : {
+              type,
+            }),
     };
 
     options.push(option);

--- a/packages/angular/cli/src/command-builder/utilities/json-schema_spec.ts
+++ b/packages/angular/cli/src/command-builder/utilities/json-schema_spec.ts
@@ -42,6 +42,10 @@ describe('parseJsonSchemaToOptions', () => {
               'enum': ['always', 'never', 'default-array'],
             },
           },
+          'arrayWithNumbers': {
+            'type': 'array',
+            'items': { 'type': 'number' },
+          },
           'extendable': {
             'type': 'object',
             'properties': {},
@@ -114,6 +118,9 @@ describe('parseJsonSchemaToOptions', () => {
                 },
               ],
             },
+          },
+          'oneOfAtRoot': {
+            'oneOf': [{ 'type': 'array', 'items': { 'type': 'string' } }, { 'type': 'boolean' }],
           },
         },
       };
@@ -226,6 +233,35 @@ describe('parseJsonSchemaToOptions', () => {
           jasmine.objectContaining({
             'arrayWithComplexAnyOf': ['default', 'something-else'],
           }),
+        );
+      });
+    });
+
+    describe('type=array, oneOf at root', () => {
+      it('parses valid option value', async () => {
+        expect(
+          await parse([
+            '--oneOfAtRoot',
+            'first',
+            '--oneOfAtRoot',
+            'second',
+            '--oneOfAtRoot',
+            'third',
+          ]),
+        ).toEqual(jasmine.objectContaining({ 'oneOfAtRoot': ['first', 'second', 'third'] }));
+      });
+
+      it('parses --no prefix', async () => {
+        expect(await parse(['--no-oneOfAtRoot'])).toEqual(
+          jasmine.objectContaining({ 'oneOfAtRoot': false }),
+        );
+      });
+    });
+
+    describe('type=Array<number>', () => {
+      it('parses valid option value', async () => {
+        expect(await parse(['--arrayWithNumbers', '42', '--arrayWithNumbers', '24'])).toEqual(
+          jasmine.objectContaining({ 'arrayWithNumbers': [42, 24] }),
         );
       });
     });


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Options such as `--allowed-hosts` are defined as `oneOf([array<string>, boolean])` but the array option is not chosen, even though it is first, because the JSONSchema conversion only supports an array at the root of the option schema.

Issue Number: N/A

## What is the new behavior?

This change fixes JSONSchemas where `oneOf` is placed at the root of the option schema rather than in an array's `items`. This allows an array to be passed via the command-line, but additional types to be represented via configuration.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

This will affect any commands for each of the options that use `oneOf` at the root of their schemas. This change does not change the precedence of schema definition, so if there are any changes and they are not wanted then it is just uncovering a bug where the preferred type should have been ordered first.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
