### PR TITLE
docs: release notes for the v20.3.20 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="20.3.20"></a>
+
+# 20.3.20 (2026-03-11)
+
+### @angular/build
+
+| Commit                                                                                              | Type | Description                                             |
+| --------------------------------------------------------------------------------------------------- | ---- | ------------------------------------------------------- |
+| [0fd6823af](https://github.com/angular/angular-cli/commit/0fd6823af0adec23f7c3f1d531f45f6432afe555) | fix  | pass process environment variables to prerender workers |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="22.0.0-next.0"></a>
 
 # 22.0.0-next.0 (2026-03-05)


### PR DESCRIPTION
Cherry-picks the changelog from the "20.3.x" branch to the next branch (main).