### PR TITLE
fix(@angular/build): normalize `allowedHosts` in dev-server

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite/index.ts
+++ b/packages/angular/build/src/builders/dev-server/vite/index.ts
@@ -97,8 +97,10 @@ export async function* serveWithVite(
     browserOptions.ssr ||= true;
   }
 
+  // Vite allowedHost syntax doesn't allow `*.` but `.` acts as `*.`
+  // Angular SSR supports `*.`.
   const allowedHosts = Array.isArray(serverOptions.allowedHosts)
-    ? [...serverOptions.allowedHosts]
+    ? serverOptions.allowedHosts.map((host) => (host[0] === '.' ? '*' + host : host))
     : [];
 
   // Always allow the dev server host


### PR DESCRIPTION
This change ensures that allowed hosts starting with a dot (e.g. '.example.com') are converted to the wildcard format ('*.example.com') required by Angular SSR host validation. This aligns Vite's configuration style with Angular's internal validation logic.