### PR TITLE
ci: block esbuild updates due to a regression

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "baseBranchPatterns": ["main", "21.2.x"],
   "extends": ["github>angular/dev-infra//renovate-presets/default.json5"],
+  "ignoreDeps": ["esbuild"],
   "ignorePaths": ["tests/e2e/assets/**", "tests/schematics/update/packages/**"],
   "packageRules": [
     {


### PR DESCRIPTION

Version 0.27.4 caused a regression which breaks metadata file

See: https://github.com/evanw/esbuild/issues/4420