### PR TITLE
fix(@schematics/angular): preserve the workspace build version during migration

### DIFF
--- a/packages/schematics/angular/migrations/use-application-builder/migration.ts
+++ b/packages/schematics/angular/migrations/use-application-builder/migration.ts
@@ -15,6 +15,7 @@ import {
   externalSchematic,
 } from '@angular-devkit/schematics';
 import { dirname, join } from 'node:path/posix';
+import { getPackageJsonDependency } from '../../utility/dependencies';
 import {
   DependencyType,
   ExistingBehavior,
@@ -270,8 +271,11 @@ function updateProjects(tree: Tree, context: SchematicContext) {
       }
 
       // Add direct @angular/build dependencies and remove @angular-devkit/build-angular
+      const buildDependency =
+        getPackageJsonDependency(tree, '@angular-devkit/build-angular') ??
+        getPackageJsonDependency(tree, '@angular/build');
       rules.push(
-        addDependency('@angular/build', latestVersions.DevkitBuildAngular, {
+        addDependency('@angular/build', buildDependency?.version ?? latestVersions.AngularBuild, {
           type: DependencyType.Dev,
           existing: ExistingBehavior.Replace,
         }),

--- a/packages/schematics/angular/migrations/use-application-builder/migration.ts
+++ b/packages/schematics/angular/migrations/use-application-builder/migration.ts
@@ -273,7 +273,7 @@ function updateProjects(tree: Tree, context: SchematicContext) {
       // Add direct @angular/build dependencies and remove @angular-devkit/build-angular
       const buildAngularVersion =
         getDependency(tree, '@angular-devkit/build-angular')?.version ??
-        latestVersions.DevkitBuildAngular;
+        latestVersions.AngularBuild;
       rules.push(
         addDependency('@angular/build', buildAngularVersion, {
           type: DependencyType.Dev,

--- a/packages/schematics/angular/migrations/use-application-builder/migration.ts
+++ b/packages/schematics/angular/migrations/use-application-builder/migration.ts
@@ -15,11 +15,11 @@ import {
   externalSchematic,
 } from '@angular-devkit/schematics';
 import { dirname, join } from 'node:path/posix';
-import { getPackageJsonDependency } from '../../utility/dependencies';
 import {
   DependencyType,
   ExistingBehavior,
   addDependency,
+  getDependency,
   removeDependency,
 } from '../../utility/dependency';
 import { JSONFile } from '../../utility/json-file';
@@ -271,13 +271,13 @@ function updateProjects(tree: Tree, context: SchematicContext) {
       }
 
       // Add direct @angular/build dependencies and remove @angular-devkit/build-angular
-      const buildDependency =
-        getPackageJsonDependency(tree, '@angular-devkit/build-angular') ??
-        getPackageJsonDependency(tree, '@angular/build');
+      const buildAngularVersion =
+        getDependency(tree, '@angular-devkit/build-angular')?.version ??
+        latestVersions.DevkitBuildAngular;
       rules.push(
-        addDependency('@angular/build', buildDependency?.version ?? latestVersions.AngularBuild, {
+        addDependency('@angular/build', buildAngularVersion, {
           type: DependencyType.Dev,
-          existing: ExistingBehavior.Replace,
+          existing: ExistingBehavior.Skip,
         }),
         removeDependency('@angular-devkit/build-angular'),
       );

--- a/packages/schematics/angular/migrations/use-application-builder/migration_spec.ts
+++ b/packages/schematics/angular/migrations/use-application-builder/migration_spec.ts
@@ -9,6 +9,7 @@
 import { JsonObject } from '@angular-devkit/core';
 import { EmptyTree } from '@angular-devkit/schematics';
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+import { latestVersions } from '../../utility/latest-versions';
 import { Builders, ProjectType, WorkspaceSchema } from '../../utility/workspace-models';
 
 function createWorkSpaceConfig(tree: UnitTestTree) {
@@ -464,6 +465,14 @@ describe(`Migration to use the application builder`, () => {
 
     const { devDependencies } = JSON.parse(newTree.readContent('/package.json'));
     expect(devDependencies['@angular/build']).toBe('~18.2.20');
+    expect(devDependencies['@angular-devkit/build-angular']).toBeUndefined();
+  });
+
+  it('should use the latest "@angular/build" version when no builder is installed', async () => {
+    const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
+
+    const { devDependencies } = JSON.parse(newTree.readContent('/package.json'));
+    expect(devDependencies['@angular/build']).toBe(latestVersions.AngularBuild);
     expect(devDependencies['@angular-devkit/build-angular']).toBeUndefined();
   });
 

--- a/packages/schematics/angular/migrations/use-application-builder/migration_spec.ts
+++ b/packages/schematics/angular/migrations/use-application-builder/migration_spec.ts
@@ -467,6 +467,24 @@ describe(`Migration to use the application builder`, () => {
     expect(devDependencies['@angular-devkit/build-angular']).toBeUndefined();
   });
 
+  it('should preserve an existing "@angular/build" version when migrating', async () => {
+    tree.overwrite(
+      '/package.json',
+      JSON.stringify({
+        devDependencies: {
+          '@angular-devkit/build-angular': '~18.2.20',
+          '@angular/build': '~18.2.10',
+        },
+      }),
+    );
+
+    const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
+
+    const { devDependencies } = JSON.parse(newTree.readContent('/package.json'));
+    expect(devDependencies['@angular/build']).toBe('~18.2.10');
+    expect(devDependencies['@angular-devkit/build-angular']).toBeUndefined();
+  });
+
   it('it should not add esModuleInterop and moduleResolution when module is preserve', async () => {
     tree.overwrite(
       'tsconfig.json',

--- a/packages/schematics/angular/migrations/use-application-builder/migration_spec.ts
+++ b/packages/schematics/angular/migrations/use-application-builder/migration_spec.ts
@@ -450,6 +450,23 @@ describe(`Migration to use the application builder`, () => {
     expect(devDependencies['postcss']).toBeUndefined();
   });
 
+  it('should reuse the installed builder version when migrating to "@angular/build"', async () => {
+    tree.overwrite(
+      '/package.json',
+      JSON.stringify({
+        devDependencies: {
+          '@angular-devkit/build-angular': '~18.2.20',
+        },
+      }),
+    );
+
+    const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
+
+    const { devDependencies } = JSON.parse(newTree.readContent('/package.json'));
+    expect(devDependencies['@angular/build']).toBe('~18.2.20');
+    expect(devDependencies['@angular-devkit/build-angular']).toBeUndefined();
+  });
+
   it('it should not add esModuleInterop and moduleResolution when module is preserve', async () => {
     tree.overwrite(
       'tsconfig.json',


### PR DESCRIPTION
## Summary
- reuse the workspace version of `@angular-devkit/build-angular` when the `use-application-builder` migration adds `@angular/build`
- fall back to an existing `@angular/build` version if it is already present, and only then fall back to the repo default
- add a regression spec covering an `18.2.x` workspace so the migration no longer upgrades the package to an incompatible `20.x` release

## Testing
- `corepack pnpm exec prettier --check packages/schematics/angular/migrations/use-application-builder/migration.ts packages/schematics/angular/migrations/use-application-builder/migration_spec.ts`
- `corepack pnpm exec eslint packages/schematics/angular/migrations/use-application-builder/migration.ts packages/schematics/angular/migrations/use-application-builder/migration_spec.ts`
- `git diff --check`
- `corepack pnpm -s ng-dev format staged`
- attempted `corepack pnpm bazel test //packages/schematics/angular:test --lockfile_mode=update --test_output=errors --verbose_failures` under portable Node `v24.13.1` with `BAZEL_SH` pointed at Git Bash; the target analyzed successfully but the Windows host then failed in Bazel's TypeScript toolchain before the schematic suite ran because the expected `aspect_rules_js` TypeScript entry point was missing from the generated execroot

Fixes #30696