### PR TITLE
build: introduce package deprecation metadata and integrate it into the release configuration

### DIFF
--- a/.monorepo.json
+++ b/.monorepo.json
@@ -62,7 +62,11 @@
     "@angular-devkit/architect-cli": {
       "name": "Architect CLI",
       "section": "Tooling",
-      "snapshotRepo": "angular/angular-devkit-architect-cli-builds"
+      "snapshotRepo": "angular/angular-devkit-architect-cli-builds",
+      "deprecated": {
+        "version": ">=21.2.0",
+        "message": "The Architect CLI is now available directly via '@angular-devkit/architect'."
+      }
     },
     "@angular-devkit/build-angular": {
       "name": "Build Angular",

--- a/.ng-dev/release.mjs
+++ b/.ng-dev/release.mjs
@@ -8,7 +8,11 @@ import { releasePackages } from '../scripts/packages.mts';
  */
 export const release = {
   representativeNpmPackage: '@angular/cli',
-  npmPackages: releasePackages.map(({ name, experimental }) => ({ name, experimental })),
+  npmPackages: releasePackages.map(({ name, experimental, deprecated }) => ({
+    name,
+    experimental,
+    deprecated,
+  })),
   buildPackages: async () => {
     // The `performNpmReleaseBuild` function is loaded at runtime to avoid loading additional
     // files and dependencies unless a build is required.

--- a/scripts/packages.mts
+++ b/scripts/packages.mts
@@ -13,6 +13,10 @@ import { dirname } from 'node:path';
 export interface PackageInfo {
   name: string;
   root: string;
+  deprecated?: {
+    version: string;
+    message: string;
+  };
   experimental: boolean;
   packageJson: Record<string, boolean | number | string | object>;
 }
@@ -31,6 +35,7 @@ function getPackages(): PackageInfo[] {
     packages.push({
       name: packageJson.name,
       experimental: !!packageJson.experimental,
+      deprecated: monorepoData.packages[packageJson.name].deprecated,
       root: dirname(pkg),
       packageJson,
     });


### PR DESCRIPTION


`ng-dev` now supports deprecations of NPM packages. See: https://github.com/angular/dev-infra/pull/3463
