### PR TITLE
fix(@angular/cli): correct dev dependency detection logic in `ng add`

### DIFF
--- a/packages/angular/cli/src/commands/add/cli.ts
+++ b/packages/angular/cli/src/commands/add/cli.ts
@@ -583,7 +583,7 @@ export default class AddCommandModule
         await packageManager.add(
           packageIdentifier.toString(),
           'none',
-          savePackage !== 'dependencies',
+          savePackage === 'devDependencies',
           false,
           true,
           {

--- a/tests/e2e/tests/commands/add/add-material.ts
+++ b/tests/e2e/tests/commands/add/add-material.ts
@@ -1,9 +1,10 @@
 import { assertIsError } from '../../../utils/utils';
-import { expectFileToMatch, rimraf } from '../../../utils/fs';
+import { readFile, rimraf } from '../../../utils/fs';
 import { getActivePackageManager, uninstallPackage } from '../../../utils/packages';
 import { ng } from '../../../utils/process';
 import { isPrereleaseCli } from '../../../utils/project';
 import { appendFile } from 'node:fs/promises';
+import assert from 'node:assert';
 
 export default async function () {
   // forcibly remove in case another test doesn't clean itself up
@@ -32,7 +33,12 @@ export default async function () {
     '--verbose',
     '--skip-confirmation',
   );
-  await expectFileToMatch('package.json', /@angular\/material/);
+
+  const { dependencies } = JSON.parse(await readFile('package.json'));
+  assert.ok(
+    dependencies['@angular/material'],
+    '`@angular/material` was not found added to dependencies',
+  );
 
   // Clean up existing cdk package
   // Not doing so can cause adding material to fail if an incompatible cdk is present


### PR DESCRIPTION
Previously, the logic for determining whether to install a package as a dev dependency in `ng add` was using a negative check (`!== 'dependencies'`). This has been changed to an explicit check (`=== 'devDependencies'`) to ensure the same behaviour as previous versions.

Closes #32630