### PR TITLE
fix(@angular/ssr): improve header validation logic

### DIFF
--- a/goldens/public-api/angular/ssr/index.api.md
+++ b/goldens/public-api/angular/ssr/index.api.md
@@ -14,6 +14,7 @@ export class AngularAppEngine {
     constructor(options?: AngularAppEngineOptions);
     handle(request: Request, requestContext?: unknown): Promise<Response | null>;
     static ɵallowStaticRouteRender: boolean;
+    static ɵdisableAllowedHostsCheck: boolean;
     static ɵhooks: Hooks;
 }
 

--- a/packages/angular/build/src/tools/vite/middlewares/ssr-middleware.ts
+++ b/packages/angular/build/src/tools/vite/middlewares/ssr-middleware.ts
@@ -90,6 +90,10 @@ export async function createAngularSsrExternalMiddleware(
     '@angular/ssr/node' as string
   )) as typeof import('@angular/ssr/node', { with: { 'resolution-mode': 'import' } });
 
+  // Disable host check if allowed hosts is true meaning allow all hosts.
+  const { allowedHosts } = server.config.server;
+  const disableAllowedHostsCheck = allowedHosts === true;
+
   return function angularSsrExternalMiddleware(
     req: Connect.IncomingMessage,
     res: ServerResponse,
@@ -123,6 +127,7 @@ export async function createAngularSsrExternalMiddleware(
       }
 
       if (cachedAngularAppEngine !== AngularAppEngine) {
+        AngularAppEngine.ɵdisableAllowedHostsCheck = disableAllowedHostsCheck;
         AngularAppEngine.ɵallowStaticRouteRender = true;
         AngularAppEngine.ɵhooks.on('html:transform:pre', async ({ html, url }) => {
           const processedHtml = await server.transformIndexHtml(url.pathname, html);

--- a/packages/angular/ssr/src/app-engine.ts
+++ b/packages/angular/ssr/src/app-engine.ts
@@ -43,6 +43,15 @@ export class AngularAppEngine {
   static ɵallowStaticRouteRender = false;
 
   /**
+   * A flag to enable or disable the allowed hosts check.
+   *
+   * Typically used during development to avoid the allowed hosts check.
+   *
+   * @private
+   */
+  static ɵdisableAllowedHostsCheck = false;
+
+  /**
    * Hooks for extending or modifying the behavior of the server application.
    * These hooks are used by the Angular CLI when running the development server and
    * provide extensibility points for the application lifecycle.
@@ -106,23 +115,33 @@ export class AngularAppEngine {
    */
   async handle(request: Request, requestContext?: unknown): Promise<Response | null> {
     const allowedHost = this.allowedHosts;
+    const disableAllowedHostsCheck = AngularAppEngine.ɵdisableAllowedHostsCheck;
 
     try {
-      validateRequest(request, allowedHost);
+      validateRequest(request, allowedHost, disableAllowedHostsCheck);
     } catch (error) {
       return this.handleValidationError(error as Error, request);
     }
 
     // Clone request with patched headers to prevent unallowed host header access.
-    const { request: securedRequest, onError: onHeaderValidationError } =
-      cloneRequestAndPatchHeaders(request, allowedHost);
+    const { request: securedRequest, onError: onHeaderValidationError } = disableAllowedHostsCheck
+      ? { request, onError: null }
+      : cloneRequestAndPatchHeaders(request, allowedHost);
 
     const serverApp = await this.getAngularServerAppForRequest(securedRequest);
     if (serverApp) {
-      return Promise.race([
-        onHeaderValidationError.then((error) => this.handleValidationError(error, securedRequest)),
-        serverApp.handle(securedRequest, requestContext),
-      ]);
+      const promises: Promise<Response | null>[] = [];
+      if (onHeaderValidationError) {
+        promises.push(
+          onHeaderValidationError.then((error) =>
+            this.handleValidationError(error, securedRequest),
+          ),
+        );
+      }
+
+      promises.push(serverApp.handle(securedRequest, requestContext));
+
+      return Promise.race(promises);
     }
 
     if (this.supportedLocales.length > 1) {

--- a/packages/angular/ssr/src/utils/validation.ts
+++ b/packages/angular/ssr/src/utils/validation.ts
@@ -56,11 +56,19 @@ export function getFirstHeaderValue(
  *
  * @param request - The incoming `Request` object to validate.
  * @param allowedHosts - A set of allowed hostnames.
+ * @param disableHostCheck - Whether to disable the host check.
  * @throws Error if any of the validated headers contain invalid values.
  */
-export function validateRequest(request: Request, allowedHosts: ReadonlySet<string>): void {
+export function validateRequest(
+  request: Request,
+  allowedHosts: ReadonlySet<string>,
+  disableHostCheck: boolean,
+): void {
   validateHeaders(request);
-  validateUrl(new URL(request.url), allowedHosts);
+
+  if (!disableHostCheck) {
+    validateUrl(new URL(request.url), allowedHosts);
+  }
 }
 
 /**

--- a/packages/angular/ssr/test/app-engine_spec.ts
+++ b/packages/angular/ssr/test/app-engine_spec.ts
@@ -426,4 +426,61 @@ describe('AngularAppEngine', () => {
       });
     });
   });
+
+  describe('Disable host check', () => {
+    let consoleErrorSpy: jasmine.Spy;
+
+    beforeAll(() => {
+      setAngularAppEngineManifest({
+        allowedHosts: ['example.com'],
+        entryPoints: {
+          '': async () => {
+            setAngularAppTestingManifest(
+              [{ path: 'home', component: TestHomeComponent }],
+              [{ path: '**', renderMode: RenderMode.Server }],
+            );
+
+            return {
+              ɵgetOrCreateAngularServerApp: getOrCreateAngularServerApp,
+              ɵdestroyAngularServerApp: destroyAngularServerApp,
+            };
+          },
+        },
+        basePath: '/',
+        supportedLocales: { 'en-US': '' },
+      });
+
+      appEngine = new AngularAppEngine();
+
+      AngularAppEngine.ɵdisableAllowedHostsCheck = true;
+    });
+
+    afterAll(() => {
+      AngularAppEngine.ɵdisableAllowedHostsCheck = false;
+    });
+
+    beforeEach(() => {
+      consoleErrorSpy = spyOn(console, 'error');
+    });
+
+    it('should allow requests to disallowed hosts', async () => {
+      const request = new Request('https://evil.com/home');
+      const response = await appEngine.handle(request);
+      expect(response).toBeDefined();
+      expect(response?.status).toBe(200);
+      expect(await response?.text()).toContain('Home works');
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('should allow requests with disallowed host header', async () => {
+      const request = new Request('https://example.com/home', {
+        headers: { 'host': 'evil.com' },
+      });
+      const response = await appEngine.handle(request);
+      expect(response).toBeDefined();
+      expect(response?.status).toBe(200);
+      expect(await response?.text()).toContain('Home works');
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
Updates the `validateRequest` function to correctly handle the `allowedHost=true` option.
