### PR TITLE
fix(@angular/ssr): use createRedirectResponse for i18n base-path redirects

### DIFF
--- a/packages/angular/ssr/src/app-engine.ts
+++ b/packages/angular/ssr/src/app-engine.ts
@@ -147,7 +147,7 @@ export class AngularAppEngine {
 
     if (this.supportedLocales.length > 1) {
       // Redirect to the preferred language if i18n is enabled.
-      return this.redirectBasedOnAcceptLanguage(request);
+      return this.redirectBasedOnAcceptLanguage(securedRequest);
     }
 
     return null;

--- a/packages/angular/ssr/src/app-engine.ts
+++ b/packages/angular/ssr/src/app-engine.ts
@@ -10,6 +10,7 @@ import type { AngularServerApp, getOrCreateAngularServerApp } from './app';
 import { Hooks } from './hooks';
 import { getPotentialLocaleIdFromUrl, getPreferredLocale } from './i18n';
 import { EntryPointExports, getAngularAppEngineManifest } from './manifest';
+import { createRedirectResponse } from './utils/redirect';
 import { joinUrlParts } from './utils/url';
 import { cloneRequestAndPatchHeaders, validateRequest } from './utils/validation';
 
@@ -179,13 +180,14 @@ export class AngularAppEngine {
     if (preferredLocale) {
       const subPath = supportedLocales[preferredLocale];
       if (subPath !== undefined) {
-        return new Response(null, {
-          status: 302, // Use a 302 redirect as language preference may change.
-          headers: {
-            'Location': joinUrlParts(pathname, subPath),
-            'Vary': 'Accept-Language',
-          },
-        });
+        const prefix = request.headers.get('X-Forwarded-Prefix') ?? '';
+
+        return createRedirectResponse(
+          joinUrlParts(prefix, pathname, subPath),
+          302,
+          // Use a 302 redirect as language preference may change.
+          { 'Vary': 'Accept-Language' },
+        );
       }
     }
 

--- a/packages/angular/ssr/test/app-engine_spec.ts
+++ b/packages/angular/ssr/test/app-engine_spec.ts
@@ -160,7 +160,21 @@ describe('AngularAppEngine', () => {
         const response = await appEngine.handle(request);
         expect(response?.status).toBe(302);
         expect(response?.headers.get('Location')).toBe('/it');
-        expect(response?.headers.get('Vary')).toBe('Accept-Language');
+        expect(response?.headers.get('Vary')).toBe('X-Forwarded-Prefix, Accept-Language');
+      });
+
+      it('should include forwarded prefix in locale redirect location when present', async () => {
+        const request = new Request('https://example.com', {
+          headers: {
+            'Accept-Language': 'it',
+            'X-Forwarded-Prefix': '/app',
+          },
+        });
+
+        const response = await appEngine.handle(request);
+        expect(response?.status).toBe(302);
+        expect(response?.headers.get('Location')).toBe('/app/it');
+        expect(response?.headers.get('Vary')).toBe('X-Forwarded-Prefix, Accept-Language');
       });
 
       it('should return null for requests to file-like resources in a locale', async () => {


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The Accept-Language redirect path in `AngularAppEngine` constructs a redirect response directly instead of using the shared redirect helper. As a result, that path does not include forwarded prefix context in `Location`, and the `Vary` header omits `X-Forwarded-Prefix`.

Issue Number: N/A

## What is the new behavior?

The locale redirect path now uses `createRedirectResponse`, matching the rest of SSR redirect handling. Redirect responses now:
- Build `Location` with `X-Forwarded-Prefix` when present.
- Include `Vary: X-Forwarded-Prefix, Accept-Language`.

Regression tests were added to verify both header semantics and prefixed redirect behavior.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This PR is intentionally scoped to the Accept-Language base-path redirect flow.
