### PR TITLE
fix(@angular/cli): preserve exact version in ng add when requested

### DIFF
--- a/packages/angular/cli/src/commands/add/cli.ts
+++ b/packages/angular/cli/src/commands/add/cli.ts
@@ -45,6 +45,7 @@ interface AddCommandArgs extends SchematicsCommandArgs {
 
 interface AddCommandTaskContext {
   packageIdentifier: npa.Result;
+  isExactVersion: boolean;
   savePackage?: NgAddSaveDependency;
   collectionName?: string;
   executeSchematic: AddCommandModule['executeSchematic'];
@@ -188,6 +189,7 @@ export default class AddCommandModule
 
     const taskContext = {
       packageIdentifier,
+      isExactVersion: packageIdentifier.type === 'version',
       executeSchematic: this.executeSchematic.bind(this),
       getPeerDependencyConflicts: this.getPeerDependencyConflicts.bind(this),
       dryRun: options.dryRun,
@@ -515,7 +517,7 @@ export default class AddCommandModule
         context.packageIdentifier.name,
         // `save-prefix` option is ignored by some package managers so the caret is needed to ensure
         // that the value in the project package.json is correct.
-        '^' + manifest.version,
+        (context.isExactVersion ? '' : '^') + manifest.version,
       );
     }
 


### PR DESCRIPTION
The `ng add` command would previously always add a caret (`^`) prefix to the resolved package version, even if the user explicitly requested an exact version. This change ensures that the exact version is preserved in the package identifier if requested, while maintaining the caret prefix for general requests to ensure consistent behavior with package managers.