### PR TITLE
fix(ssr): allow underscores in host validation

### DIFF
--- a/packages/angular/ssr/src/utils/validation.ts
+++ b/packages/angular/ssr/src/utils/validation.ts
@@ -24,7 +24,7 @@ const VALID_PROTO_REGEX = /^https?$/i;
 /**
  * Regular expression to validate that the host is a valid hostname.
  */
-const VALID_HOST_REGEX = /^[a-z0-9.:-]+$/i;
+const VALID_HOST_REGEX = /^[a-z0-9_.-]+(:[0-9]+)?$/i;
 
 /**
  * Regular expression to validate that the prefix is valid.


### PR DESCRIPTION
The VALID_HOST_REGEX has been updated to include the underscore character. This ensures that hostnames containing underscores (e.g., in some internal or development environments) are correctly validated instead of being rejected.

Closes #32835
