### PR TITLE
fix(@angular/cli): disable npm update notifier in package manager host

### DIFF
--- a/packages/angular/cli/src/package-managers/host.ts
+++ b/packages/angular/cli/src/package-managers/host.ts
@@ -137,6 +137,9 @@ export const NodeJS_HOST: Host = {
         env: {
           ...process.env,
           ...options.env,
+          //  NPM updater notifier will prevents the child process from closing until it timeout after 3 minutes.
+          NO_UPDATE_NOTIFIER: '1',
+          NPM_CONFIG_UPDATE_NOTIFIER: 'false',
         },
       } satisfies SpawnOptions;
       const childProcess = isWin32


### PR DESCRIPTION
The NPM update notifier can prevent child processes from closing promptly, causing them to hang until a timeout occurs (up to 3 minutes). This change disables the update notifier by setting the `NO_UPDATE_NOTIFIER` and `NPM_CONFIG_UPDATE_NOTIFIER` environment variables when spawning package manager processes.
