### PR TITLE
fix(@angular/cli): restore console methods after logger completes

### DIFF
--- a/packages/angular/cli/lib/cli/index.ts
+++ b/packages/angular/cli/lib/cli/index.ts
@@ -40,6 +40,7 @@ export default async function (options: { cliArgs: string[] }) {
   };
   const logger = new logging.IndentLogger('cli-main-logger');
   const logInfo = console.log;
+  const logWarn = console.warn;
   const logError = console.error;
   const useColor = supportColor();
 
@@ -109,5 +110,11 @@ export default async function (options: { cliArgs: string[] }) {
   } finally {
     logger.complete();
     await loggerFinished;
+
+    // Restore original console methods so that late consumers
+    // (e.g. process.on('exit') handlers) still produce output.
+    console.log = console.info = logInfo;
+    console.warn = logWarn;
+    console.error = logError;
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

`console.log()` when called after `finally` will be dropped. This could become an issue if code prints late like `eslint` which uses `process.on("exit")` to print timing information. This code will run after the logger has completed and will be dropped.

This means that `TIMING=all ng lint` does not work, eventhough `eslint` is seeing the var and collecting the data, but fails to print because `console.log()` is dead.

## What is the new behavior?

<!-- Please describe the new behavior that. -->

Once the logger is completed, we reinsert `console.log`, `console.info`, `console.warn` and `console.error` so that any console logs that happens to trigger as the process is exiting, will still be printed to stdout.

Maybe there's a way to keep the logger living for longer, but since it's doing asyncronous things, I don't think we can clean it up in `process.on('exit')` or similiar? This fix at least prints to stdout as a best effort.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Ran into this issue by trying to print the timing information when using `ng lint` (angular-eslint), and realised that they werent doing anything weird, the console log was running, it was just disapparing. After some more tracking I realised that angular-cli was the one hijacking console.log(), so hoping to clean out this little tripwire.