### PR TITLE
perf(@angular/cli): lazily initialize package manager in command context

### DIFF
--- a/goldens/public-api/angular_devkit/core/index.api.md
+++ b/goldens/public-api/angular_devkit/core/index.api.md
@@ -982,7 +982,7 @@ interface SimpleMemoryHostStats {
 // @public (undocumented)
 interface SmartDefaultProvider<T> {
     // (undocumented)
-    (schema: JsonObject): T | Observable<T>;
+    (schema: JsonObject): T | Observable<T> | Promise<T>;
 }
 
 // @public

--- a/packages/angular/cli/src/command-builder/architect-base-command-module.ts
+++ b/packages/angular/cli/src/command-builder/architect-base-command-module.ts
@@ -189,7 +189,7 @@ export abstract class ArchitectBaseCommandModule<T extends object>
     } catch (e) {
       assertIsError(e);
       if (e.code === 'MODULE_NOT_FOUND') {
-        this.warnOnMissingNodeModules();
+        await this.warnOnMissingNodeModules();
         throw new CommandModuleError(`Could not find the '${builderConf}' builder's node package.`);
       }
 
@@ -203,7 +203,7 @@ export abstract class ArchitectBaseCommandModule<T extends object>
     );
   }
 
-  private warnOnMissingNodeModules(): void {
+  private async warnOnMissingNodeModules(): Promise<void> {
     const basePath = this.context.workspace?.basePath;
     if (!basePath) {
       return;
@@ -218,7 +218,9 @@ export abstract class ArchitectBaseCommandModule<T extends object>
     } catch {}
 
     this.context.logger.warn(
-      `Node packages may not be installed. Try installing with '${this.context.packageManager.name} install'.`,
+      `Node packages may not be installed. Try installing with '${
+        (await this.context.packageManager).name
+      } install'.`,
     );
   }
 

--- a/packages/angular/cli/src/command-builder/command-module.ts
+++ b/packages/angular/cli/src/command-builder/command-module.ts
@@ -153,12 +153,23 @@ export abstract class CommandModule<T extends {} = {}> implements CommandModuleI
       ['version', 'update', 'analytics'].includes(this.commandName),
     );
 
-    return userId
-      ? new AnalyticsCollector(this.context.logger, userId, {
-          name: this.context.packageManager.name,
-          version: await this.context.packageManager.getVersion(),
-        })
-      : undefined;
+    if (!userId) {
+      return undefined;
+    }
+
+    try {
+      const packageManager = await this.context.packageManager;
+
+      return new AnalyticsCollector(this.context.logger, userId, {
+        name: packageManager.name,
+        version: await packageManager.getVersion(),
+      });
+    } catch (e) {
+      // If this fails it shouldn't be a fatal error.
+      this.context.logger.error(`Failed to get package manager info for analytics: ${e}`);
+
+      return undefined;
+    }
   }
 
   /**

--- a/packages/angular/cli/src/command-builder/command-runner.ts
+++ b/packages/angular/cli/src/command-builder/command-runner.ts
@@ -18,7 +18,7 @@ import {
   RootCommands,
   RootCommandsAliases,
 } from '../commands/command-config';
-import { createPackageManager } from '../package-managers';
+import { PackageManager, createPackageManager } from '../package-managers';
 import { ConfiguredPackageManagerInfo } from '../package-managers/factory';
 import { colors } from '../utilities/color';
 import { AngularWorkspace, getProjectByCwd, getWorkspace } from '../utilities/config';
@@ -65,20 +65,8 @@ export async function runCommand(args: string[], logger: logging.Logger): Promis
   }
 
   const root = workspace?.basePath ?? process.cwd();
-  const cacheConfig = workspace && getCacheConfig(workspace);
-  const packageManager = await createPackageManager({
-    cwd: root,
-    logger,
-    dryRun: dryRun || help || jsonHelp || getYargsCompletions,
-    tempDirectory: cacheConfig?.enabled ? cacheConfig.path : undefined,
-    configuredPackageManager: await getConfiguredPackageManager(
-      root,
-      workspace,
-      globalConfiguration,
-    ),
-  });
-
   const localYargs = yargs(args);
+  let packageManager: Promise<PackageManager> | undefined;
   const context: CommandContext = {
     globalConfiguration,
     workspace,
@@ -86,7 +74,23 @@ export async function runCommand(args: string[], logger: logging.Logger): Promis
     currentDirectory: process.cwd(),
     yargsInstance: localYargs,
     root,
-    packageManager,
+    get packageManager() {
+      return (packageManager ??= (async () => {
+        const cacheConfig = workspace && getCacheConfig(workspace);
+
+        return createPackageManager({
+          cwd: root,
+          logger,
+          dryRun: dryRun || help || jsonHelp || getYargsCompletions,
+          tempDirectory: cacheConfig?.enabled ? cacheConfig.path : undefined,
+          configuredPackageManager: await getConfiguredPackageManager(
+            root,
+            workspace,
+            globalConfiguration,
+          ),
+        });
+      })());
+    },
     args: {
       positional: positional.map((v) => v.toString()),
       options: {

--- a/packages/angular/cli/src/command-builder/definitions.ts
+++ b/packages/angular/cli/src/command-builder/definitions.ts
@@ -28,7 +28,7 @@ export interface CommandContext {
   workspace?: AngularWorkspace;
   globalConfiguration: AngularWorkspace;
   logger: logging.Logger;
-  packageManager: PackageManager;
+  readonly packageManager: Promise<PackageManager>;
   yargsInstance: Argv<{}>;
 
   /** Arguments parsed in free-from without parser configuration. */

--- a/packages/angular/cli/src/command-builder/schematics-command-module.ts
+++ b/packages/angular/cli/src/command-builder/schematics-command-module.ts
@@ -108,9 +108,9 @@ export abstract class SchematicsCommandModule
     collectionName: string,
     options: SchematicsExecutionOptions,
   ): Promise<NodeWorkflow> {
-    const { logger, root, packageManager } = this.context;
+    const { logger, root } = this.context;
+    const packageManager = await this.context.packageManager;
     const { force, dryRun, packageRegistry } = options;
-
     const workflow = new NodeWorkflow(root, {
       force,
       dryRun,

--- a/packages/angular/cli/src/commands/add/cli.ts
+++ b/packages/angular/cli/src/commands/add/cli.ts
@@ -199,8 +199,8 @@ export default class AddCommandModule
       [
         {
           title: 'Determining Package Manager',
-          task: (_context, task) =>
-            (task.output = `Using package manager: ${color.dim(this.context.packageManager.name)}`),
+          task: async (_context, task) =>
+            (task.output = `Using package manager: ${color.dim((await this.context.packageManager).name)}`),
           rendererOptions: { persistentOutput: true },
         },
         {
@@ -318,7 +318,7 @@ export default class AddCommandModule
   ): Promise<void> {
     const { registry, verbose } = options;
     const { packageIdentifier } = context;
-    const { packageManager } = this.context;
+    const packageManager = await this.context.packageManager;
     const packageName = packageIdentifier.name;
 
     assert(packageName, 'Registry package identifiers should always have a name.');
@@ -416,7 +416,7 @@ export default class AddCommandModule
     },
   ): Promise<PackageManifest | null> {
     const { packageIdentifier } = context;
-    const { packageManager } = this.context;
+    const packageManager = await this.context.packageManager;
     const { registry, verbose, rejectionReasons } = options;
     const packageName = packageIdentifier.name;
     assert(packageName, 'Package name must be defined.');
@@ -491,10 +491,11 @@ export default class AddCommandModule
     options: Options<AddCommandArgs>,
   ): Promise<void> {
     const { registry } = options;
-
+    const packageManager = await this.context.packageManager;
     let manifest;
+
     try {
-      manifest = await this.context.packageManager.getManifest(context.packageIdentifier, {
+      manifest = await packageManager.getManifest(context.packageIdentifier, {
         registry,
       });
     } catch (e) {
@@ -567,7 +568,7 @@ export default class AddCommandModule
   ): Promise<void> {
     const { registry } = options;
     const { packageIdentifier, savePackage } = context;
-    const { packageManager } = this.context;
+    const packageManager = await this.context.packageManager;
 
     // Only show if installation will actually occur
     task.title = 'Installing package';

--- a/packages/angular/cli/src/commands/new/cli.ts
+++ b/packages/angular/cli/src/commands/new/cli.ts
@@ -75,7 +75,7 @@ export default class NewCommandModule
     workflow.registry.addSmartDefaultProvider('ng-cli-version', () => VERSION.full);
     workflow.registry.addSmartDefaultProvider(
       'packageManager',
-      () => this.context.packageManager.name,
+      async () => (await this.context.packageManager).name,
     );
 
     return this.runSchematic({

--- a/packages/angular/cli/src/commands/update/cli.ts
+++ b/packages/angular/cli/src/commands/update/cli.ts
@@ -163,7 +163,8 @@ export default class UpdateCommandModule extends CommandModule<UpdateCommandArgs
   }
 
   async run(options: Options<UpdateCommandArgs>): Promise<number | void> {
-    const { logger, packageManager } = this.context;
+    const { logger } = this.context;
+    const packageManager = await this.context.packageManager;
 
     // Check if the current installed CLI version is older than the latest compatible version.
     // Skip when running `ng update` without a package name as this will not trigger an actual update.
@@ -517,7 +518,7 @@ export default class UpdateCommandModule extends CommandModule<UpdateCommandArgs
         verbose: options.verbose,
         force: options.force,
         next: options.next,
-        packageManager: this.context.packageManager.name,
+        packageManager: (await this.context.packageManager).name,
         packages: packagesToUpdate,
       },
     );

--- a/packages/angular/cli/src/commands/version/version-info.ts
+++ b/packages/angular/cli/src/commands/version/version-info.ts
@@ -103,6 +103,7 @@ export async function gatherVersionInfo(context: CommandContext): Promise<Versio
   }
 
   const angularCoreVersion = packages['@angular/core'];
+  const packageManager = await context.packageManager;
 
   return {
     cli: {
@@ -121,8 +122,8 @@ export async function gatherVersionInfo(context: CommandContext): Promise<Versio
         architecture: process.arch,
       },
       packageManager: {
-        name: context.packageManager.name,
-        version: await context.packageManager.getVersion(),
+        name: packageManager.name,
+        version: await packageManager.getVersion(),
       },
     },
     packages,

--- a/packages/angular_devkit/core/src/json/schema/interface.ts
+++ b/packages/angular_devkit/core/src/json/schema/interface.ts
@@ -39,7 +39,7 @@ export interface SchemaFormat {
 }
 
 export interface SmartDefaultProvider<T> {
-  (schema: JsonObject): T | Observable<T>;
+  (schema: JsonObject): T | Observable<T> | Promise<T>;
 }
 
 export interface SchemaKeywordValidator {

--- a/packages/angular_devkit/core/src/json/schema/registry.ts
+++ b/packages/angular_devkit/core/src/json/schema/registry.ts
@@ -99,7 +99,7 @@ export class CoreSchemaRegistry implements SchemaRegistry {
 
   private _smartDefaultKeyword = false;
   private _promptProvider?: PromptProvider;
-  private _sourceMap = new Map<string, SmartDefaultProvider<{}>>();
+  private _sourceProvider = new Map<string, SmartDefaultProvider<{}>>();
 
   constructor(formats: SchemaFormat[] = []) {
     this._ajv = new Ajv({
@@ -387,11 +387,11 @@ export class CoreSchemaRegistry implements SchemaRegistry {
   }
 
   addSmartDefaultProvider<T>(source: string, provider: SmartDefaultProvider<T>): void {
-    if (this._sourceMap.has(source)) {
+    if (this._sourceProvider.has(source)) {
       throw new Error(source);
     }
 
-    this._sourceMap.set(source, provider as unknown as SmartDefaultProvider<{}>);
+    this._sourceProvider.set(source, provider as unknown as SmartDefaultProvider<{}>);
 
     if (!this._smartDefaultKeyword) {
       this._smartDefaultKeyword = true;
@@ -632,17 +632,17 @@ export class CoreSchemaRegistry implements SchemaRegistry {
   ): Promise<void> {
     for (const [pointer, schema] of smartDefaults.entries()) {
       const fragments = JSON.parse(pointer) as string[];
-      const source = this._sourceMap.get(schema.$source as string);
+      const source = this._sourceProvider.get(schema.$source as string);
       if (!source) {
         continue;
       }
 
       let value = source(schema);
       if (isObservable(value)) {
-        value = (await lastValueFrom(value)) as {};
+        value = lastValueFrom(value) as {};
       }
 
-      CoreSchemaRegistry._set(data, fragments, value);
+      CoreSchemaRegistry._set(data, fragments, await value);
     }
   }
 


### PR DESCRIPTION
This change refactors the `CommandContext` to defer the initialization of the `packageManager` instance until it is first accessed. This optimization avoids unnecessary configuration discovery and disk I/O for commands that do not require the package manager, such as `ng help`, and certain shell completions.

As part of this refactoring:
- The `packageManager` property in `CommandContext` is now a `Promise<PackageManager>`.
- Internal command modules and utility functions have been updated to `await` the package manager's lazy initialization.
- In `@angular-devkit/core`, `CoreSchemaRegistry` was updated to rename `_sourceMap` to `_sourceProvider` and optimize the resolution of smart defaults by awaiting values during the `_set` operation.
