### PR TITLE
fix(@angular/build): trigger test re-run on non-spec file changes in watch mode

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
@@ -141,6 +141,7 @@ export class VitestExecutor implements TestExecutor {
     if (buildResult.kind === ResultKind.Incremental) {
       // To rerun tests, Vitest needs the original test file paths, not the output paths.
       const modifiedSourceFiles = new Set<string>();
+      const modifiedNonTestFiles = new Set<string>();
       for (const modifiedFile of [...buildResult.modified, ...buildResult.added]) {
         // The `modified` files in the build result are the output paths.
         // We need to find the original source file path to pass to Vitest.
@@ -156,6 +157,10 @@ export class VitestExecutor implements TestExecutor {
             DebugLogLevel.Verbose,
             `Could not map output file '${modifiedFile}' to a source file. It may not be a test file.`,
           );
+          // Track non-test output files so we can find dependent test specs later.
+          modifiedNonTestFiles.add(
+            this.normalizePath(path.join(this.options.workspaceRoot, modifiedFile)),
+          );
         }
         vitest.invalidateFile(
           this.normalizePath(path.join(this.options.workspaceRoot, modifiedFile)),
@@ -167,6 +172,19 @@ export class VitestExecutor implements TestExecutor {
         vitest.invalidateFile(file);
         const specs = vitest.getModuleSpecifications(file);
         if (specs) {
+          specsToRerun.push(...specs);
+        }
+      }
+
+      // For non-test files (e.g., services, components), find dependent test specs
+      // via Vitest's module graph so that changes to these files trigger test re-runs.
+      for (const file of modifiedNonTestFiles) {
+        const specs = vitest.getModuleSpecifications(file);
+        if (specs) {
+          this.debugLog(
+            DebugLogLevel.Verbose,
+            `Found ${specs.length} dependent test specification(s) for non-test file '${file}'.`,
+          );
           specsToRerun.push(...specs);
         }
       }

--- a/packages/angular/build/src/builders/unit-test/tests/behavior/watch_rebuild_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/behavior/watch_rebuild_spec.ts
@@ -20,6 +20,53 @@ describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
       setupApplicationTarget(harness);
     });
 
+    it('should re-run tests when a non-spec file changes', async () => {
+      // Set up a component with a testable value and a spec that checks it
+      harness.writeFiles({
+        'src/app/app.component.ts': `
+          import { Component } from '@angular/core';
+          @Component({ selector: 'app-root', template: '' })
+          export class AppComponent {
+            title = 'hello';
+          }`,
+        'src/app/app.component.spec.ts': `
+          import { describe, expect, test } from 'vitest';
+          import { AppComponent } from './app.component';
+          describe('AppComponent', () => {
+            test('should have correct title', () => {
+              const app = new AppComponent();
+              expect(app.title).toBe('hello');
+            });
+          });`,
+      });
+
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        watch: true,
+      });
+
+      await harness.executeWithCases([
+        // 1. Initial run should succeed
+        ({ result }) => {
+          expect(result?.success).toBeTrue();
+
+          // 2. Modify only the non-spec component file (change the title value)
+          harness.writeFiles({
+            'src/app/app.component.ts': `
+              import { Component } from '@angular/core';
+              @Component({ selector: 'app-root', template: '' })
+              export class AppComponent {
+                title = 'changed';
+              }`,
+          });
+        },
+        // 3. Test should re-run and fail because the title changed
+        ({ result }) => {
+          expect(result?.success).toBeFalse();
+        },
+      ]);
+    });
+
     it('should run tests when a compilation error is fixed and a test failure is introduced simultaneously', async () => {
       harness.useTarget('test', {
         ...BASE_OPTIONS,


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## What is the current behavior?

In watch mode, the unit-test builder only re-runs tests when `.spec.ts` files change. Changes to non-test files (services, components, etc.) are ignored, even though tests depend on them.

Issue Number: #32159

## What is the new behavior?

When non-test files change during watch mode, Vitest's module graph is queried to find dependent test specifications, which are then included in the re-run set. This ensures that changes to any source file trigger the relevant tests.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No