### PR TITLE
fix(@angular/build): correct zoneless app detection with polyfills array

### DIFF
--- a/packages/angular/build/src/tools/esbuild/utils.ts
+++ b/packages/angular/build/src/tools/esbuild/utils.ts
@@ -471,13 +471,13 @@ export async function logMessages(
 
 /**
  * Ascertain whether the application operates without `zone.js`, we currently rely on the polyfills setting to determine its status.
- * If a file with an extension is provided or if `zone.js` is included in the polyfills, the application is deemed as not zoneless.
+ * If `zone.js` is included in the polyfills, the application is deemed as not zoneless.
  * @param polyfills An array of polyfills
  * @returns true, when the application is considered as zoneless.
  */
 export function isZonelessApp(polyfills: string[] | undefined): boolean {
   // TODO: Instead, we should rely on the presence of zone.js in the polyfills build metadata.
-  return !polyfills?.some((p) => p === 'zone.js' || /\.[mc]?[jt]s$/.test(p));
+  return !polyfills?.some((p) => p === 'zone.js');
 }
 
 export function getEntryPointName(entryPoint: string): string {

--- a/packages/angular/build/src/tools/esbuild/utils_spec.ts
+++ b/packages/angular/build/src/tools/esbuild/utils_spec.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { isZonelessApp } from './utils';
+
+describe('isZonelessApp', () => {
+  it('should return true when polyfills is undefined', () => {
+    expect(isZonelessApp(undefined)).toBeTrue();
+  });
+
+  it('should return true when polyfills is an empty array', () => {
+    expect(isZonelessApp([])).toBeTrue();
+  });
+
+  it('should return false when polyfills contains "zone.js"', () => {
+    expect(isZonelessApp(['zone.js'])).toBeFalse();
+  });
+
+  it('should return false when polyfills contains "zone.js" among other entries', () => {
+    expect(isZonelessApp(['some-polyfill', 'zone.js'])).toBeFalse();
+  });
+
+  it('should return true when polyfills contains only non-zone.js package names', () => {
+    expect(isZonelessApp(['some-polyfill'])).toBeTrue();
+  });
+
+  it('should return true when polyfills contains custom .ts files without zone.js', () => {
+    expect(isZonelessApp(['./polyfill-buffer.ts'])).toBeTrue();
+  });
+
+  it('should return true when polyfills contains custom .js files without zone.js', () => {
+    expect(isZonelessApp(['./custom-polyfill.js'])).toBeTrue();
+  });
+
+  it('should return true when polyfills contains custom .mjs files without zone.js', () => {
+    expect(isZonelessApp(['./polyfill.mjs'])).toBeTrue();
+  });
+
+  it('should return true when polyfills contains a mix of file polyfills and package names without zone.js', () => {
+    expect(isZonelessApp(['./polyfill-buffer.ts', 'some-polyfill', './other.js'])).toBeTrue();
+  });
+
+  it('should return false when polyfills contains file polyfills and zone.js', () => {
+    expect(isZonelessApp(['./polyfill-buffer.ts', 'zone.js'])).toBeFalse();
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## What is the current behavior?

The `isZonelessApp` function incorrectly treats any polyfill entry with a file extension (e.g., `./polyfill-buffer.ts`) as an indicator that zone.js is present. This causes apps with custom polyfill files but no zone.js to be incorrectly detected as non-zoneless.

Issue Number: #30689

## What is the new behavior?

The detection now only checks for the literal `'zone.js'` string in the polyfills array, ignoring custom polyfill files with extensions. Added comprehensive unit tests for `isZonelessApp`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No