### PR TITLE
fix(@angular/cli): ensure group members are updated to targeted version

### DIFF
--- a/packages/angular/cli/src/commands/update/schematic/index.ts
+++ b/packages/angular/cli/src/commands/update/schematic/index.ts
@@ -886,6 +886,13 @@ export default function (options: UpdateSchema): Rule {
       lastPackagesSize = packages.size;
       npmPackageJsonMap.forEach((npmPackageJson) => {
         _addPackageGroup(tree, packages, npmDeps, npmPackageJson, logger);
+      });
+    } while (packages.size > lastPackagesSize);
+
+    // This is done in seperate loop to ensure that package groups are added before peer dependencies.
+    do {
+      lastPackagesSize = packages.size;
+      npmPackageJsonMap.forEach((npmPackageJson) => {
         _addPeerDependencies(tree, packages, npmDeps, npmPackageJson, npmPackageJsonMap, logger);
       });
     } while (packages.size > lastPackagesSize);

--- a/packages/angular/cli/src/commands/update/schematic/index_spec.ts
+++ b/packages/angular/cli/src/commands/update/schematic/index_spec.ts
@@ -335,4 +335,57 @@ describe('@schematics/update', () => {
     const resultTreeContent = resultTree.readContent('/package.json');
     expect(resultTreeContent.endsWith('}')).toBeTrue();
   });
+
+  it('updates group members to the same version as the targeted package', async () => {
+    const packageJsonContent = `{
+      "name": "test",
+      "dependencies": {
+        "@angular/cdk": "^19.2.19",
+        "@angular/common": "^19.2.0",
+        "@angular/compiler": "^19.2.0",
+        "@angular/core": "^19.2.0",
+        "@angular/forms": "^19.2.0",
+        "@angular/platform-browser": "^19.2.0",
+        "@angular/platform-browser-dynamic": "^19.2.0",
+        "@angular/router": "^19.2.0",
+        "rxjs": "~7.8.0",
+        "tslib": "^2.3.0",
+        "zone.js": "~0.15.0"
+      },
+      "devDependencies": {
+        "@angular-devkit/build-angular": "^19.2.21",
+        "@angular/cli": "^19.2.21",
+        "@angular/compiler-cli": "^19.2.0",
+        "typescript": "~5.7.2"
+      }
+    }`;
+
+    const inputTree = new UnitTestTree(
+      new HostTree(
+        new virtualFs.test.TestHost({
+          '/package.json': packageJsonContent,
+        }),
+      ),
+    );
+
+    const resultTree = await schematicRunner.runSchematic(
+      'update',
+      { force: true, packages: ['@angular/cli@20', '@angular/cdk@20', '@angular/core@20'] },
+      inputTree,
+    );
+
+    const { devDependencies, dependencies } = resultTree.readJson('/package.json') as {
+      devDependencies: Record<string, string>;
+      dependencies: Record<string, string>;
+    };
+
+    const version20Regexp = /^\^20.\d+.\d+$/;
+
+    expect(devDependencies['typescript']).toMatch(/5\.9\.\d+/);
+    expect(devDependencies['@angular/cli']).toMatch(version20Regexp);
+    expect(devDependencies['@angular/compiler-cli']).toMatch(version20Regexp);
+    expect(dependencies['@angular/cdk']).toMatch(version20Regexp);
+    expect(dependencies['@angular/common']).toMatch(version20Regexp);
+    expect(dependencies['@angular/core']).toMatch(version20Regexp);
+  });
 });


### PR DESCRIPTION
When performing an update, all members of a package group should be updated to the same version as the targeted packages in that group, even if they are not explicitly passed as arguments to the command.

This change separates the package group expansion and peer dependency resolution into two distinct loops. By completing the package group expansion first, we ensure that all group members are added to the update list with their group-synced versions before Evaluate peer dependencies. This prevents cases where a peer dependency might be pulled in at a newer (latest) version before its membership in a targeted group update is recognized.

Closes #32576