### PR TITLE
refactor(@angular/build): remove Node.js v20 conditional file copying logic

### DIFF
--- a/packages/angular/build/src/builders/application/index.ts
+++ b/packages/angular/build/src/builders/application/index.ts
@@ -28,8 +28,6 @@ import {
 import { Result, ResultKind } from './results';
 import { Schema as ApplicationBuilderOptions } from './schema';
 
-const isNodeV22orHigher = Number(process.versions.node.split('.', 1)[0]) >= 22;
-
 export type { ApplicationBuilderOptions };
 
 export async function* buildApplicationInternal(
@@ -222,17 +220,10 @@ export async function* buildApplication(
         await fs.writeFile(fullFilePath, file.contents);
       } else {
         // Copy file contents
-        if (isNodeV22orHigher) {
-          // Use newer `cp` API on Node.js 22+ (minimum v22 for CLI is 22.11)
-          await fs.cp(file.inputPath, fullFilePath, {
-            mode: fs.constants.COPYFILE_FICLONE,
-            preserveTimestamps: true,
-          });
-        } else {
-          // For Node.js 20 use `copyFile` (`cp` is not stable for v20)
-          // TODO: Remove when Node.js 20 is no longer supported
-          await fs.copyFile(file.inputPath, fullFilePath, fs.constants.COPYFILE_FICLONE);
-        }
+        await fs.cp(file.inputPath, fullFilePath, {
+          mode: fs.constants.COPYFILE_FICLONE,
+          preserveTimestamps: true,
+        });
       }
     });
 

--- a/tests/e2e/tests/build/assets.ts
+++ b/tests/e2e/tests/build/assets.ts
@@ -6,8 +6,6 @@ import { updateJsonFile } from '../../utils/project';
 import { expectToFail } from '../../utils/utils';
 import { getGlobalVariable } from '../../utils/env';
 
-const isNodeV22orHigher = Number(process.versions.node.split('.', 1)[0]) >= 22;
-
 export default async function () {
   // Update the atime and mtime of the original file.
   // Note: Node.js has different time precision, which may cause mtime-based tests to fail.
@@ -28,7 +26,7 @@ export default async function () {
   await expectToFail(() => expectFileToExist('dist/test-project/browser/.gitkeep'));
 
   // Timestamp preservation only supported with application build system on Node.js v22+
-  if (isNodeV22orHigher && getGlobalVariable('argv')['esbuild']) {
+  if (getGlobalVariable('argv')['esbuild']) {
     const [originalStats, outputStats] = await Promise.all([
       stat('public/favicon.ico'),
       stat('dist/test-project/browser/favicon.ico'),


### PR DESCRIPTION
The Node.js v20 `fs.copyFile` fallback has been removed in favor of `fs.cp`. This simplifies the file copying logic within the application builder, as `fs.cp` is now the standard for all supported Node.js versions. The related e2e test has also been updated to run unconditionally.