### PR TITLE
refactor: remove `tree-kill` dependency by using native `child_process.kill` and correcting `spawn` usage

### DIFF
--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -154,7 +154,6 @@ ts_project(
         ":node_modules/source-map-support",
         ":node_modules/terser",
         ":node_modules/tinyglobby",
-        ":node_modules/tree-kill",
         ":node_modules/webpack",
         ":node_modules/webpack-dev-middleware",
         ":node_modules/webpack-dev-server",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -53,7 +53,6 @@
     "source-map-support": "0.5.21",
     "terser": "5.46.0",
     "tinyglobby": "0.2.15",
-    "tree-kill": "1.2.2",
     "tslib": "2.8.1",
     "webpack": "5.105.2",
     "webpack-dev-middleware": "7.4.5",

--- a/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/utils.ts
+++ b/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/utils.ts
@@ -9,7 +9,6 @@
 import { SpawnOptions, spawn } from 'node:child_process';
 import { AddressInfo, createConnection, createServer } from 'node:net';
 import { Observable, mergeMap, retryWhen, throwError, timer } from 'rxjs';
-import treeKill from 'tree-kill';
 
 export function getAvailablePort(): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -50,8 +49,8 @@ export function spawnAsObservable(
       });
 
     return () => {
-      if (!proc.killed && proc.pid) {
-        treeKill(proc.pid, 'SIGTERM');
+      if (!proc.killed) {
+        proc.kill();
       }
     };
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -694,9 +694,6 @@ importers:
       tinyglobby:
         specifier: 0.2.15
         version: 0.2.15
-      tree-kill:
-        specifier: 1.2.2
-        version: 1.2.2
       tslib:
         specifier: 2.8.1
         version: 2.8.1


### PR DESCRIPTION

This is no longer required.