### PR TITLE
fix(@angular/ssr): patch Headers.forEach in cloneRequestAndPatchHeaders

### DIFF
--- a/packages/angular/ssr/src/utils/validation.ts
+++ b/packages/angular/ssr/src/utils/validation.ts
@@ -151,6 +151,19 @@ export function cloneRequestAndPatchHeaders(
     };
   };
 
+  const originalForEach = headers.forEach;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  (headers.forEach as typeof originalForEach) = function (callback, thisArg) {
+    originalForEach.call(
+      headers,
+      (value, key, parent) => {
+        validateHeader(key, value, allowedHosts, onError);
+        callback.call(thisArg, value, key, parent);
+      },
+      thisArg,
+    );
+  };
+
   // Ensure for...of loops use the new patched entries
   (headers[Symbol.iterator] as typeof originalEntries) = headers.entries;
 

--- a/packages/angular/ssr/test/utils/validation_spec.ts
+++ b/packages/angular/ssr/test/utils/validation_spec.ts
@@ -325,5 +325,24 @@ describe('Validation Utils', () => {
         }),
       );
     });
+
+    it('should validate headers when iterating with forEach()', async () => {
+      const req = new Request('http://example.com', {
+        headers: { 'host': 'evil.com' },
+      });
+      const { request: secured, onError } = cloneRequestAndPatchHeaders(req, allowedHosts);
+
+      expect(() => {
+        secured.headers.forEach(() => {
+          // access the header to trigger the validation
+        });
+      }).toThrowError('Header "host" with value "evil.com" is not allowed.');
+
+      await expectAsync(onError).toBeResolvedTo(
+        jasmine.objectContaining({
+          message: jasmine.stringMatching('Header "host" with value "evil.com" is not allowed.'),
+        }),
+      );
+    });
   });
 });


### PR DESCRIPTION
This commit updates the cloneRequestAndPatchHeaders function to patch the Headers.forEach method. This ensures that host headers are validated when the application iterates over request headers using forEach, preventing potential host header injection attacks during header iteration.

A unit test has been added to validation_spec.ts to verify that forEach correctly triggers validation and throws an error for disallowed hosts.
