### PR TITLE
feat(@angular/build): Support splitting browser and server stats jsonfiles for easier consumption

### DIFF
--- a/packages/angular/build/src/builders/application/execute-build.ts
+++ b/packages/angular/build/src/builders/application/execute-build.ts
@@ -308,13 +308,31 @@ export async function executeBuild(
   if (options.stats) {
     executionResult.addOutputFile(
       'browser-stats.json',
-      JSON.stringify(buildMetafileForType(metafile, 'browser', outputFiles), null, 2),
+      JSON.stringify(buildMetafileForType(metafile, 'browser', false, outputFiles), null, 2),
+      BuildOutputFileType.Root,
+    );
+    executionResult.addOutputFile(
+      'browser-initial-stats.json',
+      JSON.stringify(
+        buildMetafileForType(metafile, 'browser', true, outputFiles, initialFiles),
+        null,
+        2,
+      ),
       BuildOutputFileType.Root,
     );
     if (ssrOutputEnabled) {
       executionResult.addOutputFile(
         'server-stats.json',
-        JSON.stringify(buildMetafileForType(metafile, 'server', outputFiles), null, 2),
+        JSON.stringify(buildMetafileForType(metafile, 'server', false, outputFiles), null, 2),
+        BuildOutputFileType.Root,
+      );
+      executionResult.addOutputFile(
+        'server-initial-stats.json',
+        JSON.stringify(
+          buildMetafileForType(metafile, 'server', true, outputFiles, initialFiles),
+          null,
+          2,
+        ),
         BuildOutputFileType.Root,
       );
     }

--- a/packages/angular/build/src/builders/application/execute-build.ts
+++ b/packages/angular/build/src/builders/application/execute-build.ts
@@ -20,6 +20,7 @@ import { checkCommonJSModules } from '../../tools/esbuild/commonjs-checker';
 import { extractLicenses } from '../../tools/esbuild/license-extractor';
 import { profileAsync } from '../../tools/esbuild/profiling';
 import {
+  buildMetafileForType,
   calculateEstimatedTransferSizes,
   logBuildStats,
   transformSupportedBrowsersToTargets,
@@ -301,13 +302,22 @@ export async function executeBuild(
     BuildOutputFileType.Root,
   );
 
+  const ssrOutputEnabled: boolean = !!ssrOptions;
+
   // Write metafile if stats option is enabled
   if (options.stats) {
     executionResult.addOutputFile(
-      'stats.json',
-      JSON.stringify(metafile, null, 2),
+      'browser-stats.json',
+      JSON.stringify(buildMetafileForType(metafile, 'browser', outputFiles), null, 2),
       BuildOutputFileType.Root,
     );
+    if (ssrOutputEnabled) {
+      executionResult.addOutputFile(
+        'server-stats.json',
+        JSON.stringify(buildMetafileForType(metafile, 'server', outputFiles), null, 2),
+        BuildOutputFileType.Root,
+      );
+    }
   }
 
   if (!jsonLogs) {
@@ -322,7 +332,7 @@ export async function executeBuild(
         colors,
         changedFiles,
         estimatedTransferSizes,
-        !!ssrOptions,
+        ssrOutputEnabled,
         verbose,
       ),
     );

--- a/packages/angular/build/src/builders/application/schema.json
+++ b/packages/angular/build/src/builders/application/schema.json
@@ -535,7 +535,7 @@
     },
     "statsJson": {
       "type": "boolean",
-      "description": "Generates a 'stats.json' file which can be analyzed with https://esbuild.github.io/analyze/.",
+      "description": "Generates a 'browser-stats.json' (and 'server-stats.json' when SSR is enabled) file which can be analyzed with https://esbuild.github.io/analyze/.",
       "default": false
     },
     "budgets": {

--- a/packages/angular/build/src/tools/esbuild/utils.ts
+++ b/packages/angular/build/src/tools/esbuild/utils.ts
@@ -29,6 +29,50 @@ import {
   PrerenderedRoutesRecord,
 } from './bundler-execution-result';
 
+export function buildMetafileForType(
+  metafile: Metafile,
+  type: 'browser' | 'server',
+  outputFiles: BuildOutputFile[],
+): Metafile {
+  const outputPathsForType = new Set(
+    outputFiles
+      .filter(({ type: fileType }) => {
+        const isServerFile =
+          fileType === BuildOutputFileType.ServerApplication ||
+          fileType === BuildOutputFileType.ServerRoot;
+
+        return type === 'server' ? isServerFile : !isServerFile;
+      })
+      .map(({ path }) => path),
+  );
+
+  const filteredOutputs: Metafile['outputs'] = {};
+  for (const [outputPath, output] of Object.entries(metafile.outputs)) {
+    if (outputPathsForType.has(outputPath)) {
+      filteredOutputs[outputPath] = output;
+    }
+  }
+
+  const referencedInputs = new Set<string>();
+  for (const output of Object.values(filteredOutputs)) {
+    for (const inputPath of Object.keys(output.inputs)) {
+      referencedInputs.add(inputPath);
+    }
+  }
+
+  const filteredInputs: Metafile['inputs'] = {};
+  for (const [inputPath, input] of Object.entries(metafile.inputs)) {
+    if (referencedInputs.has(inputPath)) {
+      filteredInputs[inputPath] = input;
+    }
+  }
+
+  return {
+    inputs: filteredInputs,
+    outputs: filteredOutputs,
+  };
+}
+
 export function logBuildStats(
   metafile: Metafile,
   outputFiles: BuildOutputFile[],

--- a/packages/angular/build/src/tools/esbuild/utils.ts
+++ b/packages/angular/build/src/tools/esbuild/utils.ts
@@ -32,8 +32,12 @@ import {
 export function buildMetafileForType(
   metafile: Metafile,
   type: 'browser' | 'server',
+  initial: boolean,
   outputFiles: BuildOutputFile[],
+  initialFiles?: Map<string, InitialFileRecord>,
 ): Metafile {
+  const isServer = type === 'server';
+
   const outputPathsForType = new Set(
     outputFiles
       .filter(({ type: fileType }) => {
@@ -41,16 +45,20 @@ export function buildMetafileForType(
           fileType === BuildOutputFileType.ServerApplication ||
           fileType === BuildOutputFileType.ServerRoot;
 
-        return type === 'server' ? isServerFile : !isServerFile;
+        return isServer ? isServerFile : !isServerFile;
       })
       .map(({ path }) => path),
   );
 
   const filteredOutputs: Metafile['outputs'] = {};
   for (const [outputPath, output] of Object.entries(metafile.outputs)) {
-    if (outputPathsForType.has(outputPath)) {
-      filteredOutputs[outputPath] = output;
+    if (!outputPathsForType.has(outputPath)) {
+      continue;
     }
+    if (initial && !initialFiles?.has(outputPath)) {
+      continue;
+    }
+    filteredOutputs[outputPath] = output;
   }
 
   const referencedInputs = new Set<string>();

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/schema.json
@@ -406,7 +406,7 @@
     },
     "statsJson": {
       "type": "boolean",
-      "description": "Generates a 'stats.json' file which can be analyzed using tools such as 'webpack-bundle-analyzer'.",
+      "description": "Generates a 'browser-stats.json' file which can be analyzed using tools such as 'webpack-bundle-analyzer'.",
       "default": false
     },
     "budgets": {

--- a/packages/angular_devkit/build_angular/src/builders/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/browser/schema.json
@@ -394,7 +394,7 @@
     },
     "statsJson": {
       "type": "boolean",
-      "description": "Generates a 'stats.json' file which can be analyzed using tools such as 'webpack-bundle-analyzer'.",
+      "description": "Generates a 'browser-stats.json' (and 'server-stats.json' when SSR is enabled) file which can be analyzed using tools such as 'webpack-bundle-analyzer'.",
       "default": false
     },
     "budgets": {

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/stats-json_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/stats-json_spec.ts
@@ -21,13 +21,13 @@ describe('Browser Builder stats json', () => {
 
   it('works', async () => {
     const { files } = await browserBuild(architect, host, target, { statsJson: true });
-    expect('stats.json' in files).toBe(true);
+    expect('browser-stats.json' in files).toBe(true);
   });
 
   it('works with profile flag', async () => {
     const { files } = await browserBuild(architect, host, target, { statsJson: true });
-    expect('stats.json' in files).toBe(true);
-    const stats = JSON.parse(await files['stats.json']);
+    expect('browser-stats.json' in files).toBe(true);
+    const stats = JSON.parse(await files['browser-stats.json']);
     expect(stats.chunks[0].modules[0].profile.building).toBeDefined();
   });
 });

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/options/stats-json_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/options/stats-json_spec.ts
@@ -26,9 +26,15 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
 
       expect(result?.success).toBe(true);
 
-      if (harness.expectFile('dist/stats.json').toExist()) {
-        const content = harness.readFile('dist/stats.json');
+      if (harness.expectFile('dist/browser-stats.json').toExist()) {
+        const content = harness.readFile('dist/browser-stats.json');
         expect(() => JSON.parse(content))
+          .withContext('Expected Webpack Stats file to be valid JSON.')
+          .not.toThrow();
+      }
+      if (harness.expectFile('dist/browser-initial-stats.json').toExist()) {
+        const initialContent = harness.readFile('dist/browser-initial-stats.json');
+        expect(() => JSON.parse(initialContent))
           .withContext('Expected Webpack Stats file to be valid JSON.')
           .not.toThrow();
       }
@@ -45,8 +51,8 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
 
       expect(result?.success).toBe(true);
 
-      if (harness.expectFile('dist/stats.json').toExist()) {
-        const stats = JSON.parse(harness.readFile('dist/stats.json'));
+      if (harness.expectFile('dist/browser-stats.json').toExist()) {
+        const stats = JSON.parse(harness.readFile('dist/browser-stats.json'));
         expect(stats?.chunks?.[0]?.modules?.[0]?.profile?.building).toBeDefined();
       }
     });
@@ -61,7 +67,8 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
 
       expect(result?.success).toBe(true);
 
-      harness.expectFile('dist/stats.json').toNotExist();
+      harness.expectFile('dist/browser-stats.json').toNotExist();
+      harness.expectFile('dist/browser-initial-stats.json').toNotExist();
     });
 
     it('does not generate a Webpack Stats file in output when not present', async () => {
@@ -73,7 +80,8 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
 
       expect(result?.success).toBe(true);
 
-      harness.expectFile('dist/stats.json').toNotExist();
+      harness.expectFile('dist/browser-stats.json').toNotExist();
+      harness.expectFile('dist/browser-initial-stats.json').toNotExist();
     });
   });
 });

--- a/packages/angular_devkit/build_angular/src/builders/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/server/schema.json
@@ -208,7 +208,7 @@
     },
     "statsJson": {
       "type": "boolean",
-      "description": "Generates a 'stats.json' file which can be analyzed using tools such as 'webpack-bundle-analyzer'.",
+      "description": "Generates a 'browser-stats.json' and 'server-stats.json' file which can be analyzed using tools such as 'webpack-bundle-analyzer'.",
       "default": false
     },
     "watch": {

--- a/packages/angular_devkit/build_angular/src/tools/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/configs/common.ts
@@ -83,9 +83,8 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
   // Once TypeScript provides support for keeping the dynamic import this workaround can be
   // changed to a direct dynamic import.
   const { VERSION: NG_VERSION } = await import('@angular/compiler-cli');
-  const { GLOBAL_DEFS_FOR_TERSER, GLOBAL_DEFS_FOR_TERSER_WITH_AOT } = await import(
-    '@angular/compiler-cli/private/tooling'
-  );
+  const { GLOBAL_DEFS_FOR_TERSER, GLOBAL_DEFS_FOR_TERSER_WITH_AOT } =
+    await import('@angular/compiler-cli/private/tooling');
 
   // determine hashing format
   const hashFormat = getOutputHashFormat(buildOptions.outputHashing);
@@ -245,7 +244,7 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
 
   if (buildOptions.statsJson) {
     extraPlugins.push(
-      new JsonStatsPlugin(path.resolve(root, buildOptions.outputPath, 'stats.json')),
+      new JsonStatsPlugin(path.resolve(root, buildOptions.outputPath, 'browser-stats.json')),
     );
   }
 

--- a/packages/angular_devkit/build_angular/src/tools/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/configs/common.ts
@@ -245,6 +245,9 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
   if (buildOptions.statsJson) {
     extraPlugins.push(
       new JsonStatsPlugin(path.resolve(root, buildOptions.outputPath, 'browser-stats.json')),
+      new JsonStatsPlugin(
+        path.resolve(root, buildOptions.outputPath, 'browser-initial-stats.json'),
+      ),
     );
   }
 


### PR DESCRIPTION
This feature supports splitting out the browser and server stats json files so it's easier to inspect the bundle in various analyzers. Today, everything gets dumped into a single file and it's nearly impossible to use without hours of `fix -> remove unused browser/server chunks -> analyze` and starting the loop all over again.

This feature implements the feature request I made in #28185, along with another developers request to see a stats json file for just the initial page bundle. I've tested this out in my own repository and it's already helped an incredible amount.

Original closed feature: https://github.com/angular/angular-cli/pull/32631

Fixes #28185 #28671

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When using `--stats-json`, the CLI outputs a single stats.json file.

Issue Number: 28185

## What is the new behavior?

We now receive a `browser-stats.json`, `server-stats.json`, `browser-stats-initial.json` and `server-stats-initial.json`

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

This is a breaking change for anyone relying on CI processes that inspect the old `stats.json` file as it will no longer be named that.

## Other information
