### PR TITLE
fix(@angular/ssr): ensure unique values in redirect response Vary header

### DIFF
--- a/packages/angular/ssr/src/utils/redirect.ts
+++ b/packages/angular/ssr/src/utils/redirect.ts
@@ -50,13 +50,18 @@ export function createRedirectResponse(
     );
   }
 
-  let vary = resHeaders.get('Vary') ?? '';
-  if (vary) {
-    vary += ', ';
-  }
-  vary += 'X-Forwarded-Prefix';
+  // Ensure unique values for Vary header
+  const varyArray = resHeaders.get('Vary')?.split(',') ?? [];
+  const varySet = new Set(['X-Forwarded-Prefix']);
+  for (const vary of varyArray) {
+    const value = vary.trim();
 
-  resHeaders.set('Vary', vary);
+    if (value) {
+      varySet.add(value);
+    }
+  }
+
+  resHeaders.set('Vary', [...varySet].join(', '));
   resHeaders.set('Location', location);
 
   return new Response(null, {

--- a/packages/angular/ssr/test/utils/redirect_spec.ts
+++ b/packages/angular/ssr/test/utils/redirect_spec.ts
@@ -36,7 +36,14 @@ describe('Redirect Utils', () => {
         'Vary': 'Host',
       });
       expect(response.headers.get('Location')).toBe('/home');
-      expect(response.headers.get('Vary')).toBe('Host, X-Forwarded-Prefix');
+      expect(response.headers.get('Vary')).toBe('X-Forwarded-Prefix, Host');
+    });
+
+    it('should NOT add duplicate X-Forwarded-Prefix if already present in Vary header', () => {
+      const response = createRedirectResponse('/home', 302, {
+        'Vary': 'X-Forwarded-Prefix, Host',
+      });
+      expect(response.headers.get('Vary')).toBe('X-Forwarded-Prefix, Host');
     });
 
     it('should warn if Location header is provided in extra headers in dev mode', () => {


### PR DESCRIPTION
Refactors the `createRedirectResponse` function to use a `Set` for constructing the `Vary` header. This ensures that `X-Forwarded-Prefix` is always present exactly once, and that existing `Vary` values from provided headers are correctly parsed, deduplicated, and preserved.

Updates the associated unit tests to reflect the new header order and verify the deduplication logic.
