### PR TITLE
fix(@angular/build): warn when vitest watch config conflicts with builder

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
@@ -377,6 +377,7 @@ export class VitestExecutor implements TestExecutor {
           setupFiles: testSetupFiles,
           projectPlugins,
           include,
+          watch,
         }),
       ],
     };

--- a/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
@@ -46,6 +46,7 @@ interface VitestConfigPluginOptions {
   projectPlugins: Exclude<UserWorkspaceConfig['plugins'], undefined>;
   include: string[];
   optimizeDepsInclude: string[];
+  watch: boolean;
 }
 
 async function findTestEnvironment(
@@ -95,6 +96,14 @@ export async function createVitestConfigPlugin(
             'The Angular CLI Test system will manage test file discovery.',
         );
         delete testConfig.include;
+      }
+
+      if (testConfig?.watch !== undefined && testConfig.watch !== options.watch) {
+        this.warn(
+          `The "test.watch" option in the Vitest configuration file is overridden by the builder's ` +
+            `watch option. Please use the Angular CLI "--watch" option to enable or disable watch mode.`,
+        );
+        delete testConfig.watch;
       }
 
       // Merge user-defined plugins from the Vitest config with the CLI's internal plugins.

--- a/packages/angular/build/src/builders/unit-test/tests/behavior/runner-config-vitest_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/behavior/runner-config-vitest_spec.ts
@@ -290,6 +290,39 @@ describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
       // );
     });
 
+    it('should warn and ignore "test.watch" option from runnerConfig file', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        watch: false,
+        runnerConfig: 'vitest.config.ts',
+      });
+
+      harness.writeFile(
+        'vitest.config.ts',
+        `
+        import { defineConfig } from 'vitest/config';
+        export default defineConfig({
+          test: {
+            watch: true,
+          },
+        });
+        `,
+      );
+
+      const { result, logs } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+
+      // TODO: Re-enable once Vite logs are remapped through build system
+      // expect(logs).toContain(
+      //   jasmine.objectContaining({
+      //     level: 'warn',
+      //     message: jasmine.stringMatching(
+      //       'The "test.watch" option in the Vitest configuration file is overridden by the builder\\'s watch option.',
+      //     ),
+      //   }),
+      // );
+    });
+
     it(`should append "test.setupFiles" (string) from runnerConfig to the CLI's setup`, async () => {
       harness.useTarget('test', {
         ...BASE_OPTIONS,


### PR DESCRIPTION
Added a warning in the `angular:vitest-configuration` plugin to alert users if the `watch` option specified in their `vitest.config.ts` differs from the Angular CLI builder's `--watch` option. Because the Angular CLI's build system and file watcher drives the execution, the Vitest-specific `watch` option is overridden and has no effect.