### PR TITLE
fix(@angular/build): skip HTML fallback for dotfile requests

### DIFF
--- a/packages/angular/build/src/tools/vite/middlewares/html-fallback-middleware.ts
+++ b/packages/angular/build/src/tools/vite/middlewares/html-fallback-middleware.ts
@@ -27,6 +27,15 @@ export function angularHtmlFallbackMiddleware(
   }
 
   if (req.url) {
+    // No fallback for dotfile requests (e.g., .env, .npmrc)
+    const pathname = req.url.split('?')[0];
+    const lastSegment = pathname.substring(pathname.lastIndexOf('/') + 1);
+    if (lastSegment.startsWith('.')) {
+      next();
+
+      return;
+    }
+
     const mimeType = lookupMimeTypeFromRequest(req.url);
     if (
       (mimeType === 'text/html' || mimeType === 'application/xhtml+xml') &&

--- a/packages/angular/build/src/tools/vite/middlewares/html-fallback-middleware.ts
+++ b/packages/angular/build/src/tools/vite/middlewares/html-fallback-middleware.ts
@@ -7,6 +7,7 @@
  */
 
 import type { ServerResponse } from 'node:http';
+import { basename } from 'node:path/posix';
 import type { Connect } from 'vite';
 import { lookupMimeTypeFromRequest } from '../utils';
 
@@ -29,7 +30,7 @@ export function angularHtmlFallbackMiddleware(
   if (req.url) {
     // No fallback for dotfile requests (e.g., .env, .npmrc)
     const pathname = req.url.split('?')[0];
-    const lastSegment = pathname.substring(pathname.lastIndexOf('/') + 1);
+    const lastSegment = basename(pathname);
     if (lastSegment.startsWith('.')) {
       next();
 


### PR DESCRIPTION
## Description

Currently, the Angular dev server's HTML fallback middleware rewrites requests for dotfiles (such as `/.env`, `/.npmrc`, `/.htpasswd`) to `/index.html` and returns a `200 OK` response. This happens because `path.extname()` treats leading-dot filenames as extensionless (e.g., `extname('.env')` returns `''`), so `lookupMimeTypeFromRequest` returns `undefined` and these requests fall through the existing MIME type check to the SPA fallback logic.

While the actual file contents are not leaked (the response body is the Angular app's `index.html`), returning `200` for sensitive dotfiles is not ideal. Explicitly skipping the SPA fallback for dotfile requests would be a small defense-in-depth improvement, especially when the dev server is exposed to the network via `--host`.

This PR adds a check in `angularHtmlFallbackMiddleware` to skip the HTML fallback for requests where the last path segment starts with `.` (e.g., `/.env`, `/.npmrc`). The check uses `url.split('?')[0]`, which is the same pattern already used internally by `lookupMimeTypeFromRequest`. Instead of rewriting to `/index.html`, these requests are passed to `next()`, which will result in a `404` from downstream middleware.

## Motivation

I noticed this behavior while researching how various frameworks handle sensitive file access on their dev servers. The Angular dev server already has good protection through its strict `server.fs.allow` configuration, but adding this small check makes the behavior more explicit and prevents dotfile URLs from being silently rewritten to `index.html`.

## Changes

- **`html-fallback-middleware.ts`**: Added a dotfile check at the top of the `if (req.url)` block, before the MIME type check. Requests for paths whose last segment starts with `.` (e.g., `/.env`) are no longer rewritten to `/index.html`.

### Before

```
GET /.env       → 200 (index.html content)
GET /.npmrc     → 200 (index.html content)
GET /.htpasswd  → 200 (index.html content)
```

### After

```
GET /.env       → 404
GET /.npmrc     → 404
GET /.htpasswd  → 404
```

Normal Angular routes continue to work as expected (e.g., `GET /dashboard` → `200` with `index.html`).

Made with [Cursor](https://cursor.com)