### PR TITLE
fix(@angular/build): conditionally allow `vi.mock` for non-relative imports

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
@@ -186,13 +186,32 @@ export async function getVitestBuildOptions(
 
   const mockPatchContents = `
     import { vi } from 'vitest';
+
     const error = new Error(
-    'The "vi.mock" and related methods are not supported with the Angular unit-test system. Please use Angular TestBed for mocking.');
-    vi.mock = () => { throw error; };
-    vi.doMock = () => { throw error; };
-    vi.importMock = () => { throw error; };
-    vi.unmock = () => { throw error; };
-    vi.doUnmock = () => { throw error; };
+      'The "vi.mock" and related methods are not supported for relative imports with the Angular unit-test system. ' +
+      'Please use Angular TestBed for mocking dependencies.'
+    );
+
+    // Store original implementations
+    const { mock, doMock, importMock, unmock, doUnmock } = vi;
+
+    function patch(original) {
+      return (path, ...args) => {
+        // Check if the path is a string and starts with a character that indicates a relative path.
+        if (typeof path === 'string' && /^[./]/.test(path)) {
+          throw error;
+        }
+
+        // Call the original function for non-relative paths.
+        return original(path, ...args);
+      };
+    }
+
+    vi.mock = patch(mock);
+    vi.doMock = patch(doMock);
+    vi.importMock = patch(importMock);
+    vi.unmock = patch(unmock);
+    vi.doUnmock = patch(doUnmock);
   `;
 
   return {

--- a/packages/angular/build/src/builders/unit-test/tests/behavior/vitest-mock-unsupported_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/behavior/vitest-mock-unsupported_spec.ts
@@ -34,8 +34,35 @@ describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
       `,
       );
 
-      const { result, logs } = await harness.executeOnce();
+      const { result } = await harness.executeOnce();
       expect(result?.success).toBeFalse();
+    });
+
+    it('should not fail when vi.mock is used with a non-relative path', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+      });
+
+      harness.writeFile(
+        'src/app/mock-non-relative.spec.ts',
+        `
+        import { vi } from 'vitest';
+        vi.mock('@angular/cdk', () => ({}));
+        describe('Ignored', () => { it('pass', () => expect(true).toBe(true)); });
+      `,
+      );
+
+      // Overwrite default to avoid noise
+      harness.writeFile(
+        'src/app/app.component.spec.ts',
+        `
+        import { describe, it, expect } from 'vitest';
+        describe('Ignored', () => { it('pass', () => expect(true).toBe(true)); });
+      `,
+      );
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
     });
   });
 });


### PR DESCRIPTION
Previously, `vi.mock` and related Vitest mocking APIs were completely disabled, causing errors even for valid use cases like mocking Node.js built-in modules or installed packages.

This commit refactors the `vitest-mock-patch` to:
- Allow `vi.mock` for non-relative module paths (e.g., 'fs', '@angular/core').
- Continue to block `vi.mock` for relative module paths (e.g., './my-local-module') to enforce the use of Angular TestBed for local dependency mocking.