### PR TITLE
perf(@angular/cli): avoid redundant package version resolution in ng add

### DIFF
--- a/packages/angular/cli/src/commands/add/cli.ts
+++ b/packages/angular/cli/src/commands/add/cli.ts
@@ -489,12 +489,9 @@ export default class AddCommandModule
 
     let manifest;
     try {
-      manifest = await this.context.packageManager.getManifest(
-        context.packageIdentifier.toString(),
-        {
-          registry,
-        },
-      );
+      manifest = await this.context.packageManager.getManifest(context.packageIdentifier, {
+        registry,
+      });
     } catch (e) {
       assertIsError(e);
       throw new CommandError(
@@ -505,6 +502,17 @@ export default class AddCommandModule
     if (!manifest) {
       throw new CommandError(
         `Unable to fetch package information for '${context.packageIdentifier}'.`,
+      );
+    }
+
+    // Avoid fully resolving the package version from the registry again in later steps
+    if (context.packageIdentifier.registry) {
+      assert(context.packageIdentifier.name, 'Registry package identifier must have a name');
+      context.packageIdentifier = npa.resolve(
+        context.packageIdentifier.name,
+        // `save-prefix` option is ignored by some package managers so the caret is needed to ensure
+        // that the value in the project package.json is correct.
+        '^' + manifest.version,
       );
     }
 


### PR DESCRIPTION
The `ng add` command would previously resolve the package version from the registry multiple times during execution. This change updates the package identifier with the exact version from the manifest once it has been fetched from the registry, preventing subsequent redundant lookups. Additionally, the already-parsed package identifier is now passed directly to the package manager's `getManifest` method.