### PR TITLE
build: standardize `bin` script paths and `repository.url` formats across `package.json` files

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/angular-cli.git"
+    "url": "git+https://github.com/angular/angular-cli.git"
   },
   "packageManager": "pnpm@10.30.3",
   "engines": {

--- a/packages/angular/cli/package.json
+++ b/packages/angular/cli/package.json
@@ -4,7 +4,7 @@
   "description": "CLI tool for Angular",
   "main": "lib/cli/index.js",
   "bin": {
-    "ng": "./bin/ng.js"
+    "ng": "bin/ng.js"
   },
   "keywords": [
     "angular",
@@ -13,7 +13,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/angular-cli.git"
+    "url": "git+https://github.com/angular/angular-cli.git"
   },
   "author": "Angular Authors",
   "license": "MIT",

--- a/packages/angular/create/package.json
+++ b/packages/angular/create/package.json
@@ -9,7 +9,7 @@
     "code generation",
     "schematics"
   ],
-  "bin": "./src/index.js",
+  "bin": "src/index.js",
   "dependencies": {
     "@angular/cli": "0.0.0-PLACEHOLDER"
   }

--- a/packages/angular/ssr/package.json
+++ b/packages/angular/ssr/package.json
@@ -42,6 +42,6 @@
   "schematics": "./schematics/collection.json",
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/angular-cli.git"
+    "url": "git+https://github.com/angular/angular-cli.git"
   }
 }

--- a/packages/angular_devkit/architect/package.json
+++ b/packages/angular_devkit/architect/package.json
@@ -4,7 +4,7 @@
   "description": "Angular Build Facade",
   "experimental": true,
   "bin": {
-    "architect": "./bin/cli.js"
+    "architect": "bin/cli.js"
   },
   "main": "src/index.js",
   "typings": "src/index.d.ts",

--- a/packages/angular_devkit/schematics_cli/package.json
+++ b/packages/angular_devkit/schematics_cli/package.json
@@ -4,7 +4,7 @@
   "description": "Angular Schematics - CLI",
   "homepage": "https://github.com/angular/angular-cli",
   "bin": {
-    "schematics": "./bin/schematics.js"
+    "schematics": "bin/schematics.js"
   },
   "keywords": [
     "blueprints",

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -13,7 +13,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/angular-cli.git"
+    "url": "git+https://github.com/angular/angular-cli.git"
   },
   "author": "angular",
   "bugs": {


### PR DESCRIPTION

This removed warnings during the releases