### PR TITLE
fix(@angular/build): alias createRequire banner import to avoid duplicate binding

### DIFF
--- a/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
@@ -196,9 +196,14 @@ export function createServerPolyfillBundleOptions(
   if (isNodePlatform) {
     // Note: Needed as esbuild does not provide require shims / proxy from ESModules.
     // See: https://github.com/evanw/esbuild/issues/1921.
+    // Use an alias to avoid colliding with any `createRequire` import that may
+    // already exist in the bundled user code. ESBuild processes banner content
+    // as raw text outside of its module graph, so it cannot deduplicate or
+    // rename banner imports the way it does for user imports. Without the alias,
+    // a duplicate `import { createRequire }` binding would cause a runtime error.
     jsBanner.push(
-      `import { createRequire } from 'node:module';`,
-      `globalThis['require'] ??= createRequire(import.meta.url);`,
+      `import { createRequire as __ngCreateRequire } from 'node:module';`,
+      `globalThis['require'] ??= __ngCreateRequire(import.meta.url);`,
     );
   }
 
@@ -397,9 +402,14 @@ export function createSsrEntryCodeBundleOptions(
     if (isNodePlatform) {
       // Note: Needed as esbuild does not provide require shims / proxy from ESModules.
       // See: https://github.com/evanw/esbuild/issues/1921.
+      // Use an alias to avoid colliding with any `createRequire` import that may
+      // already exist in the bundled user code. ESBuild processes banner content
+      // as raw text outside of its module graph, so it cannot deduplicate or
+      // rename banner imports the way it does for user imports. Without the alias,
+      // a duplicate `import { createRequire }` binding would cause a runtime error.
       jsBanner.push(
-        `import { createRequire } from 'node:module';`,
-        `globalThis['require'] ??= createRequire(import.meta.url);`,
+        `import { createRequire as __ngCreateRequire } from 'node:module';`,
+        `globalThis['require'] ??= __ngCreateRequire(import.meta.url);`,
       );
     }
 


### PR DESCRIPTION
ESBuild processes banner content as raw text outside of its module graph, so it cannot deduplicate or rename banner imports the way it does for user imports. If user code already imports `createRequire` from `node:module`, the injected banner produces a duplicate binding that causes a runtime error.

Alias the banner import to `__ngCreateRequire` to avoid colliding with any `createRequire` binding that esbuild may emit from bundled user code.