### PR TITLE
fix(@angular/ssr): validate decoded x-forwarded-prefix before prefix checks

### DIFF
--- a/packages/angular/ssr/src/utils/validation.ts
+++ b/packages/angular/ssr/src/utils/validation.ts
@@ -268,9 +268,18 @@ function validateHeaders(request: Request): void {
   }
 
   const xForwardedPrefix = getFirstHeaderValue(headers.get('x-forwarded-prefix'));
-  if (xForwardedPrefix && INVALID_PREFIX_REGEX.test(xForwardedPrefix)) {
-    throw new Error(
-      'Header "x-forwarded-prefix" must not start with "\\" or multiple "/" or contain ".", ".." path segments.',
-    );
+  if (xForwardedPrefix) {
+    let decodedXForwardedPrefix: string;
+    try {
+      decodedXForwardedPrefix = decodeURIComponent(xForwardedPrefix);
+    } catch {
+      throw new Error('Header "x-forwarded-prefix" contains an invalid percent-encoded sequence.');
+    }
+
+    if (INVALID_PREFIX_REGEX.test(decodedXForwardedPrefix)) {
+      throw new Error(
+        'Header "x-forwarded-prefix" must not start with "\\" or multiple "/" or contain ".", ".." path segments.',
+      );
+    }
   }
 }

--- a/packages/angular/ssr/test/utils/validation_spec.ts
+++ b/packages/angular/ssr/test/utils/validation_spec.ts
@@ -213,6 +213,36 @@ describe('Validation Utils', () => {
           .not.toThrow();
       }
     });
+
+    it('should throw error if x-forwarded-prefix contains percent-encoded invalid prefixes', () => {
+      const inputs = ['%5Cevil.com', '%2F%2Fevil.com', '%2F..%2Fevil.com'];
+
+      for (const prefix of inputs) {
+        const request = new Request('https://example.com', {
+          headers: {
+            'x-forwarded-prefix': prefix,
+          },
+        });
+
+        expect(() => validateRequest(request, allowedHosts, false))
+          .withContext(`Prefix: "${prefix}"`)
+          .toThrowError(
+            'Header "x-forwarded-prefix" must not start with "\\" or multiple "/" or contain ".", ".." path segments.',
+          );
+      }
+    });
+
+    it('should throw error if x-forwarded-prefix contains malformed percent-encoding', () => {
+      const request = new Request('https://example.com', {
+        headers: {
+          'x-forwarded-prefix': '/%ZZ',
+        },
+      });
+
+      expect(() => validateRequest(request, allowedHosts, false)).toThrowError(
+        'Header "x-forwarded-prefix" contains an invalid percent-encoded sequence.',
+      );
+    });
   });
 
   describe('cloneRequestAndPatchHeaders', () => {


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

`X-Forwarded-Prefix` is validated before decoding. In practice that means encoded unsafe values can pass the regex check and only become unsafe later when decoded in SSR URL handling.

Issue Number: N/A

## What is the new behavior?

`X-Forwarded-Prefix` is decoded first during validation. If decoding fails, request validation now returns a clear error for invalid percent-encoding. The existing prefix safety checks are then applied to the decoded value.

Regression tests were added to cover encoded bypass attempts and malformed encoded prefixes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This change is intentionally scoped to header validation only.