### PR TITLE
fix(@angular/cli): ignore unknown files when formatting schematic changes

### DIFF
--- a/packages/angular/cli/src/utilities/prettier.ts
+++ b/packages/angular/cli/src/utilities/prettier.ts
@@ -44,7 +44,7 @@ export async function formatFiles(cwd: string, files: Set<string>): Promise<void
 
   await execFileAsync(
     process.execPath,
-    [prettierCliPath, '--write', '--no-error-on-unmatched-pattern', ...files],
+    [prettierCliPath, '--write', '--no-error-on-unmatched-pattern', '--ignore-unknown', ...files],
     {
       cwd,
       shell: false,


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When schematics modify files such as .gitignore, Prettier cannot infer a parser and formatting fails.

```
npx prettier --check .gitignore
[error] No parser could be inferred for file ".gitignore".
```

## What is the new behavior?

With `ignore-unknown` enabled, Prettier does not throw this parser error

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
