### PR TITLE
test: ignore HMR disabled console errors

### DIFF
--- a/tests/e2e/utils/puppeteer.ts
+++ b/tests/e2e/utils/puppeteer.ts
@@ -53,7 +53,10 @@ export async function executeBrowserTest(options: BrowserTestOptions = {}) {
         }
       });
       page.on('pageerror', (err) => {
-        errors.push(`${err}`);
+        const error = `${err}`;
+        if (!error.includes('Hot Module Replacement is disabled')) {
+          errors.push(error);
+        }
       });
 
       await page.goto(url);


### PR DESCRIPTION
The e2e test utility now ignores browser console errors containing the string "Hot Module Replacement is disabled". This prevents tests from failing when running with HMR disabled.