### PR TITLE
fix(@angular/build): prevent deleting parent directories of project root

### DIFF
--- a/packages/angular/build/src/utils/delete-output-dir.ts
+++ b/packages/angular/build/src/utils/delete-output-dir.ts
@@ -7,7 +7,7 @@
  */
 
 import { readdir, rm } from 'node:fs/promises';
-import { join, relative, resolve } from 'node:path';
+import { isAbsolute, join, relative, resolve } from 'node:path';
 
 /**
  * Delete an output directory, but error out if it's the root of the project.
@@ -19,7 +19,9 @@ export async function deleteOutputDir(
 ): Promise<void> {
   const resolvedOutputPath = resolve(root, outputPath);
   const relativePath = relative(resolvedOutputPath, root);
-  if (!relativePath || !relativePath.startsWith('..')) {
+  // When relative() returns an absolute path, the paths are on different drives/roots
+  // (e.g. Windows drive letters or UNC paths), so it cannot be an ancestor.
+  if (!relativePath || (!isAbsolute(relativePath) && !relativePath.startsWith('..'))) {
     throw new Error(
       `Output path "${resolvedOutputPath}" MUST not be the project root directory or its parent.`,
     );

--- a/packages/angular/build/src/utils/delete-output-dir.ts
+++ b/packages/angular/build/src/utils/delete-output-dir.ts
@@ -21,7 +21,7 @@ export async function deleteOutputDir(
   const relativePath = relative(resolvedOutputPath, root);
   if (!relativePath || !relativePath.startsWith('..')) {
     throw new Error(
-      `Output path "${resolvedOutputPath}" MUST not be the project root directory or a parent of it.`,
+      `Output path "${resolvedOutputPath}" MUST not be the project root directory or its parent.`,
     );
   }
 

--- a/packages/angular/build/src/utils/delete-output-dir.ts
+++ b/packages/angular/build/src/utils/delete-output-dir.ts
@@ -7,7 +7,7 @@
  */
 
 import { readdir, rm } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
+import { join, relative, resolve } from 'node:path';
 
 /**
  * Delete an output directory, but error out if it's the root of the project.
@@ -18,8 +18,11 @@ export async function deleteOutputDir(
   emptyOnlyDirectories?: string[],
 ): Promise<void> {
   const resolvedOutputPath = resolve(root, outputPath);
-  if (resolvedOutputPath === root) {
-    throw new Error('Output path MUST not be project root directory!');
+  const relativePath = relative(resolvedOutputPath, root);
+  if (!relativePath || !relativePath.startsWith('..')) {
+    throw new Error(
+      `Output path "${resolvedOutputPath}" MUST not be the project root directory or a parent of it.`,
+    );
   }
 
   const directoriesToEmpty = emptyOnlyDirectories

--- a/packages/angular/build/src/utils/delete-output-dir.ts
+++ b/packages/angular/build/src/utils/delete-output-dir.ts
@@ -7,7 +7,7 @@
  */
 
 import { readdir, rm } from 'node:fs/promises';
-import { isAbsolute, join, relative, resolve } from 'node:path';
+import { isAbsolute, join, resolve, sep } from 'node:path';
 
 /**
  * Delete an output directory, but error out if it's the root of the project.
@@ -18,12 +18,13 @@ export async function deleteOutputDir(
   emptyOnlyDirectories?: string[],
 ): Promise<void> {
   const resolvedOutputPath = resolve(root, outputPath);
-  const relativePath = relative(resolvedOutputPath, root);
-  // When relative() returns an absolute path, the paths are on different drives/roots
-  // (e.g. Windows drive letters or UNC paths), so it cannot be an ancestor.
-  if (!relativePath || (!isAbsolute(relativePath) && !relativePath.startsWith('..'))) {
+  if (resolvedOutputPath === root) {
+    throw new Error('Output path MUST not be the workspace root directory.');
+  }
+
+  if (!isAbsolute(outputPath) && !resolvedOutputPath.startsWith(root + sep)) {
     throw new Error(
-      `Output path "${resolvedOutputPath}" MUST not be the project root directory or its parent.`,
+      `Output path "${resolvedOutputPath}" MUST not be a parent of the workspace root directory.`,
     );
   }
 

--- a/packages/angular/build/src/utils/delete-output-dir_spec.ts
+++ b/packages/angular/build/src/utils/delete-output-dir_spec.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { deleteOutputDir } from './delete-output-dir';
+
+describe('deleteOutputDir', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    // Use a unique temp directory for each test
+    const { mkdtemp } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    root = await mkdtemp(join(tmpdir(), 'ng-test-'));
+  });
+
+  it('should throw when output path is the project root', async () => {
+    await expectAsync(deleteOutputDir(root, '.')).toBeRejectedWithError(
+      /MUST not be the project root directory or a parent of it/,
+    );
+  });
+
+  it('should throw when output path is a parent of the project root', async () => {
+    await expectAsync(deleteOutputDir(root, '..')).toBeRejectedWithError(
+      /MUST not be the project root directory or a parent of it/,
+    );
+  });
+
+  it('should throw when output path is a grandparent of the project root', async () => {
+    await expectAsync(deleteOutputDir(root, '../..')).toBeRejectedWithError(
+      /MUST not be the project root directory or a parent of it/,
+    );
+  });
+
+  it('should not throw when output path is a child of the project root', async () => {
+    const outputDir = join(root, 'dist');
+    await mkdir(outputDir, { recursive: true });
+    await writeFile(join(outputDir, 'old-file.txt'), 'content');
+
+    await expectAsync(deleteOutputDir(root, 'dist')).toBeResolved();
+  });
+
+  it('should delete contents of a valid output directory', async () => {
+    const outputDir = join(root, 'dist');
+    await mkdir(outputDir, { recursive: true });
+    await writeFile(join(outputDir, 'old-file.txt'), 'content');
+
+    await deleteOutputDir(root, 'dist');
+
+    const { readdir } = await import('node:fs/promises');
+    const entries = await readdir(outputDir);
+    expect(entries.length).toBe(0);
+  });
+
+  it('should not throw when output directory does not exist', async () => {
+    await expectAsync(deleteOutputDir(root, 'nonexistent')).toBeResolved();
+  });
+});

--- a/packages/angular/build/src/utils/delete-output-dir_spec.ts
+++ b/packages/angular/build/src/utils/delete-output-dir_spec.ts
@@ -58,4 +58,11 @@ describe('deleteOutputDir', () => {
   it('should not throw when output directory does not exist', async () => {
     await expectAsync(deleteOutputDir(root, 'nonexistent')).toBeResolved();
   });
+
+  it('should not throw when output path is an absolute path outside the project', async () => {
+    const externalDir = await mkdtemp(join(tmpdir(), 'ng-test-external-'));
+    await writeFile(join(externalDir, 'old-file.txt'), 'content');
+
+    await expectAsync(deleteOutputDir(root, externalDir)).toBeResolved();
+  });
 });

--- a/packages/angular/build/src/utils/delete-output-dir_spec.ts
+++ b/packages/angular/build/src/utils/delete-output-dir_spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { deleteOutputDir } from './delete-output-dir';
 
@@ -14,9 +15,6 @@ describe('deleteOutputDir', () => {
   let root: string;
 
   beforeEach(async () => {
-    // Use a unique temp directory for each test
-    const { mkdtemp } = await import('node:fs/promises');
-    const { tmpdir } = await import('node:os');
     root = await mkdtemp(join(tmpdir(), 'ng-test-'));
   });
 
@@ -53,7 +51,6 @@ describe('deleteOutputDir', () => {
 
     await deleteOutputDir(root, 'dist');
 
-    const { readdir } = await import('node:fs/promises');
     const entries = await readdir(outputDir);
     expect(entries.length).toBe(0);
   });

--- a/packages/angular/build/src/utils/delete-output-dir_spec.ts
+++ b/packages/angular/build/src/utils/delete-output-dir_spec.ts
@@ -20,19 +20,19 @@ describe('deleteOutputDir', () => {
 
   it('should throw when output path is the project root', async () => {
     await expectAsync(deleteOutputDir(root, '.')).toBeRejectedWithError(
-      /MUST not be the project root directory or a parent of it/,
+      /MUST not be the project root directory or its parent/,
     );
   });
 
   it('should throw when output path is a parent of the project root', async () => {
     await expectAsync(deleteOutputDir(root, '..')).toBeRejectedWithError(
-      /MUST not be the project root directory or a parent of it/,
+      /MUST not be the project root directory or its parent/,
     );
   });
 
   it('should throw when output path is a grandparent of the project root', async () => {
     await expectAsync(deleteOutputDir(root, '../..')).toBeRejectedWithError(
-      /MUST not be the project root directory or a parent of it/,
+      /MUST not be the project root directory or its parent/,
     );
   });
 

--- a/packages/angular/build/src/utils/delete-output-dir_spec.ts
+++ b/packages/angular/build/src/utils/delete-output-dir_spec.ts
@@ -20,19 +20,19 @@ describe('deleteOutputDir', () => {
 
   it('should throw when output path is the project root', async () => {
     await expectAsync(deleteOutputDir(root, '.')).toBeRejectedWithError(
-      /MUST not be the project root directory or its parent/,
+      /MUST not be the workspace root directory/,
     );
   });
 
   it('should throw when output path is a parent of the project root', async () => {
     await expectAsync(deleteOutputDir(root, '..')).toBeRejectedWithError(
-      /MUST not be the project root directory or its parent/,
+      /MUST not be a parent of the workspace root directory/,
     );
   });
 
   it('should throw when output path is a grandparent of the project root', async () => {
     await expectAsync(deleteOutputDir(root, '../..')).toBeRejectedWithError(
-      /MUST not be the project root directory or its parent/,
+      /MUST not be a parent of the workspace root directory/,
     );
   });
 


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
The `deleteOutputDir` utility only checks if the output path is exactly equal to the project root. Setting the output path to a parent directory (e.g. `../` or `../../`) bypasses this check, and `ng build` silently deletes all contents of that directory potentially wiping out source files or entire directory trees. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes: #6485

## What is the new behavior?
Uses `path.relative()` to detect when the resolved output path is the project root OR any ancestor of it, and throws a descriptive error in both cases.

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
The original issue reported a user losing 10 days of work after setting `outDir: "../../"` which caused `ng build --prod` to delete their entire project directory. This fix closes the gap that has been open since 2017.