### PR TITLE
fix(@angular/build): remove default for unit-test coverage option

### DIFF
--- a/packages/angular/build/src/builders/unit-test/schema.json
+++ b/packages/angular/build/src/builders/unit-test/schema.json
@@ -75,8 +75,7 @@
     },
     "coverage": {
       "type": "boolean",
-      "description": "Enables coverage reporting for tests.",
-      "default": false
+      "description": "Enables coverage reporting for tests. If not specified, the coverage configuration from a runner configuration file will be used if present. Otherwise, coverage is disabled by default."
     },
     "coverageInclude": {
       "type": "array",

--- a/packages/angular/build/src/builders/unit-test/tests/behavior/runner-config-vitest_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/behavior/runner-config-vitest_spec.ts
@@ -92,6 +92,31 @@ describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
       harness.expectFile('coverage/test/coverage-final.json').toExist();
     });
 
+    it('should enable coverage when set in runnerConfig file without builder option', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        runnerConfig: 'vitest.config.ts',
+      });
+
+      harness.writeFile(
+        'vitest.config.ts',
+        `
+        import { defineConfig } from 'vitest/config';
+        export default defineConfig({
+          test: {
+            coverage: {
+              enabled: true,
+            },
+          },
+        });
+        `,
+      );
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      harness.expectFile('coverage/test/coverage-final.json').toExist();
+    });
+
     it('should exclude test files based on runnerConfig file', async () => {
       harness.useTarget('test', {
         ...BASE_OPTIONS,


### PR DESCRIPTION
Removing the default value of `false` for the `coverage` schema option in the unit-test builder. When a default was present, it forced the coverage check in the Vitest plugins to override any user-provided `coverage: { enabled: true }` values set within a custom `vitest.config.ts`.

Removing the default explicitly allows the option to be `undefined`, respecting the fallback behavior of the runner configuration.

The description was also updated to explicitly document how the Vitest runner resolves the coverage configuration when the builder flag is omitted.