### PR TITLE
docs: update long-description

### DIFF
--- a/packages/angular/cli/src/commands/update/long-description.md
+++ b/packages/angular/cli/src/commands/update/long-description.md
@@ -13,10 +13,10 @@ ng update @angular/cli@^<major_version> @angular/core@^<major_version>
 ```
 
 We recommend that you always update to the latest patch version, as it contains fixes we released since the initial major release.
-For example, use the following command to take the latest 10.x.x version and use that to update.
+For example, use the following command to take the latest 21.x.x version and use that to update.
 
 ```
-ng update @angular/cli@^10 @angular/core@^10
+ng update @angular/cli@^21 @angular/core@^21
 ```
 
-For detailed information and guidance on updating your application, see the interactive [Angular Update Guide](https://update.angular.dev/).
+For detailed information and guidance on updating your application, see the interactive [Angular Update Guide](/update-guide).


### PR DESCRIPTION
 

## What is the current behavior?
 
<img width="839" height="177" alt="image" src="https://github.com/user-attachments/assets/539beef4-abba-424a-861f-b3f1aec9336c" />


## What is the new behavior?

Avoid using absolute links in angular.dev since this is an internal route.
 
<img width="855" height="184" alt="image" src="https://github.com/user-attachments/assets/3d9a77ce-d474-4373-8aae-23bf690c6fb6" />

 