### PR TITLE
fix(@angular/build): resolve style include paths relative to `ng-package.json` in unit-test builder

### DIFF
--- a/packages/angular/build/src/builders/unit-test/builder.ts
+++ b/packages/angular/build/src/builders/unit-test/builder.ts
@@ -375,16 +375,15 @@ async function transformNgPackagrOptions(
     });
   }
 
-  const lib = ngPackageJson['lib'] || {};
-  const styleIncludePaths = lib['styleIncludePaths'] || [];
-  const assets = ngPackageJson['assets'] || [];
-  const inlineStyleLanguage = ngPackageJson['inlineStyleLanguage'];
+  const { lib: { styleIncludePaths = [] } = {}, assets = [], inlineStyleLanguage } = ngPackageJson;
+
+  const includePaths = styleIncludePaths.map((includePath: string) =>
+    path.resolve(path.dirname(ngPackagePath), includePath),
+  );
 
   return {
-    stylePreprocessorOptions: styleIncludePaths.length
-      ? { includePaths: styleIncludePaths }
-      : undefined,
+    stylePreprocessorOptions: includePaths.length ? { includePaths } : undefined,
     assets: assets.length ? assets : undefined,
-    inlineStyleLanguage: typeof inlineStyleLanguage === 'string' ? inlineStyleLanguage : undefined,
+    inlineStyleLanguage,
   } as ApplicationBuilderInternalOptions;
 }

--- a/tests/e2e/tests/vitest/library.ts
+++ b/tests/e2e/tests/vitest/library.ts
@@ -1,12 +1,9 @@
 import assert from 'node:assert/strict';
 import { updateJsonFile } from '../../utils/project';
-import { ng, silentNpm } from '../../utils/process';
-import { createDir, writeFile } from '../../utils/fs';
+import { ng } from '../../utils/process';
+import { appendToFile, createDir, writeFile } from '../../utils/fs';
 
 export default async function (): Promise<void> {
-  // Install Vitest deps
-  await silentNpm('install', 'vitest@^4.0.8', 'jsdom@^27.1.0', '--save-dev');
-
   // Generate a library
   await ng('generate', 'library', 'my-lib', '--test-runner', 'vitest');
 
@@ -25,17 +22,10 @@ export default async function (): Promise<void> {
 
   // 3. Update the component to use SCSS and import the shared file
   // Rename CSS to SCSS
-  await ng(
-    'generate',
-    'component',
-    'styled-comp',
-    '--project=my-lib',
-    '--style=scss',
-    '--skip-import',
-  );
+  await ng('generate', 'component', 'styled-comp', '--project=my-lib', '--style=scss');
 
-  await writeFile(
-    'projects/my-lib/src/lib/styled-comp/styled-comp.component.scss',
+  await appendToFile(
+    'projects/my-lib/src/lib/styled-comp/styled-comp.scss',
     `
       @use 'vars';
       p { color: vars.$primary-color; }


### PR DESCRIPTION

When using the `unit-test` builder with an `ng-packagr` build target, the `styleIncludePaths` from `ng-package.json` were being used relative to the workspace root instead of the library's directory. This caused build failures when libraries specified style include paths.

This change ensures that these paths are correctly resolved relative to the directory containing `ng-package.json`.
