### PR TITLE
fix(@angular/ssr): remove CSR fallback for invalid hosts

### DIFF
--- a/packages/angular/ssr/node/src/app-engine.ts
+++ b/packages/angular/ssr/node/src/app-engine.ts
@@ -60,8 +60,7 @@ export class AngularNodeAppEngine {
    * @remarks
    * To prevent potential Server-Side Request Forgery (SSRF), this function verifies the hostname
    * of the `request.url` against a list of authorized hosts.
-   * If the hostname is not recognized and `allowedHosts` is not empty, a Client-Side Rendered (CSR) version of the
-   * page is returned otherwise a 400 Bad Request is returned.
+   * If the hostname is not recognized a 400 Bad Request is returned.
    *
    * Resolution:
    * Authorize your hostname by configuring `allowedHosts` in `angular.json` in:

--- a/packages/angular/ssr/node/src/common-engine/common-engine.ts
+++ b/packages/angular/ssr/node/src/common-engine/common-engine.ts
@@ -92,28 +92,11 @@ export class CommonEngine {
       try {
         validateUrl(urlObj, this.allowedHosts);
       } catch (error) {
-        const isAllowedHostConfigured = this.allowedHosts.size > 0;
         // eslint-disable-next-line no-console
         console.error(
           `ERROR: ${(error as Error).message}` +
             'Please provide a list of allowed hosts in the "allowedHosts" option in the "CommonEngine" constructor.',
-          isAllowedHostConfigured
-            ? ''
-            : '\nFalling back to client side rendering. This will become a 400 Bad Request in a future major version.',
         );
-
-        if (!isAllowedHostConfigured) {
-          // Fallback to CSR to avoid a breaking change.
-          // TODO(alanagius): Return a 400 and remove this fallback in the next major version (v22).
-          let document = opts.document;
-          if (!document && opts.documentFilePath) {
-            document = opts.document ?? (await this.getDocument(opts.documentFilePath));
-          }
-
-          if (document) {
-            return document;
-          }
-        }
 
         throw error;
       }

--- a/packages/angular/ssr/src/app.ts
+++ b/packages/angular/ssr/src/app.ts
@@ -484,27 +484,6 @@ export class AngularServerApp {
 
     return html;
   }
-
-  /**
-   * Serves the client-side version of the application.
-   * TODO(alanagius): Remove this method in version 22.
-   * @internal
-   */
-  async serveClientSidePage(): Promise<Response> {
-    const {
-      manifest: { locale },
-      assets,
-    } = this;
-
-    const html = await assets.getServerAsset('index.csr.html').text();
-
-    return new Response(html, {
-      headers: new Headers({
-        'Content-Type': 'text/html;charset=UTF-8',
-        ...(locale !== undefined ? { 'Content-Language': locale } : {}),
-      }),
-    });
-  }
 }
 
 let angularServerApp: AngularServerApp | undefined;

--- a/packages/angular/ssr/test/app-engine_spec.ts
+++ b/packages/angular/ssr/test/app-engine_spec.ts
@@ -290,140 +290,87 @@ describe('AngularAppEngine', () => {
   describe('Invalid host headers', () => {
     let consoleErrorSpy: jasmine.Spy;
 
-    describe('with allowed hosts configured', () => {
-      beforeAll(() => {
-        setAngularAppEngineManifest({
-          allowedHosts: ['example.com'],
-          entryPoints: {
-            '': async () => {
-              setAngularAppTestingManifest(
-                [{ path: 'home', component: TestHomeComponent }],
-                [{ path: '**', renderMode: RenderMode.Server }],
-              );
+    beforeAll(() => {
+      setAngularAppEngineManifest({
+        allowedHosts: ['example.com'],
+        entryPoints: {
+          '': async () => {
+            setAngularAppTestingManifest(
+              [{ path: 'home', component: TestHomeComponent }],
+              [{ path: '**', renderMode: RenderMode.Server }],
+            );
 
-              return {
-                ɵgetOrCreateAngularServerApp: getOrCreateAngularServerApp,
-                ɵdestroyAngularServerApp: destroyAngularServerApp,
-              };
-            },
+            return {
+              ɵgetOrCreateAngularServerApp: getOrCreateAngularServerApp,
+              ɵdestroyAngularServerApp: destroyAngularServerApp,
+            };
           },
-          basePath: '/',
-          supportedLocales: { 'en-US': '' },
-        });
-
-        appEngine = new AngularAppEngine();
+        },
+        basePath: '/',
+        supportedLocales: { 'en-US': '' },
       });
 
-      beforeEach(() => {
-        consoleErrorSpy = spyOn(console, 'error');
-      });
-
-      it('should return 400 when disallowed host', async () => {
-        const request = new Request('https://evil.com');
-        const response = await appEngine.handle(request);
-        expect(response).not.toBeNull();
-        expect(response?.status).toBe(400);
-        expect(await response?.text()).toContain('URL with hostname "evil.com" is not allowed.');
-        expect(consoleErrorSpy).toHaveBeenCalledWith(
-          jasmine.stringMatching('URL with hostname "evil.com" is not allowed.'),
-        );
-      });
-
-      it('should return 400 when disallowed host header', async () => {
-        const request = new Request('https://example.com/home', {
-          headers: { 'host': 'evil.com' },
-        });
-        const response = await appEngine.handle(request);
-        expect(response).not.toBeNull();
-        expect(response?.status).toBe(400);
-        expect(await response?.text()).toContain(
-          'Header "host" with value "evil.com" is not allowed.',
-        );
-        expect(consoleErrorSpy).toHaveBeenCalledWith(
-          jasmine.stringMatching('Header "host" with value "evil.com" is not allowed.'),
-        );
-      });
-
-      it('should return 400 when disallowed x-forwarded-host header', async () => {
-        const request = new Request('https://example.com/home', {
-          headers: { 'x-forwarded-host': 'evil.com' },
-        });
-        const response = await appEngine.handle(request);
-        expect(response).not.toBeNull();
-        expect(response?.status).toBe(400);
-        expect(await response?.text()).toContain(
-          'Header "x-forwarded-host" with value "evil.com" is not allowed.',
-        );
-        expect(consoleErrorSpy).toHaveBeenCalledWith(
-          jasmine.stringMatching('Header "x-forwarded-host" with value "evil.com" is not allowed.'),
-        );
-      });
-
-      it('should return 400 when host with path separator', async () => {
-        const request = new Request('https://example.com/home', {
-          headers: { 'host': 'example.com/evil' },
-        });
-        const response = await appEngine.handle(request);
-        expect(response).not.toBeNull();
-        expect(response?.status).toBe(400);
-        expect(await response?.text()).toContain(
-          'Header "host" contains characters that are not allowed.',
-        );
-        expect(consoleErrorSpy).toHaveBeenCalledWith(
-          jasmine.stringMatching('Header "host" contains characters that are not allowed.'),
-        );
-      });
+      appEngine = new AngularAppEngine();
     });
 
-    describe('without allowed hosts configured', () => {
-      beforeAll(() => {
-        setAngularAppEngineManifest({
-          allowedHosts: [],
-          entryPoints: {
-            '': async () => {
-              setAngularAppTestingManifest(
-                [{ path: 'home', component: TestHomeComponent }],
-                [{ path: '**', renderMode: RenderMode.Server }],
-              );
+    beforeEach(() => {
+      consoleErrorSpy = spyOn(console, 'error');
+    });
 
-              return {
-                ɵgetOrCreateAngularServerApp: getOrCreateAngularServerApp,
-                ɵdestroyAngularServerApp: destroyAngularServerApp,
-              };
-            },
-          },
-          basePath: '/',
-          supportedLocales: { 'en-US': '' },
-        });
+    it('should return 400 when disallowed host', async () => {
+      const request = new Request('https://evil.com');
+      const response = await appEngine.handle(request);
+      expect(response).not.toBeNull();
+      expect(response?.status).toBe(400);
+      expect(await response?.text()).toContain('URL with hostname "evil.com" is not allowed.');
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        jasmine.stringMatching('URL with hostname "evil.com" is not allowed.'),
+      );
+    });
 
-        appEngine = new AngularAppEngine();
+    it('should return 400 when disallowed host header', async () => {
+      const request = new Request('https://example.com/home', {
+        headers: { 'host': 'evil.com' },
       });
+      const response = await appEngine.handle(request);
+      expect(response).not.toBeNull();
+      expect(response?.status).toBe(400);
+      expect(await response?.text()).toContain(
+        'Header "host" with value "evil.com" is not allowed.',
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        jasmine.stringMatching('Header "host" with value "evil.com" is not allowed.'),
+      );
+    });
 
-      beforeEach(() => {
-        consoleErrorSpy = spyOn(console, 'error');
+    it('should return 400 when disallowed x-forwarded-host header', async () => {
+      const request = new Request('https://example.com/home', {
+        headers: { 'x-forwarded-host': 'evil.com' },
       });
+      const response = await appEngine.handle(request);
+      expect(response).not.toBeNull();
+      expect(response?.status).toBe(400);
+      expect(await response?.text()).toContain(
+        'Header "x-forwarded-host" with value "evil.com" is not allowed.',
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        jasmine.stringMatching('Header "x-forwarded-host" with value "evil.com" is not allowed.'),
+      );
+    });
 
-      it('should log error and fallback to CSR when disallowed host', async () => {
-        const request = new Request('https://example.com');
-        const response = await appEngine.handle(request);
-        expect(response).not.toBeNull();
-        expect(await response?.text()).toContain('<title>CSR page</title>');
-        expect(consoleErrorSpy).toHaveBeenCalledWith(
-          jasmine.stringMatching('URL with hostname "example.com" is not allowed.'),
-        );
+    it('should return 400 when host with path separator', async () => {
+      const request = new Request('https://example.com/home', {
+        headers: { 'host': 'example.com/evil' },
       });
-
-      it('should log error and fallback to CSR when host with path separator', async () => {
-        const request = new Request('https://example.com/home', {
-          headers: { 'host': 'example.com/evil' },
-        });
-        const response = await appEngine.handle(request);
-        expect(response).not.toBeNull();
-        expect(await response?.text()).toContain('<title>CSR page</title>');
-        expect(consoleErrorSpy).toHaveBeenCalledWith(
-          jasmine.stringMatching('Header "host" contains characters that are not allowed.'),
-        );
-      });
+      const response = await appEngine.handle(request);
+      expect(response).not.toBeNull();
+      expect(response?.status).toBe(400);
+      expect(await response?.text()).toContain(
+        'Header "host" contains characters that are not allowed.',
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        jasmine.stringMatching('Header "host" contains characters that are not allowed.'),
+      );
     });
   });
 });


### PR DESCRIPTION
Previously, when a request contained an unrecognized host header, the server would fallback to serving the client-side application (CSR) as a temporary migration path.

This commit removes this fallback behavior. Requests with invalid or unrecognized host headers will now strictly return a 400 Bad Request response.

BREAKING CHANGE: The server no longer falls back to Client-Side Rendering (CSR) when a request fails host validation. Requests with unrecognized  headers will now return a 400 Bad Request status code. Users must ensure all valid hosts are correctly configured in the  option.
