### PR TITLE
fix(@angular/build): treat empty browsers array as undefined in unit-test builder

### DIFF
--- a/packages/angular/build/src/builders/unit-test/options.ts
+++ b/packages/angular/build/src/builders/unit-test/options.ts
@@ -116,7 +116,7 @@ export async function normalizeOptions(
     buildProgress: progress,
     reporters: normalizeReporterOption(options.reporters),
     outputFile: options.outputFile,
-    browsers,
+    browsers: browsers?.length ? browsers : undefined,
     browserViewport: width && height ? { width, height } : undefined,
     watch,
     debug: options.debug ?? false,


### PR DESCRIPTION

Ensure that an empty `browsers` array is treated as `undefined` during the option normalization process. This allows the unit-test builder to properly fall back to the Node.js/jsdom environment for Vitest, and allows the Karma runner to use its default configuration.

Closes #32652