### PR TITLE
build: update minimum supported Node.js versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24]
+        node: [22, 24]
         subset: [esbuild, webpack]
         shard: [0, 1, 2, 3, 4, 5]
     runs-on: ubuntu-latest

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -68,31 +68,37 @@ use_repo(
 
 node_dev = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node", dev_dependency = True)
 
-# Node.js 20
-node_dev.toolchain(
-    name = "node20",
-    node_version = "20.19.0",
-)
-
 # Node.js 22
 node_dev.toolchain(
     name = "node22",
-    node_version = "22.12.0",
+    node_repositories = {
+        "22.22.0-darwin_arm64": ("node-v22.22.0-darwin-arm64.tar.gz", "node-v22.22.0-darwin-arm64", "5ed4db0fcf1eaf84d91ad12462631d73bf4576c1377e192d222e48026a902640"),
+        "22.22.0-darwin_amd64": ("node-v22.22.0-darwin-x64.tar.gz", "node-v22.22.0-darwin-x64", "5ea50c9d6dea3dfa3abb66b2656f7a4e1c8cef23432b558d45fb538c7b5dedce"),
+        "22.22.0-linux_arm64": ("node-v22.22.0-linux-arm64.tar.xz", "node-v22.22.0-linux-arm64", "1bf1eb9ee63ffc4e5d324c0b9b62cf4a289f44332dfef9607cea1a0d9596ba6f"),
+        "22.22.0-linux_ppc64le": ("node-v22.22.0-linux-ppc64le.tar.xz", "node-v22.22.0-linux-ppc64le", "d83b9957431cc18e1fc143a4b99f89cde7b8a18f53ef392231b4336afd058865"),
+        "22.22.0-linux_s390x": ("node-v22.22.0-linux-s390x.tar.xz", "node-v22.22.0-linux-s390x", "5aa0e520689448c4233e8d73f284e8e0634fdcd32b479735698494be5641f3e4"),
+        "22.22.0-linux_amd64": ("node-v22.22.0-linux-x64.tar.xz", "node-v22.22.0-linux-x64", "9aa8e9d2298ab68c600bd6fb86a6c13bce11a4eca1ba9b39d79fa021755d7c37"),
+        "22.22.0-windows_amd64": ("node-v22.22.0-win-x64.zip", "node-v22.22.0-win-x64", "c97fa376d2becdc8863fcd3ca2dd9a83a9f3468ee7ccf7a6d076ec66a645c77a"),
+    },
+    node_version = "22.22.0",
 )
 
 # Node.js 24
 node_dev.toolchain(
     name = "node24",
-    node_version = "24.0.0",
+    node_repositories = {
+        "24.13.1-darwin_arm64": ("node-v24.13.1-darwin-arm64.tar.gz", "node-v24.13.1-darwin-arm64", "8c039d59f2fec6195e4281ad5b0d02b9a940897b4df7b849c6fb48be6787bba6"),
+        "24.13.1-darwin_amd64": ("node-v24.13.1-darwin-x64.tar.gz", "node-v24.13.1-darwin-x64", "527f0578d9812e7dfa225121bda0b1546a6a0e4b5f556295fc8299c272de5fbf"),
+        "24.13.1-linux_arm64": ("node-v24.13.1-linux-arm64.tar.xz", "node-v24.13.1-linux-arm64", "c827d3d301e2eed1a51f36d0116b71b9e3d9e3b728f081615270ea40faac34c1"),
+        "24.13.1-linux_ppc64le": ("node-v24.13.1-linux-ppc64le.tar.xz", "node-v24.13.1-linux-ppc64le", "fb712a08d317655dbf776c90f60ac2105109d802e33811df6c9ed33d12f801c6"),
+        "24.13.1-linux_s390x": ("node-v24.13.1-linux-s390x.tar.xz", "node-v24.13.1-linux-s390x", "8e2c0d9b5545c3db22623e8cb8d6f0c28fcd470f29d32dbeabf9432dda289de2"),
+        "24.13.1-linux_amd64": ("node-v24.13.1-linux-x64.tar.xz", "node-v24.13.1-linux-x64", "30215f90ea3cd04dfbc06e762c021393fa173a1d392974298bbc871a8e461089"),
+        "24.13.1-windows_amd64": ("node-v24.13.1-win-x64.zip", "node-v24.13.1-win-x64", "fba577c4bb87df04d54dd87bbdaa5a2272f1f99a2acbf9152e1a91b8b5f0b279"),
+    },
+    node_version = "24.13.1",
 )
 use_repo(
     node_dev,
-    "node20_darwin_amd64",
-    "node20_darwin_arm64",
-    "node20_linux_amd64",
-    "node20_linux_arm64",
-    "node20_toolchains",
-    "node20_windows_amd64",
     "node22_darwin_amd64",
     "node22_darwin_arm64",
     "node22_linux_amd64",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1096,7 +1096,7 @@
     "@@rules_nodejs+//nodejs:extensions.bzl%node": {
       "general": {
         "bzlTransitiveDigest": "4pUxCNc22K4I+6+4Nxu52Hur12tFRfa1JMsN5mdDv60=",
-        "usagesDigest": "RUNc/H/4+qM5zb0RR5p3jjryvj3HZf8vDnJDU6M9uZc=",
+        "usagesDigest": "MhZgSV2KT2KowfGcEDHCUJpD8UsBfZDZKKkIgaqjXqA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1511,137 +1511,51 @@
               "user_node_repository_name": "nodejs"
             }
           },
-          "node20_linux_amd64": {
-            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
-            "attributes": {
-              "node_download_auth": {},
-              "node_repositories": {},
-              "node_urls": [
-                "https://nodejs.org/dist/v{version}/{filename}"
-              ],
-              "node_version": "20.19.0",
-              "include_headers": false,
-              "platform": "linux_amd64"
-            }
-          },
-          "node20_linux_arm64": {
-            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
-            "attributes": {
-              "node_download_auth": {},
-              "node_repositories": {},
-              "node_urls": [
-                "https://nodejs.org/dist/v{version}/{filename}"
-              ],
-              "node_version": "20.19.0",
-              "include_headers": false,
-              "platform": "linux_arm64"
-            }
-          },
-          "node20_linux_s390x": {
-            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
-            "attributes": {
-              "node_download_auth": {},
-              "node_repositories": {},
-              "node_urls": [
-                "https://nodejs.org/dist/v{version}/{filename}"
-              ],
-              "node_version": "20.19.0",
-              "include_headers": false,
-              "platform": "linux_s390x"
-            }
-          },
-          "node20_linux_ppc64le": {
-            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
-            "attributes": {
-              "node_download_auth": {},
-              "node_repositories": {},
-              "node_urls": [
-                "https://nodejs.org/dist/v{version}/{filename}"
-              ],
-              "node_version": "20.19.0",
-              "include_headers": false,
-              "platform": "linux_ppc64le"
-            }
-          },
-          "node20_darwin_amd64": {
-            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
-            "attributes": {
-              "node_download_auth": {},
-              "node_repositories": {},
-              "node_urls": [
-                "https://nodejs.org/dist/v{version}/{filename}"
-              ],
-              "node_version": "20.19.0",
-              "include_headers": false,
-              "platform": "darwin_amd64"
-            }
-          },
-          "node20_darwin_arm64": {
-            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
-            "attributes": {
-              "node_download_auth": {},
-              "node_repositories": {},
-              "node_urls": [
-                "https://nodejs.org/dist/v{version}/{filename}"
-              ],
-              "node_version": "20.19.0",
-              "include_headers": false,
-              "platform": "darwin_arm64"
-            }
-          },
-          "node20_windows_amd64": {
-            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
-            "attributes": {
-              "node_download_auth": {},
-              "node_repositories": {},
-              "node_urls": [
-                "https://nodejs.org/dist/v{version}/{filename}"
-              ],
-              "node_version": "20.19.0",
-              "include_headers": false,
-              "platform": "windows_amd64"
-            }
-          },
-          "node20_windows_arm64": {
-            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
-            "attributes": {
-              "node_download_auth": {},
-              "node_repositories": {},
-              "node_urls": [
-                "https://nodejs.org/dist/v{version}/{filename}"
-              ],
-              "node_version": "20.19.0",
-              "include_headers": false,
-              "platform": "windows_arm64"
-            }
-          },
-          "node20": {
-            "repoRuleId": "@@rules_nodejs+//nodejs/private:nodejs_repo_host_os_alias.bzl%nodejs_repo_host_os_alias",
-            "attributes": {
-              "user_node_repository_name": "node20"
-            }
-          },
-          "node20_host": {
-            "repoRuleId": "@@rules_nodejs+//nodejs/private:nodejs_repo_host_os_alias.bzl%nodejs_repo_host_os_alias",
-            "attributes": {
-              "user_node_repository_name": "node20"
-            }
-          },
-          "node20_toolchains": {
-            "repoRuleId": "@@rules_nodejs+//nodejs/private:nodejs_toolchains_repo.bzl%nodejs_toolchains_repo",
-            "attributes": {
-              "user_node_repository_name": "node20"
-            }
-          },
           "node22_linux_amd64": {
             "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {},
+              "node_repositories": {
+                "22.22.0-darwin_arm64": [
+                  "node-v22.22.0-darwin-arm64.tar.gz",
+                  "node-v22.22.0-darwin-arm64",
+                  "5ed4db0fcf1eaf84d91ad12462631d73bf4576c1377e192d222e48026a902640"
+                ],
+                "22.22.0-darwin_amd64": [
+                  "node-v22.22.0-darwin-x64.tar.gz",
+                  "node-v22.22.0-darwin-x64",
+                  "5ea50c9d6dea3dfa3abb66b2656f7a4e1c8cef23432b558d45fb538c7b5dedce"
+                ],
+                "22.22.0-linux_arm64": [
+                  "node-v22.22.0-linux-arm64.tar.xz",
+                  "node-v22.22.0-linux-arm64",
+                  "1bf1eb9ee63ffc4e5d324c0b9b62cf4a289f44332dfef9607cea1a0d9596ba6f"
+                ],
+                "22.22.0-linux_ppc64le": [
+                  "node-v22.22.0-linux-ppc64le.tar.xz",
+                  "node-v22.22.0-linux-ppc64le",
+                  "d83b9957431cc18e1fc143a4b99f89cde7b8a18f53ef392231b4336afd058865"
+                ],
+                "22.22.0-linux_s390x": [
+                  "node-v22.22.0-linux-s390x.tar.xz",
+                  "node-v22.22.0-linux-s390x",
+                  "5aa0e520689448c4233e8d73f284e8e0634fdcd32b479735698494be5641f3e4"
+                ],
+                "22.22.0-linux_amd64": [
+                  "node-v22.22.0-linux-x64.tar.xz",
+                  "node-v22.22.0-linux-x64",
+                  "9aa8e9d2298ab68c600bd6fb86a6c13bce11a4eca1ba9b39d79fa021755d7c37"
+                ],
+                "22.22.0-windows_amd64": [
+                  "node-v22.22.0-win-x64.zip",
+                  "node-v22.22.0-win-x64",
+                  "c97fa376d2becdc8863fcd3ca2dd9a83a9f3468ee7ccf7a6d076ec66a645c77a"
+                ]
+              },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.12.0",
+              "node_version": "22.22.0",
               "include_headers": false,
               "platform": "linux_amd64"
             }
@@ -1650,11 +1564,47 @@
             "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {},
+              "node_repositories": {
+                "22.22.0-darwin_arm64": [
+                  "node-v22.22.0-darwin-arm64.tar.gz",
+                  "node-v22.22.0-darwin-arm64",
+                  "5ed4db0fcf1eaf84d91ad12462631d73bf4576c1377e192d222e48026a902640"
+                ],
+                "22.22.0-darwin_amd64": [
+                  "node-v22.22.0-darwin-x64.tar.gz",
+                  "node-v22.22.0-darwin-x64",
+                  "5ea50c9d6dea3dfa3abb66b2656f7a4e1c8cef23432b558d45fb538c7b5dedce"
+                ],
+                "22.22.0-linux_arm64": [
+                  "node-v22.22.0-linux-arm64.tar.xz",
+                  "node-v22.22.0-linux-arm64",
+                  "1bf1eb9ee63ffc4e5d324c0b9b62cf4a289f44332dfef9607cea1a0d9596ba6f"
+                ],
+                "22.22.0-linux_ppc64le": [
+                  "node-v22.22.0-linux-ppc64le.tar.xz",
+                  "node-v22.22.0-linux-ppc64le",
+                  "d83b9957431cc18e1fc143a4b99f89cde7b8a18f53ef392231b4336afd058865"
+                ],
+                "22.22.0-linux_s390x": [
+                  "node-v22.22.0-linux-s390x.tar.xz",
+                  "node-v22.22.0-linux-s390x",
+                  "5aa0e520689448c4233e8d73f284e8e0634fdcd32b479735698494be5641f3e4"
+                ],
+                "22.22.0-linux_amd64": [
+                  "node-v22.22.0-linux-x64.tar.xz",
+                  "node-v22.22.0-linux-x64",
+                  "9aa8e9d2298ab68c600bd6fb86a6c13bce11a4eca1ba9b39d79fa021755d7c37"
+                ],
+                "22.22.0-windows_amd64": [
+                  "node-v22.22.0-win-x64.zip",
+                  "node-v22.22.0-win-x64",
+                  "c97fa376d2becdc8863fcd3ca2dd9a83a9f3468ee7ccf7a6d076ec66a645c77a"
+                ]
+              },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.12.0",
+              "node_version": "22.22.0",
               "include_headers": false,
               "platform": "linux_arm64"
             }
@@ -1663,11 +1613,47 @@
             "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {},
+              "node_repositories": {
+                "22.22.0-darwin_arm64": [
+                  "node-v22.22.0-darwin-arm64.tar.gz",
+                  "node-v22.22.0-darwin-arm64",
+                  "5ed4db0fcf1eaf84d91ad12462631d73bf4576c1377e192d222e48026a902640"
+                ],
+                "22.22.0-darwin_amd64": [
+                  "node-v22.22.0-darwin-x64.tar.gz",
+                  "node-v22.22.0-darwin-x64",
+                  "5ea50c9d6dea3dfa3abb66b2656f7a4e1c8cef23432b558d45fb538c7b5dedce"
+                ],
+                "22.22.0-linux_arm64": [
+                  "node-v22.22.0-linux-arm64.tar.xz",
+                  "node-v22.22.0-linux-arm64",
+                  "1bf1eb9ee63ffc4e5d324c0b9b62cf4a289f44332dfef9607cea1a0d9596ba6f"
+                ],
+                "22.22.0-linux_ppc64le": [
+                  "node-v22.22.0-linux-ppc64le.tar.xz",
+                  "node-v22.22.0-linux-ppc64le",
+                  "d83b9957431cc18e1fc143a4b99f89cde7b8a18f53ef392231b4336afd058865"
+                ],
+                "22.22.0-linux_s390x": [
+                  "node-v22.22.0-linux-s390x.tar.xz",
+                  "node-v22.22.0-linux-s390x",
+                  "5aa0e520689448c4233e8d73f284e8e0634fdcd32b479735698494be5641f3e4"
+                ],
+                "22.22.0-linux_amd64": [
+                  "node-v22.22.0-linux-x64.tar.xz",
+                  "node-v22.22.0-linux-x64",
+                  "9aa8e9d2298ab68c600bd6fb86a6c13bce11a4eca1ba9b39d79fa021755d7c37"
+                ],
+                "22.22.0-windows_amd64": [
+                  "node-v22.22.0-win-x64.zip",
+                  "node-v22.22.0-win-x64",
+                  "c97fa376d2becdc8863fcd3ca2dd9a83a9f3468ee7ccf7a6d076ec66a645c77a"
+                ]
+              },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.12.0",
+              "node_version": "22.22.0",
               "include_headers": false,
               "platform": "linux_s390x"
             }
@@ -1676,11 +1662,47 @@
             "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {},
+              "node_repositories": {
+                "22.22.0-darwin_arm64": [
+                  "node-v22.22.0-darwin-arm64.tar.gz",
+                  "node-v22.22.0-darwin-arm64",
+                  "5ed4db0fcf1eaf84d91ad12462631d73bf4576c1377e192d222e48026a902640"
+                ],
+                "22.22.0-darwin_amd64": [
+                  "node-v22.22.0-darwin-x64.tar.gz",
+                  "node-v22.22.0-darwin-x64",
+                  "5ea50c9d6dea3dfa3abb66b2656f7a4e1c8cef23432b558d45fb538c7b5dedce"
+                ],
+                "22.22.0-linux_arm64": [
+                  "node-v22.22.0-linux-arm64.tar.xz",
+                  "node-v22.22.0-linux-arm64",
+                  "1bf1eb9ee63ffc4e5d324c0b9b62cf4a289f44332dfef9607cea1a0d9596ba6f"
+                ],
+                "22.22.0-linux_ppc64le": [
+                  "node-v22.22.0-linux-ppc64le.tar.xz",
+                  "node-v22.22.0-linux-ppc64le",
+                  "d83b9957431cc18e1fc143a4b99f89cde7b8a18f53ef392231b4336afd058865"
+                ],
+                "22.22.0-linux_s390x": [
+                  "node-v22.22.0-linux-s390x.tar.xz",
+                  "node-v22.22.0-linux-s390x",
+                  "5aa0e520689448c4233e8d73f284e8e0634fdcd32b479735698494be5641f3e4"
+                ],
+                "22.22.0-linux_amd64": [
+                  "node-v22.22.0-linux-x64.tar.xz",
+                  "node-v22.22.0-linux-x64",
+                  "9aa8e9d2298ab68c600bd6fb86a6c13bce11a4eca1ba9b39d79fa021755d7c37"
+                ],
+                "22.22.0-windows_amd64": [
+                  "node-v22.22.0-win-x64.zip",
+                  "node-v22.22.0-win-x64",
+                  "c97fa376d2becdc8863fcd3ca2dd9a83a9f3468ee7ccf7a6d076ec66a645c77a"
+                ]
+              },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.12.0",
+              "node_version": "22.22.0",
               "include_headers": false,
               "platform": "linux_ppc64le"
             }
@@ -1689,11 +1711,47 @@
             "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {},
+              "node_repositories": {
+                "22.22.0-darwin_arm64": [
+                  "node-v22.22.0-darwin-arm64.tar.gz",
+                  "node-v22.22.0-darwin-arm64",
+                  "5ed4db0fcf1eaf84d91ad12462631d73bf4576c1377e192d222e48026a902640"
+                ],
+                "22.22.0-darwin_amd64": [
+                  "node-v22.22.0-darwin-x64.tar.gz",
+                  "node-v22.22.0-darwin-x64",
+                  "5ea50c9d6dea3dfa3abb66b2656f7a4e1c8cef23432b558d45fb538c7b5dedce"
+                ],
+                "22.22.0-linux_arm64": [
+                  "node-v22.22.0-linux-arm64.tar.xz",
+                  "node-v22.22.0-linux-arm64",
+                  "1bf1eb9ee63ffc4e5d324c0b9b62cf4a289f44332dfef9607cea1a0d9596ba6f"
+                ],
+                "22.22.0-linux_ppc64le": [
+                  "node-v22.22.0-linux-ppc64le.tar.xz",
+                  "node-v22.22.0-linux-ppc64le",
+                  "d83b9957431cc18e1fc143a4b99f89cde7b8a18f53ef392231b4336afd058865"
+                ],
+                "22.22.0-linux_s390x": [
+                  "node-v22.22.0-linux-s390x.tar.xz",
+                  "node-v22.22.0-linux-s390x",
+                  "5aa0e520689448c4233e8d73f284e8e0634fdcd32b479735698494be5641f3e4"
+                ],
+                "22.22.0-linux_amd64": [
+                  "node-v22.22.0-linux-x64.tar.xz",
+                  "node-v22.22.0-linux-x64",
+                  "9aa8e9d2298ab68c600bd6fb86a6c13bce11a4eca1ba9b39d79fa021755d7c37"
+                ],
+                "22.22.0-windows_amd64": [
+                  "node-v22.22.0-win-x64.zip",
+                  "node-v22.22.0-win-x64",
+                  "c97fa376d2becdc8863fcd3ca2dd9a83a9f3468ee7ccf7a6d076ec66a645c77a"
+                ]
+              },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.12.0",
+              "node_version": "22.22.0",
               "include_headers": false,
               "platform": "darwin_amd64"
             }
@@ -1702,11 +1760,47 @@
             "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {},
+              "node_repositories": {
+                "22.22.0-darwin_arm64": [
+                  "node-v22.22.0-darwin-arm64.tar.gz",
+                  "node-v22.22.0-darwin-arm64",
+                  "5ed4db0fcf1eaf84d91ad12462631d73bf4576c1377e192d222e48026a902640"
+                ],
+                "22.22.0-darwin_amd64": [
+                  "node-v22.22.0-darwin-x64.tar.gz",
+                  "node-v22.22.0-darwin-x64",
+                  "5ea50c9d6dea3dfa3abb66b2656f7a4e1c8cef23432b558d45fb538c7b5dedce"
+                ],
+                "22.22.0-linux_arm64": [
+                  "node-v22.22.0-linux-arm64.tar.xz",
+                  "node-v22.22.0-linux-arm64",
+                  "1bf1eb9ee63ffc4e5d324c0b9b62cf4a289f44332dfef9607cea1a0d9596ba6f"
+                ],
+                "22.22.0-linux_ppc64le": [
+                  "node-v22.22.0-linux-ppc64le.tar.xz",
+                  "node-v22.22.0-linux-ppc64le",
+                  "d83b9957431cc18e1fc143a4b99f89cde7b8a18f53ef392231b4336afd058865"
+                ],
+                "22.22.0-linux_s390x": [
+                  "node-v22.22.0-linux-s390x.tar.xz",
+                  "node-v22.22.0-linux-s390x",
+                  "5aa0e520689448c4233e8d73f284e8e0634fdcd32b479735698494be5641f3e4"
+                ],
+                "22.22.0-linux_amd64": [
+                  "node-v22.22.0-linux-x64.tar.xz",
+                  "node-v22.22.0-linux-x64",
+                  "9aa8e9d2298ab68c600bd6fb86a6c13bce11a4eca1ba9b39d79fa021755d7c37"
+                ],
+                "22.22.0-windows_amd64": [
+                  "node-v22.22.0-win-x64.zip",
+                  "node-v22.22.0-win-x64",
+                  "c97fa376d2becdc8863fcd3ca2dd9a83a9f3468ee7ccf7a6d076ec66a645c77a"
+                ]
+              },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.12.0",
+              "node_version": "22.22.0",
               "include_headers": false,
               "platform": "darwin_arm64"
             }
@@ -1715,11 +1809,47 @@
             "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {},
+              "node_repositories": {
+                "22.22.0-darwin_arm64": [
+                  "node-v22.22.0-darwin-arm64.tar.gz",
+                  "node-v22.22.0-darwin-arm64",
+                  "5ed4db0fcf1eaf84d91ad12462631d73bf4576c1377e192d222e48026a902640"
+                ],
+                "22.22.0-darwin_amd64": [
+                  "node-v22.22.0-darwin-x64.tar.gz",
+                  "node-v22.22.0-darwin-x64",
+                  "5ea50c9d6dea3dfa3abb66b2656f7a4e1c8cef23432b558d45fb538c7b5dedce"
+                ],
+                "22.22.0-linux_arm64": [
+                  "node-v22.22.0-linux-arm64.tar.xz",
+                  "node-v22.22.0-linux-arm64",
+                  "1bf1eb9ee63ffc4e5d324c0b9b62cf4a289f44332dfef9607cea1a0d9596ba6f"
+                ],
+                "22.22.0-linux_ppc64le": [
+                  "node-v22.22.0-linux-ppc64le.tar.xz",
+                  "node-v22.22.0-linux-ppc64le",
+                  "d83b9957431cc18e1fc143a4b99f89cde7b8a18f53ef392231b4336afd058865"
+                ],
+                "22.22.0-linux_s390x": [
+                  "node-v22.22.0-linux-s390x.tar.xz",
+                  "node-v22.22.0-linux-s390x",
+                  "5aa0e520689448c4233e8d73f284e8e0634fdcd32b479735698494be5641f3e4"
+                ],
+                "22.22.0-linux_amd64": [
+                  "node-v22.22.0-linux-x64.tar.xz",
+                  "node-v22.22.0-linux-x64",
+                  "9aa8e9d2298ab68c600bd6fb86a6c13bce11a4eca1ba9b39d79fa021755d7c37"
+                ],
+                "22.22.0-windows_amd64": [
+                  "node-v22.22.0-win-x64.zip",
+                  "node-v22.22.0-win-x64",
+                  "c97fa376d2becdc8863fcd3ca2dd9a83a9f3468ee7ccf7a6d076ec66a645c77a"
+                ]
+              },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.12.0",
+              "node_version": "22.22.0",
               "include_headers": false,
               "platform": "windows_amd64"
             }
@@ -1728,11 +1858,47 @@
             "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {},
+              "node_repositories": {
+                "22.22.0-darwin_arm64": [
+                  "node-v22.22.0-darwin-arm64.tar.gz",
+                  "node-v22.22.0-darwin-arm64",
+                  "5ed4db0fcf1eaf84d91ad12462631d73bf4576c1377e192d222e48026a902640"
+                ],
+                "22.22.0-darwin_amd64": [
+                  "node-v22.22.0-darwin-x64.tar.gz",
+                  "node-v22.22.0-darwin-x64",
+                  "5ea50c9d6dea3dfa3abb66b2656f7a4e1c8cef23432b558d45fb538c7b5dedce"
+                ],
+                "22.22.0-linux_arm64": [
+                  "node-v22.22.0-linux-arm64.tar.xz",
+                  "node-v22.22.0-linux-arm64",
+                  "1bf1eb9ee63ffc4e5d324c0b9b62cf4a289f44332dfef9607cea1a0d9596ba6f"
+                ],
+                "22.22.0-linux_ppc64le": [
+                  "node-v22.22.0-linux-ppc64le.tar.xz",
+                  "node-v22.22.0-linux-ppc64le",
+                  "d83b9957431cc18e1fc143a4b99f89cde7b8a18f53ef392231b4336afd058865"
+                ],
+                "22.22.0-linux_s390x": [
+                  "node-v22.22.0-linux-s390x.tar.xz",
+                  "node-v22.22.0-linux-s390x",
+                  "5aa0e520689448c4233e8d73f284e8e0634fdcd32b479735698494be5641f3e4"
+                ],
+                "22.22.0-linux_amd64": [
+                  "node-v22.22.0-linux-x64.tar.xz",
+                  "node-v22.22.0-linux-x64",
+                  "9aa8e9d2298ab68c600bd6fb86a6c13bce11a4eca1ba9b39d79fa021755d7c37"
+                ],
+                "22.22.0-windows_amd64": [
+                  "node-v22.22.0-win-x64.zip",
+                  "node-v22.22.0-win-x64",
+                  "c97fa376d2becdc8863fcd3ca2dd9a83a9f3468ee7ccf7a6d076ec66a645c77a"
+                ]
+              },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.12.0",
+              "node_version": "22.22.0",
               "include_headers": false,
               "platform": "windows_arm64"
             }
@@ -1759,11 +1925,47 @@
             "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {},
+              "node_repositories": {
+                "24.13.1-darwin_arm64": [
+                  "node-v24.13.1-darwin-arm64.tar.gz",
+                  "node-v24.13.1-darwin-arm64",
+                  "8c039d59f2fec6195e4281ad5b0d02b9a940897b4df7b849c6fb48be6787bba6"
+                ],
+                "24.13.1-darwin_amd64": [
+                  "node-v24.13.1-darwin-x64.tar.gz",
+                  "node-v24.13.1-darwin-x64",
+                  "527f0578d9812e7dfa225121bda0b1546a6a0e4b5f556295fc8299c272de5fbf"
+                ],
+                "24.13.1-linux_arm64": [
+                  "node-v24.13.1-linux-arm64.tar.xz",
+                  "node-v24.13.1-linux-arm64",
+                  "c827d3d301e2eed1a51f36d0116b71b9e3d9e3b728f081615270ea40faac34c1"
+                ],
+                "24.13.1-linux_ppc64le": [
+                  "node-v24.13.1-linux-ppc64le.tar.xz",
+                  "node-v24.13.1-linux-ppc64le",
+                  "fb712a08d317655dbf776c90f60ac2105109d802e33811df6c9ed33d12f801c6"
+                ],
+                "24.13.1-linux_s390x": [
+                  "node-v24.13.1-linux-s390x.tar.xz",
+                  "node-v24.13.1-linux-s390x",
+                  "8e2c0d9b5545c3db22623e8cb8d6f0c28fcd470f29d32dbeabf9432dda289de2"
+                ],
+                "24.13.1-linux_amd64": [
+                  "node-v24.13.1-linux-x64.tar.xz",
+                  "node-v24.13.1-linux-x64",
+                  "30215f90ea3cd04dfbc06e762c021393fa173a1d392974298bbc871a8e461089"
+                ],
+                "24.13.1-windows_amd64": [
+                  "node-v24.13.1-win-x64.zip",
+                  "node-v24.13.1-win-x64",
+                  "fba577c4bb87df04d54dd87bbdaa5a2272f1f99a2acbf9152e1a91b8b5f0b279"
+                ]
+              },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "24.0.0",
+              "node_version": "24.13.1",
               "include_headers": false,
               "platform": "linux_amd64"
             }
@@ -1772,11 +1974,47 @@
             "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {},
+              "node_repositories": {
+                "24.13.1-darwin_arm64": [
+                  "node-v24.13.1-darwin-arm64.tar.gz",
+                  "node-v24.13.1-darwin-arm64",
+                  "8c039d59f2fec6195e4281ad5b0d02b9a940897b4df7b849c6fb48be6787bba6"
+                ],
+                "24.13.1-darwin_amd64": [
+                  "node-v24.13.1-darwin-x64.tar.gz",
+                  "node-v24.13.1-darwin-x64",
+                  "527f0578d9812e7dfa225121bda0b1546a6a0e4b5f556295fc8299c272de5fbf"
+                ],
+                "24.13.1-linux_arm64": [
+                  "node-v24.13.1-linux-arm64.tar.xz",
+                  "node-v24.13.1-linux-arm64",
+                  "c827d3d301e2eed1a51f36d0116b71b9e3d9e3b728f081615270ea40faac34c1"
+                ],
+                "24.13.1-linux_ppc64le": [
+                  "node-v24.13.1-linux-ppc64le.tar.xz",
+                  "node-v24.13.1-linux-ppc64le",
+                  "fb712a08d317655dbf776c90f60ac2105109d802e33811df6c9ed33d12f801c6"
+                ],
+                "24.13.1-linux_s390x": [
+                  "node-v24.13.1-linux-s390x.tar.xz",
+                  "node-v24.13.1-linux-s390x",
+                  "8e2c0d9b5545c3db22623e8cb8d6f0c28fcd470f29d32dbeabf9432dda289de2"
+                ],
+                "24.13.1-linux_amd64": [
+                  "node-v24.13.1-linux-x64.tar.xz",
+                  "node-v24.13.1-linux-x64",
+                  "30215f90ea3cd04dfbc06e762c021393fa173a1d392974298bbc871a8e461089"
+                ],
+                "24.13.1-windows_amd64": [
+                  "node-v24.13.1-win-x64.zip",
+                  "node-v24.13.1-win-x64",
+                  "fba577c4bb87df04d54dd87bbdaa5a2272f1f99a2acbf9152e1a91b8b5f0b279"
+                ]
+              },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "24.0.0",
+              "node_version": "24.13.1",
               "include_headers": false,
               "platform": "linux_arm64"
             }
@@ -1785,11 +2023,47 @@
             "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {},
+              "node_repositories": {
+                "24.13.1-darwin_arm64": [
+                  "node-v24.13.1-darwin-arm64.tar.gz",
+                  "node-v24.13.1-darwin-arm64",
+                  "8c039d59f2fec6195e4281ad5b0d02b9a940897b4df7b849c6fb48be6787bba6"
+                ],
+                "24.13.1-darwin_amd64": [
+                  "node-v24.13.1-darwin-x64.tar.gz",
+                  "node-v24.13.1-darwin-x64",
+                  "527f0578d9812e7dfa225121bda0b1546a6a0e4b5f556295fc8299c272de5fbf"
+                ],
+                "24.13.1-linux_arm64": [
+                  "node-v24.13.1-linux-arm64.tar.xz",
+                  "node-v24.13.1-linux-arm64",
+                  "c827d3d301e2eed1a51f36d0116b71b9e3d9e3b728f081615270ea40faac34c1"
+                ],
+                "24.13.1-linux_ppc64le": [
+                  "node-v24.13.1-linux-ppc64le.tar.xz",
+                  "node-v24.13.1-linux-ppc64le",
+                  "fb712a08d317655dbf776c90f60ac2105109d802e33811df6c9ed33d12f801c6"
+                ],
+                "24.13.1-linux_s390x": [
+                  "node-v24.13.1-linux-s390x.tar.xz",
+                  "node-v24.13.1-linux-s390x",
+                  "8e2c0d9b5545c3db22623e8cb8d6f0c28fcd470f29d32dbeabf9432dda289de2"
+                ],
+                "24.13.1-linux_amd64": [
+                  "node-v24.13.1-linux-x64.tar.xz",
+                  "node-v24.13.1-linux-x64",
+                  "30215f90ea3cd04dfbc06e762c021393fa173a1d392974298bbc871a8e461089"
+                ],
+                "24.13.1-windows_amd64": [
+                  "node-v24.13.1-win-x64.zip",
+                  "node-v24.13.1-win-x64",
+                  "fba577c4bb87df04d54dd87bbdaa5a2272f1f99a2acbf9152e1a91b8b5f0b279"
+                ]
+              },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "24.0.0",
+              "node_version": "24.13.1",
               "include_headers": false,
               "platform": "linux_s390x"
             }
@@ -1798,11 +2072,47 @@
             "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {},
+              "node_repositories": {
+                "24.13.1-darwin_arm64": [
+                  "node-v24.13.1-darwin-arm64.tar.gz",
+                  "node-v24.13.1-darwin-arm64",
+                  "8c039d59f2fec6195e4281ad5b0d02b9a940897b4df7b849c6fb48be6787bba6"
+                ],
+                "24.13.1-darwin_amd64": [
+                  "node-v24.13.1-darwin-x64.tar.gz",
+                  "node-v24.13.1-darwin-x64",
+                  "527f0578d9812e7dfa225121bda0b1546a6a0e4b5f556295fc8299c272de5fbf"
+                ],
+                "24.13.1-linux_arm64": [
+                  "node-v24.13.1-linux-arm64.tar.xz",
+                  "node-v24.13.1-linux-arm64",
+                  "c827d3d301e2eed1a51f36d0116b71b9e3d9e3b728f081615270ea40faac34c1"
+                ],
+                "24.13.1-linux_ppc64le": [
+                  "node-v24.13.1-linux-ppc64le.tar.xz",
+                  "node-v24.13.1-linux-ppc64le",
+                  "fb712a08d317655dbf776c90f60ac2105109d802e33811df6c9ed33d12f801c6"
+                ],
+                "24.13.1-linux_s390x": [
+                  "node-v24.13.1-linux-s390x.tar.xz",
+                  "node-v24.13.1-linux-s390x",
+                  "8e2c0d9b5545c3db22623e8cb8d6f0c28fcd470f29d32dbeabf9432dda289de2"
+                ],
+                "24.13.1-linux_amd64": [
+                  "node-v24.13.1-linux-x64.tar.xz",
+                  "node-v24.13.1-linux-x64",
+                  "30215f90ea3cd04dfbc06e762c021393fa173a1d392974298bbc871a8e461089"
+                ],
+                "24.13.1-windows_amd64": [
+                  "node-v24.13.1-win-x64.zip",
+                  "node-v24.13.1-win-x64",
+                  "fba577c4bb87df04d54dd87bbdaa5a2272f1f99a2acbf9152e1a91b8b5f0b279"
+                ]
+              },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "24.0.0",
+              "node_version": "24.13.1",
               "include_headers": false,
               "platform": "linux_ppc64le"
             }
@@ -1811,11 +2121,47 @@
             "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {},
+              "node_repositories": {
+                "24.13.1-darwin_arm64": [
+                  "node-v24.13.1-darwin-arm64.tar.gz",
+                  "node-v24.13.1-darwin-arm64",
+                  "8c039d59f2fec6195e4281ad5b0d02b9a940897b4df7b849c6fb48be6787bba6"
+                ],
+                "24.13.1-darwin_amd64": [
+                  "node-v24.13.1-darwin-x64.tar.gz",
+                  "node-v24.13.1-darwin-x64",
+                  "527f0578d9812e7dfa225121bda0b1546a6a0e4b5f556295fc8299c272de5fbf"
+                ],
+                "24.13.1-linux_arm64": [
+                  "node-v24.13.1-linux-arm64.tar.xz",
+                  "node-v24.13.1-linux-arm64",
+                  "c827d3d301e2eed1a51f36d0116b71b9e3d9e3b728f081615270ea40faac34c1"
+                ],
+                "24.13.1-linux_ppc64le": [
+                  "node-v24.13.1-linux-ppc64le.tar.xz",
+                  "node-v24.13.1-linux-ppc64le",
+                  "fb712a08d317655dbf776c90f60ac2105109d802e33811df6c9ed33d12f801c6"
+                ],
+                "24.13.1-linux_s390x": [
+                  "node-v24.13.1-linux-s390x.tar.xz",
+                  "node-v24.13.1-linux-s390x",
+                  "8e2c0d9b5545c3db22623e8cb8d6f0c28fcd470f29d32dbeabf9432dda289de2"
+                ],
+                "24.13.1-linux_amd64": [
+                  "node-v24.13.1-linux-x64.tar.xz",
+                  "node-v24.13.1-linux-x64",
+                  "30215f90ea3cd04dfbc06e762c021393fa173a1d392974298bbc871a8e461089"
+                ],
+                "24.13.1-windows_amd64": [
+                  "node-v24.13.1-win-x64.zip",
+                  "node-v24.13.1-win-x64",
+                  "fba577c4bb87df04d54dd87bbdaa5a2272f1f99a2acbf9152e1a91b8b5f0b279"
+                ]
+              },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "24.0.0",
+              "node_version": "24.13.1",
               "include_headers": false,
               "platform": "darwin_amd64"
             }
@@ -1824,11 +2170,47 @@
             "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {},
+              "node_repositories": {
+                "24.13.1-darwin_arm64": [
+                  "node-v24.13.1-darwin-arm64.tar.gz",
+                  "node-v24.13.1-darwin-arm64",
+                  "8c039d59f2fec6195e4281ad5b0d02b9a940897b4df7b849c6fb48be6787bba6"
+                ],
+                "24.13.1-darwin_amd64": [
+                  "node-v24.13.1-darwin-x64.tar.gz",
+                  "node-v24.13.1-darwin-x64",
+                  "527f0578d9812e7dfa225121bda0b1546a6a0e4b5f556295fc8299c272de5fbf"
+                ],
+                "24.13.1-linux_arm64": [
+                  "node-v24.13.1-linux-arm64.tar.xz",
+                  "node-v24.13.1-linux-arm64",
+                  "c827d3d301e2eed1a51f36d0116b71b9e3d9e3b728f081615270ea40faac34c1"
+                ],
+                "24.13.1-linux_ppc64le": [
+                  "node-v24.13.1-linux-ppc64le.tar.xz",
+                  "node-v24.13.1-linux-ppc64le",
+                  "fb712a08d317655dbf776c90f60ac2105109d802e33811df6c9ed33d12f801c6"
+                ],
+                "24.13.1-linux_s390x": [
+                  "node-v24.13.1-linux-s390x.tar.xz",
+                  "node-v24.13.1-linux-s390x",
+                  "8e2c0d9b5545c3db22623e8cb8d6f0c28fcd470f29d32dbeabf9432dda289de2"
+                ],
+                "24.13.1-linux_amd64": [
+                  "node-v24.13.1-linux-x64.tar.xz",
+                  "node-v24.13.1-linux-x64",
+                  "30215f90ea3cd04dfbc06e762c021393fa173a1d392974298bbc871a8e461089"
+                ],
+                "24.13.1-windows_amd64": [
+                  "node-v24.13.1-win-x64.zip",
+                  "node-v24.13.1-win-x64",
+                  "fba577c4bb87df04d54dd87bbdaa5a2272f1f99a2acbf9152e1a91b8b5f0b279"
+                ]
+              },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "24.0.0",
+              "node_version": "24.13.1",
               "include_headers": false,
               "platform": "darwin_arm64"
             }
@@ -1837,11 +2219,47 @@
             "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {},
+              "node_repositories": {
+                "24.13.1-darwin_arm64": [
+                  "node-v24.13.1-darwin-arm64.tar.gz",
+                  "node-v24.13.1-darwin-arm64",
+                  "8c039d59f2fec6195e4281ad5b0d02b9a940897b4df7b849c6fb48be6787bba6"
+                ],
+                "24.13.1-darwin_amd64": [
+                  "node-v24.13.1-darwin-x64.tar.gz",
+                  "node-v24.13.1-darwin-x64",
+                  "527f0578d9812e7dfa225121bda0b1546a6a0e4b5f556295fc8299c272de5fbf"
+                ],
+                "24.13.1-linux_arm64": [
+                  "node-v24.13.1-linux-arm64.tar.xz",
+                  "node-v24.13.1-linux-arm64",
+                  "c827d3d301e2eed1a51f36d0116b71b9e3d9e3b728f081615270ea40faac34c1"
+                ],
+                "24.13.1-linux_ppc64le": [
+                  "node-v24.13.1-linux-ppc64le.tar.xz",
+                  "node-v24.13.1-linux-ppc64le",
+                  "fb712a08d317655dbf776c90f60ac2105109d802e33811df6c9ed33d12f801c6"
+                ],
+                "24.13.1-linux_s390x": [
+                  "node-v24.13.1-linux-s390x.tar.xz",
+                  "node-v24.13.1-linux-s390x",
+                  "8e2c0d9b5545c3db22623e8cb8d6f0c28fcd470f29d32dbeabf9432dda289de2"
+                ],
+                "24.13.1-linux_amd64": [
+                  "node-v24.13.1-linux-x64.tar.xz",
+                  "node-v24.13.1-linux-x64",
+                  "30215f90ea3cd04dfbc06e762c021393fa173a1d392974298bbc871a8e461089"
+                ],
+                "24.13.1-windows_amd64": [
+                  "node-v24.13.1-win-x64.zip",
+                  "node-v24.13.1-win-x64",
+                  "fba577c4bb87df04d54dd87bbdaa5a2272f1f99a2acbf9152e1a91b8b5f0b279"
+                ]
+              },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "24.0.0",
+              "node_version": "24.13.1",
               "include_headers": false,
               "platform": "windows_amd64"
             }
@@ -1850,11 +2268,47 @@
             "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
             "attributes": {
               "node_download_auth": {},
-              "node_repositories": {},
+              "node_repositories": {
+                "24.13.1-darwin_arm64": [
+                  "node-v24.13.1-darwin-arm64.tar.gz",
+                  "node-v24.13.1-darwin-arm64",
+                  "8c039d59f2fec6195e4281ad5b0d02b9a940897b4df7b849c6fb48be6787bba6"
+                ],
+                "24.13.1-darwin_amd64": [
+                  "node-v24.13.1-darwin-x64.tar.gz",
+                  "node-v24.13.1-darwin-x64",
+                  "527f0578d9812e7dfa225121bda0b1546a6a0e4b5f556295fc8299c272de5fbf"
+                ],
+                "24.13.1-linux_arm64": [
+                  "node-v24.13.1-linux-arm64.tar.xz",
+                  "node-v24.13.1-linux-arm64",
+                  "c827d3d301e2eed1a51f36d0116b71b9e3d9e3b728f081615270ea40faac34c1"
+                ],
+                "24.13.1-linux_ppc64le": [
+                  "node-v24.13.1-linux-ppc64le.tar.xz",
+                  "node-v24.13.1-linux-ppc64le",
+                  "fb712a08d317655dbf776c90f60ac2105109d802e33811df6c9ed33d12f801c6"
+                ],
+                "24.13.1-linux_s390x": [
+                  "node-v24.13.1-linux-s390x.tar.xz",
+                  "node-v24.13.1-linux-s390x",
+                  "8e2c0d9b5545c3db22623e8cb8d6f0c28fcd470f29d32dbeabf9432dda289de2"
+                ],
+                "24.13.1-linux_amd64": [
+                  "node-v24.13.1-linux-x64.tar.xz",
+                  "node-v24.13.1-linux-x64",
+                  "30215f90ea3cd04dfbc06e762c021393fa173a1d392974298bbc871a8e461089"
+                ],
+                "24.13.1-windows_amd64": [
+                  "node-v24.13.1-win-x64.zip",
+                  "node-v24.13.1-win-x64",
+                  "fba577c4bb87df04d54dd87bbdaa5a2272f1f99a2acbf9152e1a91b8b5f0b279"
+                ]
+              },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "24.0.0",
+              "node_version": "24.13.1",
               "include_headers": false,
               "platform": "windows_arm64"
             }

--- a/constants.bzl
+++ b/constants.bzl
@@ -1,5 +1,5 @@
 # Engine versions to stamp in a release package.json
-RELEASE_ENGINES_NODE = "^20.19.0 || ^22.12.0 || >=24.0.0"
+RELEASE_ENGINES_NODE = "^22.22.0 || >=24.13.1"
 RELEASE_ENGINES_NPM = "^6.11.0 || ^7.5.6 || >=8.0.0"
 RELEASE_ENGINES_YARN = ">= 1.13.0"
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "packageManager": "pnpm@10.30.0",
   "engines": {
-    "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+    "node": "^22.22.0 || >=24.13.1",
     "npm": "Please use pnpm instead of NPM to install dependencies",
     "yarn": "Please use pnpm instead of Yarn to install dependencies",
     "pnpm": "10.30.0"

--- a/packages/angular/build/BUILD.bazel
+++ b/packages/angular/build/BUILD.bazel
@@ -105,7 +105,6 @@ ts_project(
         ":node_modules/sass",
         ":node_modules/source-map-support",
         ":node_modules/tinyglobby",
-        ":node_modules/undici",
         ":node_modules/vite",
         ":node_modules/vitest",
         ":node_modules/watchpack",

--- a/packages/angular/build/package.json
+++ b/packages/angular/build/package.json
@@ -42,7 +42,6 @@
     "semver": "7.7.4",
     "source-map-support": "0.5.21",
     "tinyglobby": "0.2.15",
-    "undici": "7.22.0",
     "vite": "7.3.1",
     "watchpack": "2.5.1"
   },

--- a/packages/angular/build/src/tools/vite/plugins/ssr-ssl-plugin.ts
+++ b/packages/angular/build/src/tools/vite/plugins/ssr-ssl-plugin.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { readFile } from 'node:fs/promises';
-import { getCACertificates, rootCertificates, setDefaultCACertificates } from 'node:tls';
+import { getCACertificates, setDefaultCACertificates } from 'node:tls';
 import type { Plugin } from 'vite';
 
 export function createAngularServerSideSSLPlugin(): Plugin {
@@ -39,34 +38,8 @@ export function createAngularServerSideSSLPlugin(): Plugin {
       const { cert } = https;
       const additionalCerts = Array.isArray(cert) ? cert : [cert];
 
-      // TODO(alanagius): Remove the `if` check once we only support Node.js 22.18.0+ and 24.5.0+.
-      if (getCACertificates && setDefaultCACertificates) {
-        const currentCerts = getCACertificates('default');
-        setDefaultCACertificates([...currentCerts, ...additionalCerts]);
-
-        return;
-      }
-
-      // TODO(alanagius): Remove the below and `undici` dependency once we only support Node.js 22.18.0+ and 24.5.0+.
-      const { getGlobalDispatcher, setGlobalDispatcher, Agent } = await import('undici');
-      const originalDispatcher = getGlobalDispatcher();
-      const ca = [...rootCertificates, ...additionalCerts];
-      const extraNodeCerts = process.env['NODE_EXTRA_CA_CERTS'];
-      if (extraNodeCerts) {
-        ca.push(await readFile(extraNodeCerts));
-      }
-
-      setGlobalDispatcher(
-        new Agent({
-          connect: {
-            ca,
-          },
-        }),
-      );
-
-      httpServer?.on('close', () => {
-        setGlobalDispatcher(originalDispatcher);
-      });
+      const currentCerts = getCACertificates('default');
+      setDefaultCACertificates([...currentCerts, ...additionalCerts]);
     },
   };
 }

--- a/packages/angular/cli/lib/cli/index.ts
+++ b/packages/angular/cli/lib/cli/index.ts
@@ -16,7 +16,7 @@ import { writeErrorToLogFile } from '../../src/utilities/log-file';
 
 export { VERSION } from '../../src/utilities/version';
 
-const MIN_NODEJS_VERSION = [20, 19] as const;
+const MIN_NODEJS_VERSION = [22, 22] as const;
 
 /* eslint-disable no-console */
 export default async function (options: { cliArgs: string[] }) {

--- a/packages/angular/cli/src/commands/version/version-info.ts
+++ b/packages/angular/cli/src/commands/version/version-info.ts
@@ -60,7 +60,7 @@ export interface VersionInfo {
  * Major versions of Node.js that are officially supported by Angular.
  * @see https://angular.dev/reference/versions#supported-node-js-versions
  */
-const SUPPORTED_NODE_MAJORS = [20, 22, 24];
+const SUPPORTED_NODE_MAJORS = [22, 24];
 
 /**
  * A list of regular expression patterns that match package names that should be included in the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -403,9 +403,6 @@ importers:
       tinyglobby:
         specifier: 0.2.15
         version: 0.2.15
-      undici:
-        specifier: 7.22.0
-        version: 7.22.0
       vite:
         specifier: 7.3.1
         version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)

--- a/tools/toolchain_info.bzl
+++ b/tools/toolchain_info.bzl
@@ -3,18 +3,12 @@
 # the name can be anything the user wants this is just added to the target to create unique names
 # the order will match against the order in the TOOLCHAIN_VERSION list.
 TOOLCHAINS_NAMES = [
-    "node20",
     "node22",
     "node24",
 ]
 
 # this is the list of toolchains that should be used and are registered with nodejs_register_toolchains in the WORKSPACE file
 TOOLCHAINS_VERSIONS = [
-    select({
-        "@bazel_tools//src/conditions:linux_x86_64": "@node20_linux_amd64//:node_toolchain",
-        "@bazel_tools//src/conditions:darwin": "@node20_darwin_amd64//:node_toolchain",
-        "@bazel_tools//src/conditions:windows": "@node20_windows_amd64//:node_toolchain",
-    }),
     select({
         "@bazel_tools//src/conditions:linux_x86_64": "@node22_linux_amd64//:node_toolchain",
         "@bazel_tools//src/conditions:darwin": "@node22_darwin_amd64//:node_toolchain",


### PR DESCRIPTION
This commit updates the minimum supported Node.js versions. Node.js v20 support is dropped, and the minimum version for Node.js v22 is bumped to v22.22.0, and for v24 it is bumped to v24.13.1.

The 'undici' dependency has been removed from '@angular/build' as we can now rely on native Node.js APIs for SSL certificate handling in newer Node versions.

BREAKING CHANGE: Node.js v20 is no longer supported. The minimum supported Node.js versions are now v22.22.0 and v24.13.1.
