### PR TITLE
ci: remove redundant `actions/checkout` steps from dev-infra workflows

### DIFF
--- a/.github/workflows/dev-infra.yml
+++ b/.github/workflows/dev-infra.yml
@@ -15,7 +15,6 @@ jobs:
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: angular/dev-infra/github-actions/labeling/pull-request@63fd18d4726829e65f6abe6f15c0fe79f63f1dec
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}
@@ -23,7 +22,6 @@ jobs:
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: angular/dev-infra/github-actions/post-approval-changes@63fd18d4726829e65f6abe6f15c0fe79f63f1dec
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}


### PR DESCRIPTION
Checking out the repo is not needed for these actions.
