### PR TITLE
build: update dependency https-proxy-agent to v8

### DIFF
--- a/packages/angular/build/package.json
+++ b/packages/angular/build/package.json
@@ -28,7 +28,7 @@
     "beasties": "0.4.1",
     "browserslist": "^4.26.0",
     "esbuild": "0.27.3",
-    "https-proxy-agent": "7.0.6",
+    "https-proxy-agent": "8.0.0",
     "istanbul-lib-instrument": "6.0.3",
     "jsonc-parser": "3.3.1",
     "listr2": "10.2.1",

--- a/packages/angular/build/src/utils/index-file/inline-fonts.ts
+++ b/packages/angular/build/src/utils/index-file/inline-fonts.ts
@@ -6,10 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { HttpsProxyAgent } from 'https-proxy-agent';
 import { createHash } from 'node:crypto';
 import { readFile, rm, writeFile } from 'node:fs/promises';
-import { get as httpsGet } from 'node:https';
+import { type Agent, get as httpsGet } from 'node:https';
 import { join } from 'node:path';
 import { NormalizedCachedOptions } from '../normalize-cache';
 import { htmlRewritingStream } from './html-rewriting-stream';
@@ -195,12 +194,28 @@ export class InlineFontsProcessor {
     }
 
     const httpsProxy = process.env.HTTPS_PROXY ?? process.env.https_proxy;
+    let agent: Agent | undefined;
+    if (httpsProxy) {
+      // TODO: Remove `https-proxy-agent` usage once the min supported version of Node.js is 24.5.0
+      // https.globalAgent = new https.Agent({
+      //   proxyEnv: { HTTPS_PROXY: 'http://proxy.company.com:8080' },
+      // });
+      // See: https://nodejs.org/en/learn/http/enterprise-network-configuration
+      // See: https://nodejs.org/docs/latest/api/https.html
+
+      const { HttpsProxyAgent } = (await import('https-proxy-agent' as string)) as typeof import(
+        'https-proxy-agent',
+        { with: { 'resolution-mode': 'import' } }
+      );
+      agent = new HttpsProxyAgent(httpsProxy) as unknown as Agent;
+    }
+
     const data = await new Promise<string>((resolve, reject) => {
       let rawResponse = '';
       httpsGet(
         url,
         {
-          agent: httpsProxy ? new HttpsProxyAgent(httpsProxy) : undefined,
+          agent,
           headers: {
             /**
              * Always use a Windows UA. This is because Google fonts will including hinting in fonts for Windows.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,8 +362,8 @@ importers:
         specifier: 0.27.3
         version: 0.27.3
       https-proxy-agent:
-        specifier: 7.0.6
-        version: 7.0.6(supports-color@10.2.2)
+        specifier: 8.0.0
+        version: 8.0.0
       istanbul-lib-instrument:
         specifier: 6.0.3
         version: 6.0.3
@@ -3872,6 +3872,10 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  agent-base@8.0.0:
+    resolution: {integrity: sha512-QT8i0hCz6C/KQ+KTAbSNwCHDGdmUJl2tp2ZpNlGSWCfhUNVbYG2WLE3MdZGBAgXPV4GAvjGMxo+C1hroyxmZEg==}
+    engines: {node: '>= 14'}
+
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
 
@@ -5543,6 +5547,10 @@ packages:
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@8.0.0:
+    resolution: {integrity: sha512-YYeW+iCnAS3xhvj2dvVoWgsbca3RfQy/IlaNHHOtDmU0jMqPI9euIq3Y9BJETdxk16h9NHHCKqp/KB9nIMStCQ==}
     engines: {node: '>= 14'}
 
   husky@9.1.7:
@@ -11812,6 +11820,8 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  agent-base@8.0.0: {}
+
   ajv-formats@2.1.1:
     dependencies:
       ajv: 8.18.0
@@ -13864,6 +13874,13 @@ snapshots:
   https-proxy-agent@7.0.6(supports-color@10.2.2):
     dependencies:
       agent-base: 7.1.4
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@8.0.0:
+    dependencies:
+      agent-base: 8.0.0
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
See associated pull request for more information.

Closes #32762 as a pr takeover