### PR TITLE
fix(@angular/build): invalidate cached SCSS errors when source files are corrected

### DIFF
--- a/packages/angular/build/src/tools/esbuild/load-result-cache.ts
+++ b/packages/angular/build/src/tools/esbuild/load-result-cache.ts
@@ -70,7 +70,8 @@ export class MemoryLoadResultCache implements LoadResultCache {
   }
 
   invalidate(path: string): boolean {
-    const affectedPaths = this.#fileDependencies.get(path);
+    const normalizedPath = normalize(path);
+    const affectedPaths = this.#fileDependencies.get(normalizedPath);
     let found = false;
 
     if (affectedPaths) {
@@ -79,7 +80,7 @@ export class MemoryLoadResultCache implements LoadResultCache {
           found = true;
         }
       }
-      this.#fileDependencies.delete(path);
+      this.#fileDependencies.delete(normalizedPath);
     }
 
     return found;


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## What is the current behavior?

After fixing an SCSS compilation error, the build still shows the old error until a full restart. The cache invalidation fails because the file path is not normalized before lookup in the dependency map.

Issue Number: #32744

## What is the new behavior?

Normalize the file path using the existing `normalize()` function before looking it up in the dependency map during cache invalidation, ensuring consistent path matching between storage and retrieval.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No