### PR TITLE
test: use eager change detection in fake-async test component

### DIFF
--- a/packages/angular/build/src/builders/karma/tests/behavior/fake-async_spec.ts
+++ b/packages/angular/build/src/builders/karma/tests/behavior/fake-async_spec.ts
@@ -18,12 +18,13 @@ describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget) => {
     it('loads zone.js/testing at the right time', async () => {
       await harness.writeFiles({
         './src/app/app.component.ts': `
-            import { Component } from '@angular/core';
+            import { ChangeDetectionStrategy, Component } from '@angular/core';
 
             @Component({
               selector: 'app-root',
               standalone: false,
               template: '<button (click)="changeMessage()" class="change">{{ message }}</button>',
+              changeDetection: ChangeDetectionStrategy.Eager
             })
             export class AppComponent {
               message = 'Initial';

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/fake-async_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/fake-async_spec.ts
@@ -18,12 +18,13 @@ describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget) => {
     it('loads zone.js/testing at the right time', async () => {
       await harness.writeFiles({
         './src/app/app.component.ts': `
-            import { Component } from '@angular/core';
+            import { ChangeDetectionStrategy, Component } from '@angular/core';
 
             @Component({
               selector: 'app-root',
               standalone: false,
               template: '<button (click)="changeMessage()" class="change">{{ message }}</button>',
+              changeDetection: ChangeDetectionStrategy.Eager
             })
             export class AppComponent {
               message = 'Initial';


### PR DESCRIPTION
The `AppComponent` template used within the `fake-async_spec.ts` files is updated to use `ChangeDetectionStrategy.Eager`. This ensures that change detection is triggered immediately as expected for these specific behavior tests.
