### PR TITLE
fix(@angular/cli): conditionally quote package names when adding dependencies based on host requirements

### DIFF
--- a/packages/angular/cli/src/package-managers/package-manager.ts
+++ b/packages/angular/cli/src/package-managers/package-manager.ts
@@ -323,7 +323,9 @@ export class PackageManager {
       ignoreScripts ? this.descriptor.ignoreScriptsFlag : '',
     ].filter((flag) => flag);
 
-    const args = [this.descriptor.addCommand, packageName, ...flags];
+    const specifier = this.host.requiresQuoting ? `"${packageName}"` : packageName;
+    const args = [this.descriptor.addCommand, specifier, ...flags];
+
     await this.#run(args, options);
 
     this.#dependencyCache = null;


### PR DESCRIPTION


Complex range specifiers that include shell special characters (e.g., '>', '<') can be misinterpreted when not quoted. This change ensures that version ranges are enclosed in quotes when needed to prevent such issues.
