### PR TITLE
feat(@schematics/angular): add `refactor-fake-async` migration

### DIFF
--- a/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.ts
@@ -14,6 +14,10 @@
  */
 
 import ts from '../../third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import { transformFakeAsyncFlush } from './transformers/fake-async-flush';
+import { transformFakeAsyncFlushMicrotasks } from './transformers/fake-async-flush-microtasks';
+import { transformFakeAsyncTest } from './transformers/fake-async-test';
+import { transformFakeAsyncTick } from './transformers/fake-async-tick';
 import {
   transformDoneCallback,
   transformFocusedAndSkippedTests,
@@ -46,7 +50,11 @@ import {
   transformSpyReset,
 } from './transformers/jasmine-spy';
 import { transformJasmineTypes } from './transformers/jasmine-type';
-import { addVitestValueImport, getVitestAutoImports } from './utils/ast-helpers';
+import {
+  addVitestValueImport,
+  getVitestAutoImports,
+  removeImportSpecifiers,
+} from './utils/ast-helpers';
 import { RefactorContext } from './utils/refactor-context';
 import { RefactorReporter } from './utils/refactor-reporter';
 
@@ -121,6 +129,10 @@ const callExpressionTransformers = [
   transformSpyCallInspection,
   transformtoHaveBeenCalledBefore,
   transformToHaveClass,
+  transformFakeAsyncTest,
+  transformFakeAsyncTick,
+  transformFakeAsyncFlush,
+  transformFakeAsyncFlushMicrotasks,
 
   // **Stage 3: Global Functions & Cleanup**
   // These handle global Jasmine functions and catch-alls for unsupported APIs.
@@ -179,6 +191,7 @@ export function transformJasmineToVitest(
 
   const pendingVitestValueImports = new Set<string>();
   const pendingVitestTypeImports = new Set<string>();
+  const pendingImportSpecifierRemovals = new Map<string, Set<string>>();
 
   const transformer: ts.TransformerFactory<ts.SourceFile> = (context) => {
     const refactorCtx: RefactorContext = {
@@ -187,6 +200,7 @@ export function transformJasmineToVitest(
       tsContext: context,
       pendingVitestValueImports,
       pendingVitestTypeImports,
+      pendingImportSpecifierRemovals,
     };
 
     const visitor: ts.Visitor = (node) => {
@@ -240,14 +254,23 @@ export function transformJasmineToVitest(
 
   const hasPendingValueImports = pendingVitestValueImports.size > 0;
   const hasPendingTypeImports = pendingVitestTypeImports.size > 0;
+  const hasPendingImportSpecifierRemovals = pendingImportSpecifierRemovals.size > 0;
 
   if (
     transformedSourceFile === sourceFile &&
     !reporter.hasTodos &&
     !hasPendingValueImports &&
-    !hasPendingTypeImports
+    !hasPendingTypeImports &&
+    !hasPendingImportSpecifierRemovals
   ) {
     return content;
+  }
+
+  if (hasPendingImportSpecifierRemovals) {
+    transformedSourceFile = removeImportSpecifiers(
+      transformedSourceFile,
+      pendingImportSpecifierRemovals,
+    );
   }
 
   if (hasPendingTypeImports || (options.addImports && hasPendingValueImports)) {

--- a/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer_add-imports_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer_add-imports_spec.ts
@@ -116,4 +116,26 @@ describe('Jasmine to Vitest Transformer - addImports option', () => {
       `;
     await expectTransformation(input, expected, true);
   });
+
+  it('should add imports for `onTestFinished` and `vi` when addImports is true', async () => {
+    const input = `
+        import { fakeAsync } from '@angular/core/testing';
+        
+        it('works', fakeAsync(() => {
+          expect(1).toBe(1);
+        }));
+      `;
+    const expected = `
+        import { expect, it, onTestFinished, vi } from 'vitest';
+
+        it('works', async () => {
+          vi.useFakeTimers();
+          onTestFinished(() => {
+            vi.useRealTimers();
+          });
+          expect(1).toBe(1);
+        });
+      `;
+    await expectTransformation(input, expected, true);
+  });
 });

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-flush-microtasks.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-flush-microtasks.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import ts from '../../../third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import { isNamedImportFrom } from '../utils/ast-helpers';
+import { ANGULAR_CORE_TESTING } from '../utils/constants';
+import { RefactorContext } from '../utils/refactor-context';
+import { addImportSpecifierRemoval, createViCallExpression } from '../utils/refactor-helpers';
+
+export function transformFakeAsyncFlushMicrotasks(node: ts.Node, ctx: RefactorContext): ts.Node {
+  if (
+    !(
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'flushMicrotasks' &&
+      isNamedImportFrom(ctx.sourceFile, 'flushMicrotasks', ANGULAR_CORE_TESTING)
+    )
+  ) {
+    return node;
+  }
+
+  ctx.reporter.reportTransformation(
+    ctx.sourceFile,
+    node,
+    `Transformed \`flushMicrotasks\` to \`await vi.advanceTimersByTimeAsync(0)\`.`,
+  );
+
+  addImportSpecifierRemoval(ctx, 'flushMicrotasks', ANGULAR_CORE_TESTING);
+
+  return ts.factory.createAwaitExpression(
+    createViCallExpression(ctx, 'advanceTimersByTimeAsync', [ts.factory.createNumericLiteral(0)]),
+  );
+}

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-flush-microtasks_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-flush-microtasks_spec.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { expectTransformation } from '../test-helpers';
+
+describe('transformFakeAsyncFlushMicrotasks', () => {
+  const testCases = [
+    {
+      description: 'should replace `flushMicrotasks` with `await vi.advanceTimersByTimeAsync(0)`',
+      input: `
+          import { flushMicrotasks } from '@angular/core/testing';
+          
+          flushMicrotasks();
+        `,
+      expected: `await vi.advanceTimersByTimeAsync(0);`,
+    },
+    {
+      description:
+        'should not replace `flushMicrotasks` if not imported from `@angular/core/testing`',
+      input: `
+          import { flushMicrotasks } from './my-flush-microtasks';
+          
+          flushMicrotasks();
+        `,
+      expected: `
+          import { flushMicrotasks } from './my-flush-microtasks';
+          
+          flushMicrotasks();
+        `,
+    },
+  ];
+
+  testCases.forEach(({ description, input, expected }) => {
+    it(description, async () => {
+      await expectTransformation(input, expected);
+    });
+  });
+});

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-flush.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-flush.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import ts from '../../../third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import { isNamedImportFrom } from '../utils/ast-helpers';
+import { addTodoComment } from '../utils/comment-helpers';
+import { ANGULAR_CORE_TESTING } from '../utils/constants';
+import { RefactorContext } from '../utils/refactor-context';
+import { addImportSpecifierRemoval, createViCallExpression } from '../utils/refactor-helpers';
+
+export function transformFakeAsyncFlush(node: ts.Node, ctx: RefactorContext): ts.Node {
+  if (
+    !(
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'flush' &&
+      isNamedImportFrom(ctx.sourceFile, 'flush', ANGULAR_CORE_TESTING)
+    )
+  ) {
+    return node;
+  }
+
+  ctx.reporter.reportTransformation(
+    ctx.sourceFile,
+    node,
+    `Transformed \`flush\` to \`await vi.runAllTimersAsync()\`.`,
+  );
+
+  addImportSpecifierRemoval(ctx, 'flush', ANGULAR_CORE_TESTING);
+
+  if (node.arguments.length > 0) {
+    ctx.reporter.recordTodo('flush-max-turns', ctx.sourceFile, node);
+    addTodoComment(node, 'flush-max-turns');
+  }
+
+  const awaitRunAllTimersAsync = ts.factory.createAwaitExpression(
+    createViCallExpression(ctx, 'runAllTimersAsync'),
+  );
+
+  if (ts.isExpressionStatement(node.parent)) {
+    return awaitRunAllTimersAsync;
+  } else {
+    // If `flush` is not used as its own statement, then the return value is probably used.
+    // Therefore, we replace it with nullish coalescing that returns 0:
+    // > await vi.runAllTimersAsync() ?? 0;
+    ctx.reporter.recordTodo('flush-return-value', ctx.sourceFile, node);
+    addTodoComment(node, 'flush-return-value');
+
+    return ts.factory.createBinaryExpression(
+      awaitRunAllTimersAsync,
+      ts.SyntaxKind.QuestionQuestionToken,
+      ts.factory.createNumericLiteral(0),
+    );
+  }
+}

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-flush_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-flush_spec.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { expectTransformation } from '../test-helpers';
+
+describe('transformFakeAsyncFlush', () => {
+  const testCases = [
+    {
+      description: 'should replace `flush` with `await vi.runAllTimersAsync()`',
+      input: `
+          import { flush } from '@angular/core/testing';
+          
+          flush();
+        `,
+      expected: `await vi.runAllTimersAsync();`,
+    },
+    {
+      description: 'should add TODO comment when flush is called with maxTurns',
+      input: `
+          import { flush } from '@angular/core/testing';
+
+          flush(42);
+        `,
+      expected: `
+          // TODO: vitest-migration: flush(maxTurns) was called but maxTurns parameter is not migrated. Please migrate manually.
+          await vi.runAllTimersAsync();
+        `,
+    },
+    {
+      description: 'should add TODO comment when flush return value is used',
+      input: `
+          import { flush } from '@angular/core/testing';
+          
+          const turns = flush();
+        `,
+      expected: `
+          // TODO: vitest-migration: flush() return value is not migrated. Please migrate manually.
+          const turns = await vi.runAllTimersAsync() ?? 0;
+        `,
+    },
+    {
+      description: 'should add TODO comment when flush return value is used in a return statement',
+      input: `
+          import { flush } from '@angular/core/testing';
+          
+          async function myFlushWrapper() {
+            return flush();
+          }
+        `,
+      expected: `
+         async function myFlushWrapper() {
+            // TODO: vitest-migration: flush() return value is not migrated. Please migrate manually.
+            return await vi.runAllTimersAsync() ?? 0;
+          }
+        `,
+    },
+    {
+      description: 'should not replace `flush` if not imported from `@angular/core/testing`',
+      input: `
+          import { flush } from './my-flush';
+          
+          flush();
+        `,
+      expected: `
+          import { flush } from './my-flush';
+          
+          flush();
+        `,
+    },
+    {
+      description: 'should keep other imported symbols from `@angular/core/testing`',
+      input: `
+          import { TestBed, flush } from '@angular/core/testing';
+          
+          flush();
+        `,
+      expected: `
+          import { TestBed } from '@angular/core/testing';
+          
+          await vi.runAllTimersAsync();
+        `,
+    },
+    {
+      description: 'should keep imported types from `@angular/core/testing`',
+      input: `
+          import { flush, type ComponentFixture } from '@angular/core/testing';
+          
+          flush();
+        `,
+      expected: `
+          import { type ComponentFixture } from '@angular/core/testing';
+          
+          await vi.runAllTimersAsync();
+        `,
+    },
+  ];
+
+  testCases.forEach(({ description, input, expected }) => {
+    it(description, async () => {
+      await expectTransformation(input, expected);
+    });
+  });
+});

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-test.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-test.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import ts from '../../../third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import { isNamedImportFrom } from '../utils/ast-helpers';
+import { ANGULAR_CORE_TESTING } from '../utils/constants';
+import { RefactorContext } from '../utils/refactor-context';
+import {
+  addImportSpecifierRemoval,
+  createViCallExpression,
+  requireVitestIdentifier,
+} from '../utils/refactor-helpers';
+
+export function transformFakeAsyncTest(node: ts.Node, ctx: RefactorContext): ts.Node {
+  if (
+    !(
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'fakeAsync' &&
+      node.arguments.length >= 1 &&
+      (ts.isArrowFunction(node.arguments[0]) || ts.isFunctionExpression(node.arguments[0])) &&
+      isNamedImportFrom(ctx.sourceFile, 'fakeAsync', ANGULAR_CORE_TESTING)
+    )
+  ) {
+    return node;
+  }
+
+  ctx.reporter.reportTransformation(
+    ctx.sourceFile,
+    node,
+    `Transformed \`fakeAsync\` to \`vi.useFakeTimers\`.`,
+  );
+
+  addImportSpecifierRemoval(ctx, 'fakeAsync', ANGULAR_CORE_TESTING);
+
+  const callback = node.arguments[0];
+  const callbackBody = ts.isBlock(callback.body)
+    ? callback.body
+    : ts.factory.createBlock([ts.factory.createExpressionStatement(callback.body)]);
+
+  const onTestFinished = requireVitestIdentifier(ctx, 'onTestFinished');
+
+  // Generate the following code:
+  // > vi.useFakeTimers();
+  // > onTestFinished(() => {
+  // >  vi.useRealTimers();
+  // > });
+  const setupStatements: ts.Statement[] = [
+    ts.factory.createExpressionStatement(createViCallExpression(ctx, 'useFakeTimers')),
+    ts.factory.createExpressionStatement(
+      ts.factory.createCallExpression(onTestFinished, undefined, [
+        ts.factory.createArrowFunction(
+          undefined,
+          undefined,
+          [],
+          undefined,
+          ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+          ts.factory.createBlock([
+            ts.factory.createExpressionStatement(createViCallExpression(ctx, 'useRealTimers')),
+          ]),
+        ),
+      ]),
+    ),
+    ...callbackBody.statements,
+  ];
+
+  return ts.factory.createArrowFunction(
+    [ts.factory.createModifier(ts.SyntaxKind.AsyncKeyword)],
+    undefined,
+    [],
+    undefined,
+    ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+    ts.factory.createBlock(setupStatements),
+  );
+}

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-test_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-test_spec.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { expectTransformation } from '../test-helpers';
+
+describe('transformFakeAsyncTest', () => {
+  const testCases = [
+    {
+      description: 'should transform fakeAsync test to `vi.useFakeTimers()`',
+      input: `
+          import { fakeAsync } from '@angular/core/testing';
+
+          it('works', fakeAsync(() => {
+            expect(1).toBe(1);
+          }));
+        `,
+      expected: `
+          it('works', async () => {
+            vi.useFakeTimers();
+            onTestFinished(() => {
+              vi.useRealTimers();
+            });
+            expect(1).toBe(1);
+          });
+        `,
+    },
+    {
+      description: 'should not replace `fakeAsync` if not imported from `@angular/core/testing`',
+      input: `
+          import { fakeAsync } from './my-fake-async';
+
+          it('works', fakeAsync(() => {
+            expect(1).toBe(1);
+          }));
+        `,
+      expected: `
+          import { fakeAsync } from './my-fake-async';
+
+          it('works', fakeAsync(() => {
+            expect(1).toBe(1);
+          }));
+        `,
+    },
+  ];
+
+  testCases.forEach(({ description, input, expected }) => {
+    it(description, async () => {
+      await expectTransformation(input, expected);
+    });
+  });
+});

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-tick.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-tick.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import ts from '../../../third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import { isNamedImportFrom } from '../utils/ast-helpers';
+import { ANGULAR_CORE_TESTING } from '../utils/constants';
+import { RefactorContext } from '../utils/refactor-context';
+import { addImportSpecifierRemoval, createViCallExpression } from '../utils/refactor-helpers';
+
+export function transformFakeAsyncTick(node: ts.Node, ctx: RefactorContext): ts.Node {
+  if (
+    !(
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'tick' &&
+      isNamedImportFrom(ctx.sourceFile, 'tick', ANGULAR_CORE_TESTING)
+    )
+  ) {
+    return node;
+  }
+
+  ctx.reporter.reportTransformation(
+    ctx.sourceFile,
+    node,
+    `Transformed \`tick\` to \`await vi.advanceTimersByTimeAsync()\`.`,
+  );
+
+  addImportSpecifierRemoval(ctx, 'tick', ANGULAR_CORE_TESTING);
+
+  const durationNumericLiteral =
+    node.arguments.length > 0 && ts.isNumericLiteral(node.arguments[0])
+      ? node.arguments[0]
+      : ts.factory.createNumericLiteral(0);
+
+  return ts.factory.createAwaitExpression(
+    createViCallExpression(ctx, 'advanceTimersByTimeAsync', [durationNumericLiteral]),
+  );
+}

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-tick_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-tick_spec.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { expectTransformation } from '../test-helpers';
+
+describe('transformFakeAsyncTick', () => {
+  const testCases = [
+    {
+      description: 'should replace `tick` with `vi.advanceTimersByTimeAsync`',
+      input: `
+          import { tick } from '@angular/core/testing';
+          
+          tick(100);
+        `,
+      expected: `await vi.advanceTimersByTimeAsync(100);`,
+    },
+    {
+      description: 'should replace `tick()` with `vi.advanceTimersByTimeAsync(0)`',
+      input: `
+          import { tick } from '@angular/core/testing';
+          
+          tick();
+        `,
+      expected: `await vi.advanceTimersByTimeAsync(0);`,
+    },
+    {
+      description: 'should not replace `tick` if not imported from `@angular/core/testing`',
+      input: `
+          import { tick } from './my-tick';
+          
+          tick(100);
+        `,
+      expected: `
+          import { tick } from './my-tick';
+          
+          tick(100);
+        `,
+    },
+  ];
+
+  testCases.forEach(({ description, input, expected }) => {
+    it(description, async () => {
+      await expectTransformation(input, expected);
+    });
+  });
+});

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-misc.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-misc.ts
@@ -14,16 +14,15 @@
  */
 
 import ts from '../../../third_party/github.com/Microsoft/TypeScript/lib/typescript';
-import { addVitestValueImport, createViCallExpression } from '../utils/ast-helpers';
+import { addVitestValueImport } from '../utils/ast-helpers';
 import { getJasmineMethodName, isJasmineCallExpression } from '../utils/ast-validation';
 import { addTodoComment } from '../utils/comment-helpers';
 import { RefactorContext } from '../utils/refactor-context';
+import { createViCallExpression } from '../utils/refactor-helpers';
 import { TodoCategory } from '../utils/todo-notes';
 
-export function transformTimerMocks(
-  node: ts.Node,
-  { sourceFile, reporter, pendingVitestValueImports }: RefactorContext,
-): ts.Node {
+export function transformTimerMocks(node: ts.Node, ctx: RefactorContext): ts.Node {
+  const { sourceFile, reporter, pendingVitestValueImports } = ctx;
   if (
     !ts.isCallExpression(node) ||
     !ts.isPropertyAccessExpression(node.expression) ||
@@ -71,7 +70,7 @@ export function transformTimerMocks(
       ];
     }
 
-    return createViCallExpression(newMethodName, newArgs);
+    return createViCallExpression(ctx, newMethodName, newArgs);
   }
 
   return node;
@@ -101,10 +100,8 @@ export function transformFail(node: ts.Node, { sourceFile, reporter }: RefactorC
   return node;
 }
 
-export function transformDefaultTimeoutInterval(
-  node: ts.Node,
-  { sourceFile, reporter, pendingVitestValueImports }: RefactorContext,
-): ts.Node {
+export function transformDefaultTimeoutInterval(node: ts.Node, ctx: RefactorContext): ts.Node {
+  const { sourceFile, reporter, pendingVitestValueImports } = ctx;
   if (
     ts.isExpressionStatement(node) &&
     ts.isBinaryExpression(node.expression) &&
@@ -124,7 +121,7 @@ export function transformDefaultTimeoutInterval(
         'Transformed `jasmine.DEFAULT_TIMEOUT_INTERVAL` to `vi.setConfig()`.',
       );
       const timeoutValue = assignment.right;
-      const setConfigCall = createViCallExpression('setConfig', [
+      const setConfigCall = createViCallExpression(ctx, 'setConfig', [
         ts.factory.createObjectLiteralExpression(
           [ts.factory.createPropertyAssignment('testTimeout', timeoutValue)],
           false,

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-spy.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-spy.ts
@@ -14,14 +14,11 @@
  */
 
 import ts from '../../../third_party/github.com/Microsoft/TypeScript/lib/typescript';
-import {
-  addVitestValueImport,
-  createPropertyAccess,
-  createViCallExpression,
-} from '../utils/ast-helpers';
+import { addVitestValueImport, createPropertyAccess } from '../utils/ast-helpers';
 import { getJasmineMethodName, isJasmineCallExpression } from '../utils/ast-validation';
 import { addTodoComment } from '../utils/comment-helpers';
 import { RefactorContext } from '../utils/refactor-context';
+import { createViCallExpression } from '../utils/refactor-helpers';
 
 export function transformSpies(node: ts.Node, refactorCtx: RefactorContext): ts.Node {
   const { sourceFile, reporter, pendingVitestValueImports } = refactorCtx;
@@ -194,7 +191,11 @@ export function transformSpies(node: ts.Node, refactorCtx: RefactorContext): ts.
       );
 
       // jasmine.createSpy(name, originalFn) -> vi.fn(originalFn)
-      return createViCallExpression('fn', node.arguments.length > 1 ? [node.arguments[1]] : []);
+      return createViCallExpression(
+        refactorCtx,
+        'fn',
+        node.arguments.length > 1 ? [node.arguments[1]] : [],
+      );
     case 'spyOnAllFunctions': {
       reporter.reportTransformation(
         sourceFile,
@@ -212,10 +213,8 @@ export function transformSpies(node: ts.Node, refactorCtx: RefactorContext): ts.
   return node;
 }
 
-export function transformCreateSpyObj(
-  node: ts.Node,
-  { sourceFile, reporter, pendingVitestValueImports }: RefactorContext,
-): ts.Node {
+export function transformCreateSpyObj(node: ts.Node, ctx: RefactorContext): ts.Node {
+  const { sourceFile, reporter, pendingVitestValueImports } = ctx;
   if (!isJasmineCallExpression(node, 'createSpyObj')) {
     return node;
   }
@@ -243,9 +242,9 @@ export function transformCreateSpyObj(
   }
 
   if (ts.isArrayLiteralExpression(methods)) {
-    properties = createSpyObjWithArray(methods, baseName);
+    properties = createSpyObjWithArray(ctx, methods, baseName);
   } else if (ts.isObjectLiteralExpression(methods)) {
-    properties = createSpyObjWithObject(methods, baseName);
+    properties = createSpyObjWithObject(ctx, methods, baseName);
   } else {
     const category = 'createSpyObj-dynamic-variable';
     reporter.recordTodo(category, sourceFile, node);
@@ -268,13 +267,14 @@ export function transformCreateSpyObj(
 }
 
 function createSpyObjWithArray(
+  ctx: RefactorContext,
   methods: ts.ArrayLiteralExpression,
   baseName: string | undefined,
 ): ts.PropertyAssignment[] {
   return methods.elements
     .map((element) => {
       if (ts.isStringLiteral(element)) {
-        const mockFn = createViCallExpression('fn');
+        const mockFn = createViCallExpression(ctx, 'fn');
         const methodName = element.text;
         let finalExpression: ts.Expression = mockFn;
 
@@ -298,6 +298,7 @@ function createSpyObjWithArray(
 }
 
 function createSpyObjWithObject(
+  ctx: RefactorContext,
   methods: ts.ObjectLiteralExpression,
   baseName: string | undefined,
 ): ts.PropertyAssignment[] {
@@ -306,7 +307,7 @@ function createSpyObjWithObject(
       if (ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name)) {
         const methodName = prop.name.text;
         const returnValue = prop.initializer;
-        let mockFn = createViCallExpression('fn');
+        let mockFn = createViCallExpression(ctx, 'fn');
 
         if (baseName) {
           mockFn = ts.factory.createCallExpression(

--- a/packages/schematics/angular/refactor/jasmine-vitest/utils/ast-helpers.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/utils/ast-helpers.ts
@@ -48,30 +48,15 @@ export function getVitestAutoImports(
 
   allSpecifiers.sort((a, b) => a.name.text.localeCompare(b.name.text));
 
-  const importClause = ts.factory.createImportClause(
-    isClauseTypeOnly, // Set isTypeOnly on the clause if only type imports
-    undefined,
-    ts.factory.createNamedImports(allSpecifiers),
-  );
-
   return ts.factory.createImportDeclaration(
     undefined,
-    importClause,
+    ts.factory.createImportClause(
+      isClauseTypeOnly, // Set isTypeOnly on the clause if only type imports
+      undefined,
+      ts.factory.createNamedImports(allSpecifiers),
+    ),
     ts.factory.createStringLiteral('vitest'),
   );
-}
-
-export function createViCallExpression(
-  methodName: string,
-  args: readonly ts.Expression[] = [],
-  typeArgs: ts.TypeNode[] | undefined = undefined,
-): ts.CallExpression {
-  const callee = ts.factory.createPropertyAccessExpression(
-    ts.factory.createIdentifier('vi'),
-    methodName,
-  );
-
-  return ts.factory.createCallExpression(callee, typeArgs, args);
 }
 
 export function createExpectCallExpression(
@@ -90,5 +75,104 @@ export function createPropertyAccess(
       ? ts.factory.createIdentifier(expressionOrIndentifierText)
       : expressionOrIndentifierText,
     name,
+  );
+}
+
+/**
+ * Checks if a named binding is imported from the given module in the source file.
+ * @param sourceFile The source file to search for imports.
+ * @param name The import name (e.g. 'flush', 'tick').
+ * @param moduleSpecifier The module path (e.g. '@angular/core/testing').
+ */
+export function isNamedImportFrom(
+  sourceFile: ts.SourceFile,
+  name: string,
+  moduleSpecifier: string,
+): boolean {
+  return sourceFile.statements.some((statement) => {
+    if (!_isImportDeclarationWithNamedBindings(statement)) {
+      return false;
+    }
+
+    const specifier = statement.moduleSpecifier;
+    const modulePath = ts.isStringLiteralLike(specifier) ? specifier.text : null;
+    if (modulePath !== moduleSpecifier) {
+      return false;
+    }
+    for (const element of statement.importClause.namedBindings.elements) {
+      const importedName = element.propertyName ? element.propertyName.text : element.name.text;
+      if (importedName === name) {
+        return true;
+      }
+    }
+  });
+}
+
+/**
+ * Removes specified import specifiers from ImportDeclarations.
+ * If all specifiers are removed from an import, the entire import is dropped.
+ */
+export function removeImportSpecifiers(
+  sourceFile: ts.SourceFile,
+  removals: Map<string, Set<string>>,
+): ts.SourceFile {
+  const newStatements = sourceFile.statements
+    .map((statement) => {
+      if (!_isImportDeclarationWithNamedBindings(statement)) {
+        return statement;
+      }
+
+      const specifier = statement.moduleSpecifier;
+      const modulePath = ts.isStringLiteralLike(specifier) ? specifier.text : null;
+      if (modulePath === null) {
+        return statement;
+      }
+
+      const namesToRemove = removals.get(modulePath);
+      if (namesToRemove === undefined || namesToRemove.size === 0) {
+        return statement;
+      }
+
+      const remaining = statement.importClause.namedBindings.elements.filter((el) => {
+        const name = el.propertyName ? el.propertyName.text : el.name.text;
+
+        return !namesToRemove.has(name);
+      });
+
+      if (remaining.length === 0) {
+        return;
+      }
+
+      if (remaining.length === statement.importClause.namedBindings.elements.length) {
+        return statement;
+      }
+
+      return ts.factory.updateImportDeclaration(
+        statement,
+        statement.modifiers,
+        ts.factory.updateImportClause(
+          statement.importClause,
+          undefined,
+          statement.importClause.name,
+          ts.factory.createNamedImports(remaining),
+        ),
+        statement.moduleSpecifier,
+        statement.attributes,
+      );
+    })
+    .filter((statement) => statement !== undefined);
+
+  return ts.factory.updateSourceFile(sourceFile, newStatements);
+}
+
+function _isImportDeclarationWithNamedBindings(
+  statement: ts.Statement,
+): statement is ts.ImportDeclaration & {
+  importClause: ts.ImportClause & { namedBindings: ts.NamedImports };
+} {
+  return (
+    ts.isImportDeclaration(statement) &&
+    statement.importClause?.namedBindings !== undefined &&
+    ts.isNamedImports(statement.importClause.namedBindings)
   );
 }

--- a/packages/schematics/angular/refactor/jasmine-vitest/utils/constants.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/utils/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+export const ANGULAR_CORE_TESTING = '@angular/core/testing';

--- a/packages/schematics/angular/refactor/jasmine-vitest/utils/refactor-context.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/utils/refactor-context.ts
@@ -28,6 +28,12 @@ export interface RefactorContext {
 
   /** A set of Vitest type imports to be added to the file. */
   readonly pendingVitestTypeImports: Set<string>;
+
+  /**
+   * Map of module specifier -> names to remove from that import.
+   * Used when transforming identifiers that become inlined (e.g. flush -> vi.runAllTimersAsync).
+   */
+  readonly pendingImportSpecifierRemovals: Map<string, Set<string>>;
 }
 
 /**

--- a/packages/schematics/angular/refactor/jasmine-vitest/utils/refactor-helpers.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/utils/refactor-helpers.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import ts from '../../../third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import { RefactorContext } from './refactor-context';
+
+/**
+ * Marks an identifier to be removed from an import specifier.
+ *
+ * @param ctx The refactor context object.
+ * @param name The name of the identifier to remove from the import specifier.
+ * @param moduleSpecifier The module specifier to remove the identifier from.
+ */
+export function addImportSpecifierRemoval(
+  ctx: RefactorContext,
+  name: string,
+  moduleSpecifier: string,
+): void {
+  const removals = ctx.pendingImportSpecifierRemovals.get(moduleSpecifier) ?? new Set<string>();
+  removals.add(name);
+  ctx.pendingImportSpecifierRemovals.set(moduleSpecifier, removals);
+}
+
+/**
+ * Creates a call expression to a vitest method.
+ * This also adds the `vi` identifier to the context object,
+ * to import it later if addImports option is enabled.
+ *
+ * @param ctx The refactor context object.
+ * @param args The arguments to pass to the method.
+ * @param typeArgs The type arguments to pass to the method.
+ * @param methodeName The name of the vitest method to call.
+ * @returns The created identifier node.
+ */
+export function createViCallExpression(
+  ctx: RefactorContext,
+  methodName: string,
+  args: readonly ts.Expression[] = [],
+  typeArgs: ts.TypeNode[] | undefined = undefined,
+): ts.CallExpression {
+  const vi = requireVitestIdentifier(ctx, 'vi');
+  const callee = ts.factory.createPropertyAccessExpression(vi, methodName);
+
+  return ts.factory.createCallExpression(callee, typeArgs, args);
+}
+
+/**
+ * Creates an identifier for a vitest value import.
+ * This also adds the identifier to the context object,
+ * to import it later if addImports option is enabled.
+ *
+ * @param ctx The refactor context object.
+ * @param name The name of the vitest identifier to require.
+ * @returns The created identifier node.
+ */
+export function requireVitestIdentifier(ctx: RefactorContext, name: string): ts.Identifier {
+  ctx.pendingVitestValueImports.add(name);
+
+  return ts.factory.createIdentifier(name);
+}

--- a/packages/schematics/angular/refactor/jasmine-vitest/utils/todo-notes.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/utils/todo-notes.ts
@@ -127,6 +127,13 @@ export const TODO_NOTES = {
   'unhandled-done-usage': {
     message: "The 'done' callback was used in an unhandled way. Please migrate manually.",
   },
+  'flush-max-turns': {
+    message:
+      'flush(maxTurns) was called but maxTurns parameter is not migrated. Please migrate manually.',
+  },
+  'flush-return-value': {
+    message: 'flush() return value is not migrated. Please migrate manually.',
+  },
 } as const;
 
 /**


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [X] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There is no migration from `fakeAsync` to Vitest fake timer APIs.

Issue Number: N/A

## What is the new behavior?

The current migration transforms the following test:

```ts
it("should work", fakeAsync(() => {
  let value = 0;

  setTimeout(() => value = 42, 100);

  tick(100);
  flush();

  expect(value).toBe(42);
}));
```

into:

```ts
import { onTestFinished, vi } from 'vitest';

it("should work", async () => {
  vi.useFakeTimers();
  onTestFinished(() => {
    vi.useRealTimers();
  });  

  let value = 0;

  setTimeout(() => value = 42, 100);

  await vi.advanceTimersByTimeAsync(100);
  await vi.runAllTimersAsync();

  expect(value).toBe(42);
});
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Open Questions
-  This migration could be part of the jasmine-vitest migration. Should I moved it there and add an opt-out?
- `flushMicrotasks` can only be partially reproduced (i.e. explicit `queueMicrotask` calls), transforming it have high chances of producing a broken test. Should we just skip transforming tests that use it?
- Should we generate code that measures time "manually" when the return value of `flush` is used?
- Should we generate an "ad-hoc" function in the test file that reproduces `flush`'s `maxTurns` option?
- What should we do about `processNewMacroTasksSynchronously` option?
- This only migrates `flush` and `tick` if used inside `fakeAsync` but it's probably better to just replace in the whole file as users might create some wrappers. What do you think?
