### PR TITLE
test(@angular/build): remove isViteRun from dev-server test harness

### DIFF
--- a/packages/angular/build/src/builders/dev-server/tests/behavior/build-budgets_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/behavior/build-budgets_spec.ts
@@ -11,29 +11,25 @@ import { executeDevServer } from '../../index';
 import { describeServeBuilder } from '../jasmine-helpers';
 import { BASE_OPTIONS, DEV_SERVER_BUILDER_INFO } from '../setup';
 
-describeServeBuilder(
-  executeDevServer,
-  DEV_SERVER_BUILDER_INFO,
-  (harness, setupTarget, isViteRun) => {
-    // TODO(fix-vite): currently this is broken in vite.
-    (isViteRun ? xdescribe : describe)('Behavior: "browser builder budgets"', () => {
-      beforeEach(() => {
-        setupTarget(harness, {
-          // Add a budget error for any file over 100 bytes
-          budgets: [{ type: BudgetType.All, maximumError: '100b' }],
-          optimization: true,
-        });
-      });
-
-      it('should ignore budgets defined in the "buildTarget" options', async () => {
-        harness.useTarget('serve', {
-          ...BASE_OPTIONS,
-        });
-
-        const { result } = await harness.executeOnce();
-
-        expect(result?.success).toBe(true);
+describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupTarget) => {
+  // TODO(fix-vite): currently this is broken in vite.
+  xdescribe('Behavior: "browser builder budgets"', () => {
+    beforeEach(() => {
+      setupTarget(harness, {
+        // Add a budget error for any file over 100 bytes
+        budgets: [{ type: BudgetType.All, maximumError: '100b' }],
+        optimization: true,
       });
     });
-  },
-);
+
+    it('should ignore budgets defined in the "buildTarget" options', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+    });
+  });
+});

--- a/packages/angular/build/src/builders/dev-server/tests/behavior/build-conditions_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/behavior/build-conditions_spec.ts
@@ -15,86 +15,74 @@ import { executeOnceAndFetch } from '../execute-fetch';
 import { describeServeBuilder } from '../jasmine-helpers';
 import { BASE_OPTIONS, DEV_SERVER_BUILDER_INFO } from '../setup';
 
-describeServeBuilder(
-  executeDevServer,
-  DEV_SERVER_BUILDER_INFO,
-  (harness, setupTarget, isApplicationBuilder) => {
-    describe('Behavior: "conditional imports"', () => {
-      if (!isApplicationBuilder) {
-        it('requires esbuild', () => {
-          expect(true).toBeTrue();
-        });
+describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupTarget) => {
+  describe('Behavior: "conditional imports"', () => {
+    beforeEach(async () => {
+      setupTarget(harness);
 
-        return;
-      }
-
-      beforeEach(async () => {
-        setupTarget(harness);
-
-        await setupConditionImport(harness);
-      });
-
-      interface ImportsTestCase {
-        name: string;
-        mapping: unknown;
-        output?: string;
-      }
-
-      const GOOD_TARGET = './src/good.js';
-      const BAD_TARGET = './src/bad.js';
-
-      const testCases: ImportsTestCase[] = [
-        { name: 'simple string', mapping: GOOD_TARGET },
-        {
-          name: 'default fallback without matching condition',
-          mapping: {
-            'never': BAD_TARGET,
-            'default': GOOD_TARGET,
-          },
-        },
-        {
-          name: 'development condition',
-          mapping: {
-            'development': GOOD_TARGET,
-            'default': BAD_TARGET,
-          },
-        },
-        {
-          name: 'production condition',
-          mapping: {
-            'production': BAD_TARGET,
-            'default': GOOD_TARGET,
-          },
-        },
-        {
-          name: 'browser condition (in browser)',
-          mapping: {
-            'browser': GOOD_TARGET,
-            'default': BAD_TARGET,
-          },
-        },
-      ];
-
-      for (const testCase of testCases) {
-        describe(testCase.name, () => {
-          beforeEach(async () => {
-            await setTargetMapping(harness, testCase.mapping);
-          });
-
-          it('resolves to expected target', async () => {
-            harness.useTarget('serve', {
-              ...BASE_OPTIONS,
-            });
-
-            const { result, response } = await executeOnceAndFetch(harness, '/main.js');
-
-            expect(result?.success).toBeTrue();
-            const output = await response?.text();
-            expect(output).toContain('good-value');
-            expect(output).not.toContain('bad-value');
-          });
-        });
-      }
+      await setupConditionImport(harness);
     });
-  },
-);
+
+    interface ImportsTestCase {
+      name: string;
+      mapping: unknown;
+      output?: string;
+    }
+
+    const GOOD_TARGET = './src/good.js';
+    const BAD_TARGET = './src/bad.js';
+
+    const testCases: ImportsTestCase[] = [
+      { name: 'simple string', mapping: GOOD_TARGET },
+      {
+        name: 'default fallback without matching condition',
+        mapping: {
+          'never': BAD_TARGET,
+          'default': GOOD_TARGET,
+        },
+      },
+      {
+        name: 'development condition',
+        mapping: {
+          'development': GOOD_TARGET,
+          'default': BAD_TARGET,
+        },
+      },
+      {
+        name: 'production condition',
+        mapping: {
+          'production': BAD_TARGET,
+          'default': GOOD_TARGET,
+        },
+      },
+      {
+        name: 'browser condition (in browser)',
+        mapping: {
+          'browser': GOOD_TARGET,
+          'default': BAD_TARGET,
+        },
+      },
+    ];
+
+    for (const testCase of testCases) {
+      describe(testCase.name, () => {
+        beforeEach(async () => {
+          await setTargetMapping(harness, testCase.mapping);
+        });
+
+        it('resolves to expected target', async () => {
+          harness.useTarget('serve', {
+            ...BASE_OPTIONS,
+          });
+
+          const { result, response } = await executeOnceAndFetch(harness, '/main.js');
+
+          expect(result?.success).toBeTrue();
+          const output = await response?.text();
+          expect(output).toContain('good-value');
+          expect(output).not.toContain('bad-value');
+        });
+      });
+    }
+  });
+});

--- a/packages/angular/build/src/builders/dev-server/tests/behavior/build_translation_watch_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/behavior/build_translation_watch_spec.ts
@@ -12,70 +12,66 @@ import { executeDevServer } from '../../index';
 import { describeServeBuilder } from '../jasmine-helpers';
 import { BASE_OPTIONS, DEV_SERVER_BUILDER_INFO } from '../setup';
 
-describeServeBuilder(
-  executeDevServer,
-  DEV_SERVER_BUILDER_INFO,
-  (harness, setupTarget, isViteRun) => {
-    // TODO(fix-vite): currently this is broken in vite.
-    (isViteRun ? xdescribe : describe)('Behavior: "i18n translation file watching"', () => {
-      beforeEach(() => {
-        harness.useProject('test', {
-          root: '.',
-          sourceRoot: 'src',
-          cli: {
-            cache: {
-              enabled: false,
-            },
+describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupTarget) => {
+  // TODO(fix-vite): currently this is broken in vite.
+  xdescribe('Behavior: "i18n translation file watching"', () => {
+    beforeEach(() => {
+      harness.useProject('test', {
+        root: '.',
+        sourceRoot: 'src',
+        cli: {
+          cache: {
+            enabled: false,
           },
-          i18n: {
-            locales: {
-              fr: 'src/locales/messages.fr.xlf',
-            },
+        },
+        i18n: {
+          locales: {
+            fr: 'src/locales/messages.fr.xlf',
           },
-        });
-
-        setupTarget(harness, { localize: ['fr'] });
+        },
       });
 
-      it('watches i18n translation files by default', async () => {
-        harness.useTarget('serve', {
-          ...BASE_OPTIONS,
-          watch: true,
-        });
+      setupTarget(harness, { localize: ['fr'] });
+    });
 
-        await harness.writeFile(
-          'src/app/app.component.html',
-          `
+    it('watches i18n translation files by default', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+        watch: true,
+      });
+
+      await harness.writeFile(
+        'src/app/app.component.html',
+        `
           <p id="hello" i18n="An introduction header for this sample">Hello {{ title }}! </p>
         `,
-        );
+      );
 
-        await harness.writeFile('src/locales/messages.fr.xlf', TRANSLATION_FILE_CONTENT);
+      await harness.writeFile('src/locales/messages.fr.xlf', TRANSLATION_FILE_CONTENT);
 
-        await harness.executeWithCases([
-          async ({ result }) => {
-            expect(result?.success).toBe(true);
+      await harness.executeWithCases([
+        async ({ result }) => {
+          expect(result?.success).toBe(true);
 
-            const mainUrl = new URL('main.js', `${result?.baseUrl}`);
-            const response = await fetch(mainUrl);
-            expect(await response?.text()).toContain('Bonjour');
+          const mainUrl = new URL('main.js', `${result?.baseUrl}`);
+          const response = await fetch(mainUrl);
+          expect(await response?.text()).toContain('Bonjour');
 
-            await harness.modifyFile('src/locales/messages.fr.xlf', (content) =>
-              content.replace('Bonjour', 'Salut'),
-            );
-          },
-          async ({ result }) => {
-            expect(result?.success).toBe(true);
+          await harness.modifyFile('src/locales/messages.fr.xlf', (content) =>
+            content.replace('Bonjour', 'Salut'),
+          );
+        },
+        async ({ result }) => {
+          expect(result?.success).toBe(true);
 
-            const mainUrl = new URL('main.js', `${result?.baseUrl}`);
-            const response = await fetch(mainUrl);
-            expect(await response?.text()).toContain('Salut');
-          },
-        ]);
-      });
+          const mainUrl = new URL('main.js', `${result?.baseUrl}`);
+          const response = await fetch(mainUrl);
+          expect(await response?.text()).toContain('Salut');
+        },
+      ]);
     });
-  },
-);
+  });
+});
 
 const TRANSLATION_FILE_CONTENT = `
   <?xml version="1.0" encoding="UTF-8" ?>

--- a/packages/angular/build/src/builders/dev-server/tests/behavior/serve_service-worker_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/behavior/serve_service-worker_spec.ts
@@ -36,180 +36,174 @@ const manifest = {
   ],
 };
 
-describeServeBuilder(
-  executeDevServer,
-  DEV_SERVER_BUILDER_INFO,
-  (harness, setupTarget, isViteRun) => {
-    describe('Behavior: "dev-server builder serves service worker"', () => {
-      beforeEach(async () => {
-        // Application code is not needed for these tests
-        await harness.writeFile('src/main.ts', '');
-        await harness.writeFile('src/polyfills.ts', '');
+describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupTarget) => {
+  describe('Behavior: "dev-server builder serves service worker"', () => {
+    beforeEach(async () => {
+      // Application code is not needed for these tests
+      await harness.writeFile('src/main.ts', '');
+      await harness.writeFile('src/polyfills.ts', '');
 
-        harness.useProject('test', {
-          root: '.',
-          sourceRoot: 'src',
-          cli: {
-            cache: {
-              enabled: false,
-            },
+      harness.useProject('test', {
+        root: '.',
+        sourceRoot: 'src',
+        cli: {
+          cache: {
+            enabled: false,
           },
-          i18n: {
-            sourceLocale: {
-              code: 'fr',
-            },
+        },
+        i18n: {
+          sourceLocale: {
+            code: 'fr',
           },
-        });
-      });
-
-      it('works with service worker', async () => {
-        setupTarget(harness, {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          serviceWorker: (isViteRun ? 'ngsw-config.json' : true) as any,
-          assets: ['src/favicon.ico', 'src/assets'],
-          styles: ['src/styles.css'],
-        });
-
-        await harness.writeFiles({
-          'ngsw-config.json': JSON.stringify(manifest),
-          'src/assets/folder-asset.txt': 'folder-asset.txt',
-          'src/styles.css': `body { background: url(./spectrum.png); }`,
-        });
-
-        harness.useTarget('serve', {
-          ...BASE_OPTIONS,
-        });
-
-        const { result, response } = await executeOnceAndFetch(harness, '/ngsw.json');
-
-        expect(result?.success).toBeTrue();
-
-        expect(await response?.json()).toEqual(
-          jasmine.objectContaining({
-            configVersion: 1,
-            index: '/index.html',
-            navigationUrls: [
-              { positive: true, regex: '^\\/.*$' },
-              { positive: false, regex: '^\\/(?:.+\\/)?[^/]*\\.[^/]*$' },
-              { positive: false, regex: '^\\/(?:.+\\/)?[^/]*__[^/]*$' },
-              { positive: false, regex: '^\\/(?:.+\\/)?[^/]*__[^/]*\\/.*$' },
-            ],
-            assetGroups: [
-              {
-                name: 'app',
-                installMode: 'prefetch',
-                updateMode: 'prefetch',
-                urls: ['/favicon.ico', '/index.html'],
-                cacheQueryOptions: {
-                  ignoreVary: true,
-                },
-                patterns: [],
-              },
-              {
-                name: 'assets',
-                installMode: 'lazy',
-                updateMode: 'prefetch',
-                urls: ['/assets/folder-asset.txt', '/media/spectrum.png'],
-                cacheQueryOptions: {
-                  ignoreVary: true,
-                },
-                patterns: [],
-              },
-            ],
-            dataGroups: [],
-            hashTable: {
-              '/favicon.ico': '84161b857f5c547e3699ddfbffc6d8d737542e01',
-              '/assets/folder-asset.txt': '617f202968a6a81050aa617c2e28e1dca11ce8d4',
-              '/index.html': isViteRun
-                ? 'e5b73e6798d2782bf59dd5272d254d5bde364695'
-                : '9d232e3e13b4605d197037224a2a6303dd337480',
-              '/media/spectrum.png': '8d048ece46c0f3af4b598a95fd8e4709b631c3c0',
-            },
-          }),
-        );
-      });
-
-      it('works with localize', async () => {
-        setupTarget(harness, {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          serviceWorker: (isViteRun ? 'ngsw-config.json' : true) as any,
-          assets: ['src/favicon.ico', 'src/assets'],
-          styles: ['src/styles.css'],
-          localize: ['fr'],
-        });
-
-        await harness.writeFiles({
-          'ngsw-config.json': JSON.stringify(manifest),
-          'src/assets/folder-asset.txt': 'folder-asset.txt',
-          'src/styles.css': `body { background: url(./spectrum.png); }`,
-        });
-
-        harness.useTarget('serve', {
-          ...BASE_OPTIONS,
-        });
-
-        const { result, response } = await executeOnceAndFetch(harness, '/ngsw.json');
-
-        expect(result?.success).toBeTrue();
-
-        expect(await response?.json()).toBeDefined();
-      });
-
-      // TODO(fix-vite): currently this is broken in vite due to watcher never terminates.
-      (isViteRun ? xit : it)('works in watch mode', async () => {
-        setupTarget(harness, {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          serviceWorker: (isViteRun ? 'ngsw-config.json' : true) as any,
-          assets: ['src/favicon.ico', 'src/assets'],
-          styles: ['src/styles.css'],
-        });
-
-        await harness.writeFiles({
-          'ngsw-config.json': JSON.stringify(manifest),
-          'src/assets/folder-asset.txt': 'folder-asset.txt',
-          'src/styles.css': `body { background: url(./spectrum.png); }`,
-        });
-
-        harness.useTarget('serve', {
-          ...BASE_OPTIONS,
-          watch: true,
-        });
-
-        await harness.executeWithCases([
-          async ({ result }) => {
-            expect(result?.success).toBeTrue();
-            const response = await fetch(new URL('ngsw.json', `${result?.baseUrl}`));
-            const { hashTable } = (await response.json()) as { hashTable: object };
-            const hashTableEntries = Object.keys(hashTable);
-
-            expect(hashTableEntries).toEqual([
-              '/assets/folder-asset.txt',
-              '/favicon.ico',
-              '/index.html',
-              '/media/spectrum.png',
-            ]);
-
-            await harness.writeFile(
-              'src/assets/folder-new-asset.txt',
-              harness.readFile('src/assets/folder-asset.txt'),
-            );
-          },
-          async ({ result }) => {
-            expect(result?.success).toBeTrue();
-            const response = await fetch(new URL('ngsw.json', `${result?.baseUrl}`));
-            const { hashTable } = (await response.json()) as { hashTable: object };
-            const hashTableEntries = Object.keys(hashTable);
-
-            expect(hashTableEntries).toEqual([
-              '/assets/folder-asset.txt',
-              '/assets/folder-new-asset.txt',
-              '/favicon.ico',
-              '/index.html',
-              '/media/spectrum.png',
-            ]);
-          },
-        ]);
+        },
       });
     });
-  },
-);
+
+    it('works with service worker', async () => {
+      setupTarget(harness, {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        serviceWorker: 'ngsw-config.json',
+        assets: ['src/favicon.ico', 'src/assets'],
+        styles: ['src/styles.css'],
+      });
+
+      await harness.writeFiles({
+        'ngsw-config.json': JSON.stringify(manifest),
+        'src/assets/folder-asset.txt': 'folder-asset.txt',
+        'src/styles.css': `body { background: url(./spectrum.png); }`,
+      });
+
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result, response } = await executeOnceAndFetch(harness, '/ngsw.json');
+
+      expect(result?.success).toBeTrue();
+
+      expect(await response?.json()).toEqual(
+        jasmine.objectContaining({
+          configVersion: 1,
+          index: '/index.html',
+          navigationUrls: [
+            { positive: true, regex: '^\\/.*$' },
+            { positive: false, regex: '^\\/(?:.+\\/)?[^/]*\\.[^/]*$' },
+            { positive: false, regex: '^\\/(?:.+\\/)?[^/]*__[^/]*$' },
+            { positive: false, regex: '^\\/(?:.+\\/)?[^/]*__[^/]*\\/.*$' },
+          ],
+          assetGroups: [
+            {
+              name: 'app',
+              installMode: 'prefetch',
+              updateMode: 'prefetch',
+              urls: ['/favicon.ico', '/index.html'],
+              cacheQueryOptions: {
+                ignoreVary: true,
+              },
+              patterns: [],
+            },
+            {
+              name: 'assets',
+              installMode: 'lazy',
+              updateMode: 'prefetch',
+              urls: ['/assets/folder-asset.txt', '/media/spectrum.png'],
+              cacheQueryOptions: {
+                ignoreVary: true,
+              },
+              patterns: [],
+            },
+          ],
+          dataGroups: [],
+          hashTable: {
+            '/favicon.ico': '84161b857f5c547e3699ddfbffc6d8d737542e01',
+            '/assets/folder-asset.txt': '617f202968a6a81050aa617c2e28e1dca11ce8d4',
+            '/index.html': 'e5b73e6798d2782bf59dd5272d254d5bde364695',
+            '/media/spectrum.png': '8d048ece46c0f3af4b598a95fd8e4709b631c3c0',
+          },
+        }),
+      );
+    });
+
+    it('works with localize', async () => {
+      setupTarget(harness, {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        serviceWorker: 'ngsw-config.json' as any,
+        assets: ['src/favicon.ico', 'src/assets'],
+        styles: ['src/styles.css'],
+        localize: ['fr'],
+      });
+
+      await harness.writeFiles({
+        'ngsw-config.json': JSON.stringify(manifest),
+        'src/assets/folder-asset.txt': 'folder-asset.txt',
+        'src/styles.css': `body { background: url(./spectrum.png); }`,
+      });
+
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result, response } = await executeOnceAndFetch(harness, '/ngsw.json');
+
+      expect(result?.success).toBeTrue();
+
+      expect(await response?.json()).toBeDefined();
+    });
+
+    // TODO(fix-vite): currently this is broken in vite due to watcher never terminates.
+    xit('works in watch mode', async () => {
+      setupTarget(harness, {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        serviceWorker: 'ngsw-config.json' as any,
+        assets: ['src/favicon.ico', 'src/assets'],
+        styles: ['src/styles.css'],
+      });
+
+      await harness.writeFiles({
+        'ngsw-config.json': JSON.stringify(manifest),
+        'src/assets/folder-asset.txt': 'folder-asset.txt',
+        'src/styles.css': `body { background: url(./spectrum.png); }`,
+      });
+
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+        watch: true,
+      });
+
+      await harness.executeWithCases([
+        async ({ result }) => {
+          expect(result?.success).toBeTrue();
+          const response = await fetch(new URL('ngsw.json', `${result?.baseUrl}`));
+          const { hashTable } = (await response.json()) as { hashTable: object };
+          const hashTableEntries = Object.keys(hashTable);
+
+          expect(hashTableEntries).toEqual([
+            '/assets/folder-asset.txt',
+            '/favicon.ico',
+            '/index.html',
+            '/media/spectrum.png',
+          ]);
+
+          await harness.writeFile(
+            'src/assets/folder-new-asset.txt',
+            harness.readFile('src/assets/folder-asset.txt'),
+          );
+        },
+        async ({ result }) => {
+          expect(result?.success).toBeTrue();
+          const response = await fetch(new URL('ngsw.json', `${result?.baseUrl}`));
+          const { hashTable } = (await response.json()) as { hashTable: object };
+          const hashTableEntries = Object.keys(hashTable);
+
+          expect(hashTableEntries).toEqual([
+            '/assets/folder-asset.txt',
+            '/assets/folder-new-asset.txt',
+            '/favicon.ico',
+            '/index.html',
+            '/media/spectrum.png',
+          ]);
+        },
+      ]);
+    });
+  });
+});

--- a/packages/angular/build/src/builders/dev-server/tests/jasmine-helpers.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/jasmine-helpers.ts
@@ -20,7 +20,6 @@ export function describeServeBuilder<T>(
   specDefinitions: (
     harness: JasmineBuilderHarness<T>,
     setupTarget: typeof setupApplicationTarget,
-    isViteRun: true,
   ) => void,
 ): void {
   let optionSchema = optionSchemaCache.get(options.schemaPath);
@@ -38,6 +37,6 @@ export function describeServeBuilder<T>(
     beforeEach(() => host.initialize().toPromise());
     afterEach(() => host.restore().toPromise());
 
-    specDefinitions(harness, setupApplicationTarget, true);
+    specDefinitions(harness, setupApplicationTarget);
   });
 }

--- a/packages/angular/build/src/builders/dev-server/tests/options/port_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/options/port_spec.ts
@@ -26,87 +26,58 @@ function getResultPort(result: Record<string, unknown> | undefined): string | un
   }
 }
 
-describeServeBuilder(
-  executeDevServer,
-  DEV_SERVER_BUILDER_INFO,
-  (harness, setupTarget, isViteRun) => {
-    describe('option: "port"', () => {
-      beforeEach(async () => {
-        setupTarget(harness);
+describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupTarget) => {
+  describe('option: "port"', () => {
+    beforeEach(async () => {
+      setupTarget(harness);
 
-        // Application code is not needed for these tests
-        await harness.writeFile('src/main.ts', '');
-      });
-
-      it('uses default port (4200) when not present', async () => {
-        harness.useTarget('serve', {
-          ...BASE_OPTIONS,
-          // Base options set port to zero
-          port: undefined,
-        });
-
-        const { result, response, logs } = await executeOnceAndFetch(harness, '/');
-
-        expect(result?.success).toBeTrue();
-        expect(getResultPort(result)).toBe('4200');
-        expect(await response?.text()).toContain('<title>');
-
-        if (!isViteRun) {
-          expect(logs).toContain(
-            jasmine.objectContaining({
-              message: jasmine.stringMatching(/:4200/),
-            }),
-          );
-        }
-      });
-
-      it('uses a random free port when set to 0 (zero)', async () => {
-        harness.useTarget('serve', {
-          ...BASE_OPTIONS,
-          port: 0,
-        });
-
-        const { result, response, logs } = await executeOnceAndFetch(harness, '/');
-
-        expect(result?.success).toBeTrue();
-        const port = getResultPort(result);
-        expect(port).not.toBe('4200');
-        if (isViteRun) {
-          // Should not be default Vite port either
-          expect(port).not.toBe('5173');
-        }
-
-        expect(port).toMatch(/\d{4,6}/);
-        expect(await response?.text()).toContain('<title>');
-
-        if (!isViteRun) {
-          expect(logs).toContain(
-            jasmine.objectContaining({
-              message: jasmine.stringMatching(':' + port),
-            }),
-          );
-        }
-      });
-
-      it('uses specific port when a non-zero number is specified', async () => {
-        harness.useTarget('serve', {
-          ...BASE_OPTIONS,
-          port: 8000,
-        });
-
-        const { result, response, logs } = await executeOnceAndFetch(harness, '/');
-
-        expect(result?.success).toBeTrue();
-        expect(getResultPort(result)).toBe('8000');
-        expect(await response?.text()).toContain('<title>');
-        if (!isViteRun) {
-          expect(logs).toContain(
-            jasmine.objectContaining({
-              message: jasmine.stringMatching(':8000'),
-            }),
-          );
-        }
-      });
+      // Application code is not needed for these tests
+      await harness.writeFile('src/main.ts', '');
     });
-  },
-);
+
+    it('uses default port (4200) when not present', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+        // Base options set port to zero
+        port: undefined,
+      });
+
+      const { result, response, logs } = await executeOnceAndFetch(harness, '/');
+
+      expect(result?.success).toBeTrue();
+      expect(getResultPort(result)).toBe('4200');
+      expect(await response?.text()).toContain('<title>');
+    });
+
+    it('uses a random free port when set to 0 (zero)', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+        port: 0,
+      });
+
+      const { result, response, logs } = await executeOnceAndFetch(harness, '/');
+
+      expect(result?.success).toBeTrue();
+      const port = getResultPort(result);
+      expect(port).not.toBe('4200');
+      // Should not be default Vite port either
+      expect(port).not.toBe('5173');
+
+      expect(port).toMatch(/\d{4,6}/);
+      expect(await response?.text()).toContain('<title>');
+    });
+
+    it('uses specific port when a non-zero number is specified', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+        port: 8000,
+      });
+
+      const { result, response, logs } = await executeOnceAndFetch(harness, '/');
+
+      expect(result?.success).toBeTrue();
+      expect(getResultPort(result)).toBe('8000');
+      expect(await response?.text()).toContain('<title>');
+    });
+  });
+});

--- a/packages/angular/build/src/builders/dev-server/tests/options/prebundle_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/options/prebundle_spec.ts
@@ -12,88 +12,84 @@ import { describeServeBuilder } from '../jasmine-helpers';
 import { BASE_OPTIONS, DEV_SERVER_BUILDER_INFO } from '../setup';
 
 // TODO: Temporarily disabled pending investigation into test-only Vite not stopping when caching is enabled
-describeServeBuilder(
-  executeDevServer,
-  DEV_SERVER_BUILDER_INFO,
-  (harness, setupTarget, isViteRun) => {
-    // prebundling is not available in webpack
-    (isViteRun ? xdescribe : xdescribe)('option: "prebundle"', () => {
-      beforeEach(async () => {
-        setupTarget(harness);
+describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupTarget) => {
+  // prebundling is not available in webpack
+  xdescribe('option: "prebundle"', () => {
+    beforeEach(async () => {
+      setupTarget(harness);
 
-        harness.useProject('test', {
-          cli: {
-            cache: {
-              enabled: true,
-            },
+      harness.useProject('test', {
+        cli: {
+          cache: {
+            enabled: true,
           },
-        });
+        },
+      });
 
-        // Application code is not needed for these tests
-        await harness.writeFile(
-          'src/main.ts',
-          `
+      // Application code is not needed for these tests
+      await harness.writeFile(
+        'src/main.ts',
+        `
           import { VERSION as coreVersion } from '@angular/core';
           import { VERSION as platformVersion } from '@angular/platform-browser';
 
           console.log(coreVersion);
           console.log(platformVersion);
         `,
-        );
-      });
-
-      it('should prebundle dependencies when option is not present', async () => {
-        harness.useTarget('serve', {
-          ...BASE_OPTIONS,
-        });
-
-        const { result, content } = await executeOnceAndFetch(harness, '/main.js');
-
-        expect(result?.success).toBeTrue();
-        expect(content).toContain('vite/deps/@angular_core.js');
-        expect(content).not.toContain('node_modules/@angular/core/');
-      });
-
-      it('should prebundle dependencies when option is set to true', async () => {
-        harness.useTarget('serve', {
-          ...BASE_OPTIONS,
-          prebundle: true,
-        });
-
-        const { result, content } = await executeOnceAndFetch(harness, '/main.js');
-
-        expect(result?.success).toBeTrue();
-        expect(content).toContain('vite/deps/@angular_core.js');
-        expect(content).not.toContain('node_modules/@angular/core/');
-      });
-
-      it('should not prebundle dependencies when option is set to false', async () => {
-        harness.useTarget('serve', {
-          ...BASE_OPTIONS,
-          prebundle: false,
-        });
-
-        const { result, content } = await executeOnceAndFetch(harness, '/main.js');
-
-        expect(result?.success).toBeTrue();
-        expect(content).not.toContain('vite/deps/@angular_core.js');
-        expect(content).toContain('node_modules/@angular/core/');
-      });
-
-      it('should not prebundle specified dependency if added to exclude list', async () => {
-        harness.useTarget('serve', {
-          ...BASE_OPTIONS,
-          prebundle: { exclude: ['@angular/platform-browser'] },
-        });
-
-        const { result, content } = await executeOnceAndFetch(harness, '/main.js');
-
-        expect(result?.success).toBeTrue();
-        expect(content).toContain('vite/deps/@angular_core.js');
-        expect(content).not.toContain('node_modules/@angular/core/');
-        expect(content).not.toContain('vite/deps/@angular_platform-browser.js');
-        expect(content).toContain('node_modules/@angular/platform-browser/');
-      });
+      );
     });
-  },
-);
+
+    it('should prebundle dependencies when option is not present', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result, content } = await executeOnceAndFetch(harness, '/main.js');
+
+      expect(result?.success).toBeTrue();
+      expect(content).toContain('vite/deps/@angular_core.js');
+      expect(content).not.toContain('node_modules/@angular/core/');
+    });
+
+    it('should prebundle dependencies when option is set to true', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+        prebundle: true,
+      });
+
+      const { result, content } = await executeOnceAndFetch(harness, '/main.js');
+
+      expect(result?.success).toBeTrue();
+      expect(content).toContain('vite/deps/@angular_core.js');
+      expect(content).not.toContain('node_modules/@angular/core/');
+    });
+
+    it('should not prebundle dependencies when option is set to false', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+        prebundle: false,
+      });
+
+      const { result, content } = await executeOnceAndFetch(harness, '/main.js');
+
+      expect(result?.success).toBeTrue();
+      expect(content).not.toContain('vite/deps/@angular_core.js');
+      expect(content).toContain('node_modules/@angular/core/');
+    });
+
+    it('should not prebundle specified dependency if added to exclude list', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+        prebundle: { exclude: ['@angular/platform-browser'] },
+      });
+
+      const { result, content } = await executeOnceAndFetch(harness, '/main.js');
+
+      expect(result?.success).toBeTrue();
+      expect(content).toContain('vite/deps/@angular_core.js');
+      expect(content).not.toContain('node_modules/@angular/core/');
+      expect(content).not.toContain('vite/deps/@angular_platform-browser.js');
+      expect(content).toContain('node_modules/@angular/platform-browser/');
+    });
+  });
+});

--- a/packages/angular/build/src/builders/dev-server/tests/options/serve-path_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/options/serve-path_spec.ts
@@ -12,109 +12,105 @@ import { executeOnceAndFetch } from '../execute-fetch';
 import { describeServeBuilder } from '../jasmine-helpers';
 import { BASE_OPTIONS, DEV_SERVER_BUILDER_INFO } from '../setup';
 
-describeServeBuilder(
-  executeDevServer,
-  DEV_SERVER_BUILDER_INFO,
-  (harness, setupTarget, isViteRun) => {
-    describe('option: "servePath"', () => {
-      beforeEach(async () => {
-        setupTarget(harness, {
-          assets: ['src/assets'],
-        });
-
-        // Application code is not needed for these tests
-        await harness.writeFile('src/main.ts', 'console.log("foo");');
+describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupTarget) => {
+  describe('option: "servePath"', () => {
+    beforeEach(async () => {
+      setupTarget(harness, {
+        assets: ['src/assets'],
       });
 
-      it('serves application at the root when option is not present', async () => {
-        harness.useTarget('serve', {
-          ...BASE_OPTIONS,
-        });
-
-        const { result, response } = await executeOnceAndFetch(harness, '/main.js');
-
-        expect(result?.success).toBeTrue();
-        const baseUrl = new URL(`${result?.baseUrl}`);
-        expect(baseUrl.pathname).toBe('/');
-        expect(await response?.text()).toContain('console.log');
-      });
-
-      it('serves application at specified path when option is used', async () => {
-        harness.useTarget('serve', {
-          ...BASE_OPTIONS,
-          servePath: 'test',
-        });
-
-        const { result, response } = await executeOnceAndFetch(harness, '/test/main.js');
-
-        expect(result?.success).toBeTrue();
-        const baseUrl = new URL(`${result?.baseUrl}/`);
-        expect(baseUrl.pathname).toBe('/test/');
-        expect(await response?.text()).toContain('console.log');
-      });
-
-      // TODO(fix-vite): currently this is broken in vite.
-      (isViteRun ? xit : it)('does not rewrite from root when option is used', async () => {
-        harness.useTarget('serve', {
-          ...BASE_OPTIONS,
-          servePath: 'test',
-        });
-
-        const { result, response } = await executeOnceAndFetch(harness, '/', {
-          // fallback processing requires an accept header
-          request: { headers: { accept: 'text/html' } },
-        });
-
-        expect(result?.success).toBeTrue();
-        expect(response?.status).toBe(404);
-      });
-
-      it('does not rewrite from path outside serve path when option is used', async () => {
-        harness.useTarget('serve', {
-          ...BASE_OPTIONS,
-          servePath: 'test',
-        });
-
-        const { result, response } = await executeOnceAndFetch(harness, '/api/', {
-          // fallback processing requires an accept header
-          request: { headers: { accept: 'text/html' } },
-        });
-
-        expect(result?.success).toBeTrue();
-        expect(response?.status).toBe(404);
-      });
-
-      it('rewrites from path inside serve path when option is used', async () => {
-        harness.useTarget('serve', {
-          ...BASE_OPTIONS,
-          servePath: 'test',
-        });
-
-        const { result, response } = await executeOnceAndFetch(harness, '/test/inside', {
-          // fallback processing requires an accept header
-          request: { headers: { accept: 'text/html' } },
-        });
-
-        expect(result?.success).toBeTrue();
-        expect(await response?.text()).toContain('<title>');
-      });
-
-      it('serves assets at specified path when option is used', async () => {
-        await harness.writeFile('src/assets/test.txt', 'hello world!');
-
-        harness.useTarget('serve', {
-          ...BASE_OPTIONS,
-          servePath: 'test',
-        });
-
-        const { result, response } = await executeOnceAndFetch(harness, '/test/assets/test.txt', {
-          // fallback processing requires an accept header
-          request: { headers: { accept: 'text/html' } },
-        });
-
-        expect(result?.success).toBeTrue();
-        expect(await response?.text()).toContain('hello world');
-      });
+      // Application code is not needed for these tests
+      await harness.writeFile('src/main.ts', 'console.log("foo");');
     });
-  },
-);
+
+    it('serves application at the root when option is not present', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result, response } = await executeOnceAndFetch(harness, '/main.js');
+
+      expect(result?.success).toBeTrue();
+      const baseUrl = new URL(`${result?.baseUrl}`);
+      expect(baseUrl.pathname).toBe('/');
+      expect(await response?.text()).toContain('console.log');
+    });
+
+    it('serves application at specified path when option is used', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+        servePath: 'test',
+      });
+
+      const { result, response } = await executeOnceAndFetch(harness, '/test/main.js');
+
+      expect(result?.success).toBeTrue();
+      const baseUrl = new URL(`${result?.baseUrl}/`);
+      expect(baseUrl.pathname).toBe('/test/');
+      expect(await response?.text()).toContain('console.log');
+    });
+
+    // TODO(fix-vite): currently this is broken in vite.
+    xit('does not rewrite from root when option is used', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+        servePath: 'test',
+      });
+
+      const { result, response } = await executeOnceAndFetch(harness, '/', {
+        // fallback processing requires an accept header
+        request: { headers: { accept: 'text/html' } },
+      });
+
+      expect(result?.success).toBeTrue();
+      expect(response?.status).toBe(404);
+    });
+
+    it('does not rewrite from path outside serve path when option is used', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+        servePath: 'test',
+      });
+
+      const { result, response } = await executeOnceAndFetch(harness, '/api/', {
+        // fallback processing requires an accept header
+        request: { headers: { accept: 'text/html' } },
+      });
+
+      expect(result?.success).toBeTrue();
+      expect(response?.status).toBe(404);
+    });
+
+    it('rewrites from path inside serve path when option is used', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+        servePath: 'test',
+      });
+
+      const { result, response } = await executeOnceAndFetch(harness, '/test/inside', {
+        // fallback processing requires an accept header
+        request: { headers: { accept: 'text/html' } },
+      });
+
+      expect(result?.success).toBeTrue();
+      expect(await response?.text()).toContain('<title>');
+    });
+
+    it('serves assets at specified path when option is used', async () => {
+      await harness.writeFile('src/assets/test.txt', 'hello world!');
+
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+        servePath: 'test',
+      });
+
+      const { result, response } = await executeOnceAndFetch(harness, '/test/assets/test.txt', {
+        // fallback processing requires an accept header
+        request: { headers: { accept: 'text/html' } },
+      });
+
+      expect(result?.success).toBeTrue();
+      expect(await response?.text()).toContain('hello world');
+    });
+  });
+});


### PR DESCRIPTION
Removes the `isViteRun` parameter from the `describeServeBuilder` helper and updates usage in test files.

This change simplifies the tests by assuming the modern application builder behavior, removing conditional logic for legacy builders.
