### PR TITLE
fix: prevent command injection via shell metacharacters on Windows

### DIFF
--- a/packages/angular_devkit/schematics/tasks/repo-init/executor.ts
+++ b/packages/angular_devkit/schematics/tasks/repo-init/executor.ts
@@ -29,7 +29,6 @@ export default function (
       const errorStream = ignoreErrorStream ? 'ignore' : process.stderr;
       const spawnOptions: SpawnOptions = {
         stdio: [process.stdin, outputStream, errorStream],
-        shell: true,
         cwd: path.join(rootDirectory, options.workingDirectory || ''),
         env: {
           ...process.env,
@@ -41,7 +40,7 @@ export default function (
       };
 
       return new Promise<void>((resolve, reject) => {
-        spawn(`git ${args.join(' ')}`, spawnOptions).on('close', (code: number) => {
+        spawn('git', args, spawnOptions).on('close', (code: number) => {
           if (code === 0) {
             resolve();
           } else {
@@ -82,7 +81,7 @@ export default function (
       if (options.commit) {
         const message = options.message || 'initial commit';
 
-        await execute(['commit', `-m "${message}"`]);
+        await execute(['commit', '-m', message]);
       }
 
       context.logger.info('Successfully initialized git.');


### PR DESCRIPTION
## Description

This PR fixes command injection vulnerabilities on Windows in two files:

### 1. `executor.ts` (git spawn)
- Removed `shell: true` — git is a native `.exe` and doesn't need it
- Switched from `spawn(\`git ${args.join(' ')}\`)` to `spawn('git', args)`
- Separated `-m` flag from commit message: `['commit', '-m', message]` instead of `['commit', \`-m "${message}"\`]`

### 2. `host.ts` (package manager spawn)
- Package managers (npm/yarn/pnpm) are `.cmd` scripts on Windows and need a shell
- Instead of using `shell: true` with unsanitized argument concatenation, we now invoke `cmd.exe /d /s /c` directly with properly escaped arguments
- Escape logic is based on [cross-spawn](https://github.com/moxystudio/node-cross-spawn)'s battle-tested approach, inlined to avoid adding a dependency
- Uses `windowsVerbatimArguments: true` to prevent Node.js from re-escaping

### Testing
Verified on Windows 11 (Node v25.6.0):
- npm/git commands work correctly with the new approach
- Injection payloads (`& echo INJECTED`, `& echo PWNED > file`) are blocked
- Old `shell: true` pattern confirmed vulnerable (control test)

Fixes #32509
