### PR TITLE
fix(@angular/build): pass process environment variables to prerender workers

### DIFF
--- a/packages/angular/build/src/utils/server-rendering/prerender.ts
+++ b/packages/angular/build/src/utils/server-rendering/prerender.ts
@@ -228,6 +228,7 @@ async function renderPages(
     } as RenderWorkerData,
     execArgv: workerExecArgv,
     env: {
+      ...process.env,
       'NG_ALLOWED_HOSTS': 'localhost',
     },
   });
@@ -343,6 +344,7 @@ async function getAllRoutes(
     } as RoutesExtractorWorkerData,
     execArgv: workerExecArgv,
     env: {
+      ...process.env,
       'NG_ALLOWED_HOSTS': 'localhost',
     },
   });


### PR DESCRIPTION

Worker processes used for prerendering and route extraction now inherit `process.env`. This ensures that any custom environment variables required by the application are available during the server-side rendering process.

Closes #32730