### PR TITLE
feat(@schematics/angular): rely on strict template default in generated workspaces

### DIFF
--- a/packages/schematics/angular/workspace/files/tsconfig.json.template
+++ b/packages/schematics/angular/workspace/files/tsconfig.json.template
@@ -18,8 +18,8 @@
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false<% if (strict) { %>,
     "strictInjectionParameters": true,
-    "strictInputAccessModifiers": true,
-    "strictTemplates": true<% } %>
+    "strictInputAccessModifiers": true<% } else { %>,
+    "strictTemplates": false<% } %>
   },
   "files": []
 }

--- a/packages/schematics/angular/workspace/index_spec.ts
+++ b/packages/schematics/angular/workspace/index_spec.ts
@@ -114,6 +114,8 @@ describe('Workspace Schematic', () => {
     );
     expect(compilerOptions.strict).toBeTrue();
     expect(angularCompilerOptions.strictTemplates).toBeUndefined();
+    expect(angularCompilerOptions.strictInputAccessModifiers).toBeTrue();
+    expect(angularCompilerOptions.strictInjectionParameters).toBeTrue();
   });
 
   it('should add vscode testing configuration', async () => {

--- a/packages/schematics/angular/workspace/index_spec.ts
+++ b/packages/schematics/angular/workspace/index_spec.ts
@@ -99,9 +99,9 @@ describe('Workspace Schematic', () => {
       tree.readContent('tsconfig.json').toString(),
     );
     expect(compilerOptions.strict).toBeUndefined();
-    expect(
-      Object.keys(angularCompilerOptions).filter((option) => option.startsWith('strict')),
-    ).toEqual([]);
+    expect(angularCompilerOptions.strictTemplates).toBeFalse();
+    expect(angularCompilerOptions.strictInputAccessModifiers).toBeUndefined();
+    expect(angularCompilerOptions.strictInjectionParameters).toBeUndefined();
   });
 
   it('should add strict compiler options when true', async () => {
@@ -112,8 +112,8 @@ describe('Workspace Schematic', () => {
     const { compilerOptions, angularCompilerOptions } = parseJson(
       tree.readContent('tsconfig.json').toString(),
     );
-    expect(compilerOptions.strict).toBe(true);
-    expect(angularCompilerOptions.strictTemplates).toBe(true);
+    expect(compilerOptions.strict).toBeTrue();
+    expect(angularCompilerOptions.strictTemplates).toBeUndefined();
   });
 
   it('should add vscode testing configuration', async () => {


### PR DESCRIPTION

Since strict templates are now the default in the Angular compiler, this change removes the explicit "strictTemplates": true setting when creating a new strict workspace. We now only explicitly set "strictTemplates": false when the workspace is created with --strict=false to maintain consistent behavior for non-strict setups.


See: https://github.com/angular/angular/pull/67802