### PR TITLE
refactor: relocate `verdaccio` and `verdaccio-auth-memory` dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,8 +131,6 @@
     "typescript": "6.0.1-rc",
     "undici": "7.22.0",
     "unenv": "^1.10.0",
-    "verdaccio": "6.2.9",
-    "verdaccio-auth-memory": "^10.0.0",
     "zone.js": "^0.16.0"
   },
   "dependenciesMeta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,12 +286,6 @@ importers:
       unenv:
         specifier: ^1.10.0
         version: 1.10.0
-      verdaccio:
-        specifier: 6.2.9
-        version: 6.2.9(encoding@0.1.13)
-      verdaccio-auth-memory:
-        specifier: ^10.0.0
-        version: 10.3.1
       zone.js:
         specifier: ^0.16.0
         version: 0.16.1
@@ -848,6 +842,12 @@ importers:
       tar-stream:
         specifier: 3.1.8
         version: 3.1.8
+      verdaccio:
+        specifier: 6.2.9
+        version: 6.2.9(encoding@0.1.13)
+      verdaccio-auth-memory:
+        specifier: ^10.0.0
+        version: 10.3.1
 
 packages:
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -66,8 +66,8 @@ e2e_suites(
 
         # Dynamically loaded.
         "//tests/e2e/assets",
-        "//:node_modules/verdaccio",
-        "//:node_modules/verdaccio-auth-memory",
+        "//tests:node_modules/verdaccio",
+        "//tests:node_modules/verdaccio-auth-memory",
 
         # Extra runtime deps due to bundling issues.
         # TODO: Clean this up.

--- a/tests/e2e/utils/BUILD.bazel
+++ b/tests/e2e/utils/BUILD.bazel
@@ -16,9 +16,9 @@ ts_project(
         "//:node_modules/fast-glob",
         "//:node_modules/puppeteer",
         "//:node_modules/semver",
-        "//:node_modules/verdaccio",
-        "//:node_modules/verdaccio-auth-memory",
         "//tests:node_modules/@types/tar-stream",
         "//tests:node_modules/tar-stream",
+        "//tests:node_modules/verdaccio",
+        "//tests:node_modules/verdaccio-auth-memory",
     ],
 )

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,7 +1,9 @@
 {
   "devDependencies": {
-    "@types/tar-stream": "3.1.4",
     "@angular-devkit/schematics": "workspace:*",
-    "tar-stream": "3.1.8"
+    "@types/tar-stream": "3.1.4",
+    "tar-stream": "3.1.8",
+    "verdaccio": "6.2.9",
+    "verdaccio-auth-memory": "^10.0.0"
   }
 }


### PR DESCRIPTION
Move from the root to the `tests` package and update Bazel references.
