### PR TITLE
fix(@angular/cli): use parsed package name for migrate-only updates

### DIFF
--- a/packages/angular/cli/src/commands/update/cli.ts
+++ b/packages/angular/cli/src/commands/update/cli.ts
@@ -265,7 +265,7 @@ export default class UpdateCommandModule extends CommandModule<UpdateCommandArgs
     return options.migrateOnly
       ? this.migrateOnly(
           workflow,
-          (options.packages ?? [])[0],
+          packages[0].name as string,
           rootDependencies,
           options,
           packageManager,


### PR DESCRIPTION
This change updates the update command to use the parsed package name from `npm-package-arg` instead of the raw input string when performing a 'migrate-only' update. This ensures that package identifiers are correctly and consistently handled.
