### PR TITLE
build: correct deprecated version for architect-cli in monorepo configuration

### DIFF
--- a/.monorepo.json
+++ b/.monorepo.json
@@ -64,7 +64,7 @@
       "section": "Tooling",
       "snapshotRepo": "angular/angular-devkit-architect-cli-builds",
       "deprecated": {
-        "version": ">=21.2.0",
+        "version": ">=0.2102.0",
         "message": "The Architect CLI is now available directly via '@angular-devkit/architect'."
       }
     },


### PR DESCRIPTION

The version was incorrect.