### PR TITLE
refactor: centralize ESLint file targeting within `eslint.config.mjs` to process only TypeScript files and ignore JavaScript files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,9 +10,9 @@ import { fixupConfigRules, fixupPluginRules } from '@eslint/compat';
 import { FlatCompat } from '@eslint/eslintrc';
 import js from '@eslint/js';
 import stylistic from '@stylistic/eslint-plugin';
+import header from '@tony.ganchev/eslint-plugin-header';
 import typescriptEslint from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
-import header from '@tony.ganchev/eslint-plugin-header';
 import _import from 'eslint-plugin-import';
 import globals from 'globals';
 
@@ -24,7 +24,13 @@ const compat = new FlatCompat({
 
 export default [
   {
+    files: ['**/*.ts', '**/*.mts', '**/*.cts'],
+  },
+  {
     ignores: [
+      '**/*.js',
+      '**/*.mjs',
+      '**/*.cjs',
       '**/bazel-out',
       '**/dist-schema',
       'goldens/public-api',

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "bazel test //packages/...",
     "build": "pnpm -s admin build",
     "build-schema": "bazel build //... --build_tag_filters schema --symlink_prefix dist-schema/",
-    "lint": "eslint --cache --max-warnings=0 \"**/*.@(ts|mts|cts)\"",
+    "lint": "eslint --cache --max-warnings=0",
     "templates": "pnpm -s admin templates",
     "validate": "pnpm -s admin validate",
     "postinstall": "husky",


### PR DESCRIPTION


This is needed as the glob is no longer being parsed from the CLI.

```
Run pnpm lint --cache-strategy content

> @angular/devkit-repo@22.0.0-next.0 lint /home/runner/work/angular-cli/angular-cli
> eslint --cache --max-warnings=0 "**/*.@(ts|mts|cts)" --cache-strategy content

Oops! Something went wrong! :(

ESLint: 10.0.2

No files matching the pattern "**/*.@(ts|mts|cts)" were found.
Please check for typing mistakes in the pattern.

 ELIFECYCLE  Command failed with exit code 2.
```