### PR TITLE
build: remove @angular-devkit/schematics from devDependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -839,9 +839,6 @@ importers:
 
   tests:
     devDependencies:
-      '@angular-devkit/schematics':
-        specifier: workspace:*
-        version: link:../packages/angular_devkit/schematics
       '@types/tar-stream':
         specifier: 3.1.4
         version: 3.1.4

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,7 +1,6 @@
 {
   "devDependencies": {
     "@types/tar-stream": "3.1.4",
-    "@angular-devkit/schematics": "workspace:*",
     "tar-stream": "3.1.8"
   }
 }


### PR DESCRIPTION
This is not needed.
