### PR TITLE
fix(@angular/build): preserve error stack traces during prerendering

### DIFF
--- a/packages/angular/build/src/utils/server-rendering/prerender.ts
+++ b/packages/angular/build/src/utils/server-rendering/prerender.ts
@@ -116,8 +116,12 @@ export async function prerenderPages(
     sourcemap,
     outputMode,
   ).catch((err) => {
+    assertIsError(err);
+
     return {
-      errors: [`An error occurred while extracting routes.\n\n${err.message ?? err.stack ?? err}`],
+      errors: [
+        `An error occurred while extracting routes.\n\n${err.stack ?? err.message ?? err.code ?? err}`,
+      ],
       serializedRouteTree: [],
       appShellRoute: undefined,
     };
@@ -265,8 +269,9 @@ async function renderPages(
           }
         })
         .catch((err) => {
+          assertIsError(err);
           errors.push(
-            `An error occurred while prerendering route '${route}'.\n\n${err.message ?? err.stack ?? err.code ?? err}`,
+            `An error occurred while prerendering route '${route}'.\n\n${err.stack ?? err.message ?? err.code ?? err}`,
           );
           void renderWorker.destroy();
         });
@@ -371,7 +376,7 @@ async function getAllRoutes(
 
     return {
       errors: [
-        `An error occurred while extracting routes.\n\n${err.message ?? err.stack ?? err.code ?? err}`,
+        `An error occurred while extracting routes.\n\n${err.stack ?? err.message ?? err.code ?? err}`,
       ],
       serializedRouteTree: [],
     };


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## What is the current behavior?

When prerendering fails, the error output shows only the error message but no stack trace, making debugging very difficult. This is because the nullish coalescing chain `err.message ?? err.stack ?? err` always resolves to `err.message` (since it's almost always defined on Error objects), so `err.stack` is never reached.

Issue Number: #32503

## What is the new behavior?

Reorder the chain to `err.stack ?? err.message ?? err` at all three error-handling locations in `prerender.ts`. Since `err.stack` includes the message as its first line plus the full trace, this preserves all debugging information.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No