### PR TITLE
@ngtools/webpack: Enable the emit of declaration files

### DIFF
--- a/packages/ngtools/webpack/src/ivy/loader.ts
+++ b/packages/ngtools/webpack/src/ivy/loader.ts
@@ -74,8 +74,16 @@ export function angularWebpackLoader(
       }
 
       // Write the declaration file in the target dir
-      if (result.declaration) {
-        fs.writeFileSync(this.resourcePath.replace('.ts', '.d.ts'), result.declaration);
+      if (result.declaration && fileEmitter.compilerOptions.declaration) {
+        let target = this.resourcePath.replace('.ts', '.d.ts');
+        if (fileEmitter.compilerOptions.declarationDir) {
+          if (!fileEmitter.compilerOptions.baseUrl) {
+            throw new Error('When declarationDir is specified, baseUrl is required as well');
+          }
+          const relDir = path.relative(fileEmitter.compilerOptions.baseUrl, target);
+          target = path.join(fileEmitter.compilerOptions.declarationDir, relDir);
+        }
+        fs.writeFileSync(target, result.declaration);
       }
       callback(undefined, resultContent, resultMap);
     })

--- a/packages/ngtools/webpack/src/ivy/loader.ts
+++ b/packages/ngtools/webpack/src/ivy/loader.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { LoaderContext } from 'webpack';
 import { AngularPluginSymbol, FileEmitterCollection } from './symbol';
@@ -72,6 +73,10 @@ export function angularWebpackLoader(
         );
       }
 
+      // Write the declaration file in the target dir
+      if (result.declaration) {
+        fs.writeFileSync(this.resourcePath.replace('.ts', '.d.ts'), result.declaration);
+      }
       callback(undefined, resultContent, resultMap);
     })
     .catch((err) => {

--- a/packages/ngtools/webpack/src/ivy/plugin.ts
+++ b/packages/ngtools/webpack/src/ivy/plugin.ts
@@ -681,6 +681,7 @@ export class AngularWebpackPlugin {
 
       let content: string | undefined;
       let map: string | undefined;
+      let declaration: string | undefined;
       program.emit(
         sourceFile,
         (filename, data) => {
@@ -688,6 +689,8 @@ export class AngularWebpackPlugin {
             map = data;
           } else if (filename.endsWith('.js')) {
             content = data;
+          } else if (filename.endsWith('.d.ts')) {
+            declaration = data;
           }
         },
         undefined,
@@ -705,7 +708,7 @@ export class AngularWebpackPlugin {
         ...getExtraDependencies(sourceFile),
       ].map(externalizePath);
 
-      return { content, map, dependencies, hash };
+      return { content, map, declaration, dependencies, hash };
     };
   }
 

--- a/packages/ngtools/webpack/src/ivy/plugin.ts
+++ b/packages/ngtools/webpack/src/ivy/plugin.ts
@@ -85,6 +85,7 @@ export class AngularWebpackPlugin {
   private readonly requiredFilesToEmit = new Set<string>();
   private readonly requiredFilesToEmitCache = new Map<string, EmitFileResult | undefined>();
   private readonly fileEmitHistory = new Map<string, FileEmitHistoryItem>();
+  private compilerOptions!: CompilerOptions;
 
   constructor(options: Partial<AngularWebpackPluginOptions> = {}) {
     this.pluginOptions = {
@@ -186,6 +187,7 @@ export class AngularWebpackPlugin {
 
     // Setup and read TypeScript and Angular compiler configuration
     const { compilerOptions, rootNames, errors } = this.loadConfiguration();
+    this.compilerOptions = compilerOptions;
 
     // Create diagnostics reporter and report configuration file errors
     const diagnosticsReporter = createDiagnosticsReporter(compilation, (diagnostic) =>
@@ -325,6 +327,8 @@ export class AngularWebpackPlugin {
       compilation.compiler.webpack.NormalModule.getCompilationHooks(compilation).loader.tap(
         PLUGIN_NAME,
         (context) => {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          fileEmitters!.compilerOptions = this.compilerOptions;
           const loaderContext = context as typeof context & {
             [AngularPluginSymbol]?: FileEmitterCollection;
           };

--- a/packages/ngtools/webpack/src/ivy/symbol.ts
+++ b/packages/ngtools/webpack/src/ivy/symbol.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import { CompilerOptions } from 'typescript';
+
 export const AngularPluginSymbol: unique symbol = Symbol.for('@ngtools/webpack[angular-compiler]');
 
 export interface EmitFileResult {
@@ -36,6 +38,8 @@ export class FileEmitterRegistration {
 
 export class FileEmitterCollection {
   #registrations: FileEmitterRegistration[] = [];
+
+  public compilerOptions!: CompilerOptions;
 
   register(): FileEmitterRegistration {
     const registration = new FileEmitterRegistration();

--- a/packages/ngtools/webpack/src/ivy/symbol.ts
+++ b/packages/ngtools/webpack/src/ivy/symbol.ts
@@ -11,6 +11,7 @@ export const AngularPluginSymbol: unique symbol = Symbol.for('@ngtools/webpack[a
 export interface EmitFileResult {
   content?: string;
   map?: string;
+  declaration?: string;
   dependencies: readonly string[];
   hash?: Uint8Array;
 }


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ ] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently the `AngularWebpackPlugin` is swallowing any `.d.ts` file. This differs from what the standard `ts-loader` plugin does: it normally produces a .d.ts file for each source .ts file, alongside the source itself.
If the `tsconfig` `declarationDir` property is used, the root folder of the declaration files can be changed instead (but it keeps the source folder structure).

Currently this is a viable workaround for Angular libraries:

```
            {
                test: /\.ts$/,
                use: [{
                    loader: "@ngtools/webpack",
                    options: {
                        // etc... sideEffects: true
                    }
                }, {
                    // Load `ts-loader` as well to allow .d.ts to be produced in the `declarationDir`: `@ngtools/webpack` is not doing that
                    loader: "ts-loader"
                }]
           }
```

However this produces declaration files that doesn't contains Ivy metadata, so it cannot be used by other Angular libraries.

Using the official `ng-packagr` to build Angular libraries leverages a different stack (rollup), so any webpack-based solution with custom plugins cannot be easily ported to `ng-packagr`.

This PR only shows the feasibility for producing the .d.ts again (with Ivy metadata), but it is not production ready.

Is there any reasons for not considering the declaration files emission for webpack plugin? 

## What is the new behavior?

<!-- Please describe the new behavior that. -->

New behavior aligns the angular webpack plugin to `ts-loader`, emitting the unbundled .d.ts files in place (or in the target `declarationDir`) with Ivy information, at par with the ones of `ng-packagr`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
