### PR TITLE
fix(@schematics/angular): add browsers option during vitest browser provider ng-add

### DIFF
--- a/packages/schematics/angular/vitest-browser/index.ts
+++ b/packages/schematics/angular/vitest-browser/index.ts
@@ -22,7 +22,7 @@ import {
 } from '../utility/dependency';
 import { JSONFile } from '../utility/json-file';
 import { latestVersions } from '../utility/latest-versions';
-import { getWorkspace } from '../utility/workspace';
+import { getWorkspace, updateWorkspace } from '../utility/workspace';
 import { Builders } from '../utility/workspace-models';
 import { Schema as VitestBrowserOptions } from './schema';
 
@@ -89,8 +89,33 @@ export default function (options: VitestBrowserOptions): Rule {
       }
     };
 
+    // Determine the default browser based on the provider package
+    let defaultBrowser: string;
+    if (packageName === '@vitest/browser-webdriverio') {
+      defaultBrowser = 'chrome';
+    } else {
+      // Playwright and preview both use 'chromium' as the default
+      defaultBrowser = 'chromium';
+    }
+
+    // Update angular.json to add the browsers option to the test target
+    const updateAngularJsonRule = updateWorkspace((workspace) => {
+      const project = workspace.projects.get(options.project);
+      if (project) {
+        const testTarget = project.targets.get('test');
+        if (testTarget) {
+          testTarget.options ??= {};
+          const existingBrowsers = testTarget.options['browsers'] as string[] | undefined;
+          if (!existingBrowsers?.length) {
+            testTarget.options['browsers'] = [defaultBrowser];
+          }
+        }
+      }
+    });
+
     return chain([
       updateTsConfigRule,
+      updateAngularJsonRule,
       ...dependencies.map((name) =>
         addDependency(name, latestVersions[name], {
           type: DependencyType.Dev,
@@ -101,8 +126,7 @@ export default function (options: VitestBrowserOptions): Rule {
       (_, context) => {
         context.logger.info(
           'Vitest browser testing support has been added. ' +
-            "To run tests in a browser, add a 'browsers' field to the 'test' target in 'angular.json', " +
-            "or use the '--browsers' command line option.",
+            `The test target has been configured with '${defaultBrowser}' as the default browser.`,
         );
       },
     ]);

--- a/packages/schematics/angular/vitest-browser/index_spec.ts
+++ b/packages/schematics/angular/vitest-browser/index_spec.ts
@@ -54,6 +54,59 @@ describe('Vitest Browser Provider Schematic', () => {
     expect(tsConfig.compilerOptions.types).not.toContain('jasmine');
   });
 
+  it('should add browsers option to angular.json for playwright', async () => {
+    const options = {
+      project: 'app',
+      package: '@vitest/browser-playwright',
+      skipInstall: true,
+    };
+
+    const resultTree = await schematicRunner.runSchematic('vitest-browser', options, tree);
+
+    const angularJson = parse(resultTree.readContent('/angular.json'));
+    const project = angularJson.projects.app;
+    const targets = project.architect || project.targets;
+    expect(targets.test.options.browsers).toEqual(['chromium']);
+  });
+
+  it('should add browsers option to angular.json for webdriverio', async () => {
+    const options = {
+      project: 'app',
+      package: '@vitest/browser-webdriverio',
+      skipInstall: true,
+    };
+
+    const resultTree = await schematicRunner.runSchematic('vitest-browser', options, tree);
+
+    const angularJson = parse(resultTree.readContent('/angular.json'));
+    const project = angularJson.projects.app;
+    const targets = project.architect || project.targets;
+    expect(targets.test.options.browsers).toEqual(['chrome']);
+  });
+
+  it('should not overwrite existing browsers option in angular.json', async () => {
+    // Set up existing browsers option
+    const angularJson = parse(tree.readContent('/angular.json'));
+    const project = angularJson.projects.app;
+    const targets = project.architect || project.targets;
+    targets.test.options ??= {};
+    targets.test.options.browsers = ['firefox'];
+    tree.overwrite('/angular.json', JSON.stringify(angularJson));
+
+    const options = {
+      project: 'app',
+      package: '@vitest/browser-playwright',
+      skipInstall: true,
+    };
+
+    const resultTree = await schematicRunner.runSchematic('vitest-browser', options, tree);
+
+    const updatedAngularJson = parse(resultTree.readContent('/angular.json'));
+    const updatedProject = updatedAngularJson.projects.app;
+    const updatedTargets = updatedProject.architect || updatedProject.targets;
+    expect(updatedTargets.test.options.browsers).toEqual(['firefox']);
+  });
+
   it('should add webdriverio dependency when @vitest/browser-webdriverio is used', async () => {
     const options = {
       project: 'app',


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## What is the current behavior?

When running ng-add for a Vitest browser provider (e.g., `@vitest/browser-playwright`), the schematic only logs a message telling users to manually add the `browsers` option to `angular.json`. The configuration is incomplete.

Issue Number: #32401

## What is the new behavior?

The schematic now automatically configures the `browsers` option in `angular.json` with an appropriate default browser:
- `chromium` for Playwright and Preview providers
- `chrome` for WebDriverIO

Existing `browsers` configurations are preserved and not overwritten.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No