### PR TITLE
refactor: remove `tree-kill` dependency and refactor `killAllProcesses` to use native `childProc.kill`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -842,9 +842,6 @@ importers:
       tar-stream:
         specifier: 3.1.7
         version: 3.1.7
-      tree-kill:
-        specifier: 1.2.2
-        version: 1.2.2
 
 packages:
 
@@ -7761,10 +7758,6 @@ packages:
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
-
-  tree-kill@1.2.2:
-    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
-    hasBin: true
 
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
@@ -16411,8 +16404,6 @@ snapshots:
   tree-dump@1.1.0(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
-
-  tree-kill@1.2.2: {}
 
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:

--- a/tests/e2e/utils/BUILD.bazel
+++ b/tests/e2e/utils/BUILD.bazel
@@ -20,6 +20,5 @@ ts_project(
         "//:node_modules/verdaccio-auth-memory",
         "//tests:node_modules/@types/tar-stream",
         "//tests:node_modules/tar-stream",
-        "//tests:node_modules/tree-kill",
     ],
 )

--- a/tests/e2e/utils/process.ts
+++ b/tests/e2e/utils/process.ts
@@ -1,9 +1,9 @@
 import { spawn, SpawnOptions } from 'node:child_process';
 import * as child_process from 'node:child_process';
 import { getGlobalVariable, getGlobalVariablesEnv } from './env';
-import treeKill from 'tree-kill';
 import { delimiter, join, resolve } from 'node:path';
 import { stripVTControlCharacters, styleText } from 'node:util';
+import { assertIsError } from './utils';
 
 interface ExecOptions {
   silent?: boolean;
@@ -255,26 +255,43 @@ export async function waitForAnyProcessOutputToMatch(
   return matchingProcess;
 }
 
-export async function killAllProcesses(signal = 'SIGTERM'): Promise<void> {
+/**
+ * Kills a process by PID
+ * @param pid The PID of the process to kill
+ * @param signal The signal to send to the process
+ */
+async function killProcess(pid: number, signal: NodeJS.Signals): Promise<void> {
+  if (process.platform === 'win32') {
+    // /T kills child processes, /F forces it
+    await new Promise<void>((resolve) => {
+      child_process.exec(`taskkill /pid ${pid} /T /F`, () => resolve());
+    });
+  } else {
+    // Use -pid to signal the entire process group
+    try {
+      process.kill(-pid, signal);
+    } catch (error) {
+      assertIsError(error);
+      if (error.code !== 'ESRCH') {
+        throw error;
+      }
+    }
+  }
+}
+
+/**
+ * Kills all tracked processes
+ */
+export async function killAllProcesses(signal: NodeJS.Signals = 'SIGTERM'): Promise<void> {
   const processesToKill: Promise<void>[] = [];
 
   while (_processes.length) {
     const childProc = _processes.pop();
-    if (!childProc || childProc.pid === undefined) {
+    if (!childProc || childProc.pid === undefined || childProc.killed) {
       continue;
     }
 
-    processesToKill.push(
-      new Promise<void>((resolve) => {
-        treeKill(childProc.pid!, signal, () => {
-          // Ignore all errors.
-          // This is due to a race condition with the `waitForMatch` logic.
-          // where promises are resolved on matches and not when the process terminates.
-          // Also in some cases in windows we get `The operation attempted is not supported`.
-          resolve();
-        });
-      }),
-    );
+    processesToKill.push(killProcess(childProc.pid, signal));
   }
 
   await Promise.all(processesToKill);

--- a/tests/package.json
+++ b/tests/package.json
@@ -2,7 +2,6 @@
   "devDependencies": {
     "@types/tar-stream": "3.1.4",
     "@angular-devkit/schematics": "workspace:*",
-    "tar-stream": "3.1.7",
-    "tree-kill": "1.2.2"
+    "tar-stream": "3.1.7"
   }
 }


### PR DESCRIPTION

Remove last `tree-kill` package usage.

Test: https://github.com/angular/angular-cli/actions/runs/22620146822?pr=32650