### PR TITLE
fix(@angular/build): prepend deploy-url to file loader output paths

### DIFF
--- a/packages/angular/build/src/builders/application/tests/options/deploy-url_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/deploy-url_spec.ts
@@ -58,6 +58,33 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
         );
     });
 
+    it('should prepend deploy URL to file loader import URLs', async () => {
+      await harness.writeFile(
+        './src/types.d.ts',
+        'declare module "*.svg" { const url: string; export default url; }',
+      );
+      await harness.writeFile('./src/app/test.svg', '<svg></svg>');
+      await harness.writeFile(
+        'src/main.ts',
+        `import svgUrl from './app/test.svg';\nconsole.log(svgUrl);`,
+      );
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        loader: {
+          '.svg': 'file',
+        },
+        deployUrl: 'https://example.com/some/path/',
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+
+      harness
+        .expectFile('dist/browser/main.js')
+        .content.toContain('https://example.com/some/path/media/test.svg');
+    });
+
     it('should update resources component stylesheets to reference deployURL', async () => {
       await harness.writeFile('src/app/test.svg', '<svg></svg>');
       await harness.writeFile(

--- a/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
@@ -550,6 +550,7 @@ function getEsBuildCommonOptions(options: NormalizedApplicationBuildOptions): Bu
     i18nOptions,
     customConditions,
     frameworkVersion,
+    publicPath,
   } = options;
 
   // Ensure unique hashes for i18n translation changes when using post-process inlining.
@@ -654,6 +655,7 @@ function getEsBuildCommonOptions(options: NormalizedApplicationBuildOptions): Bu
     },
     loader: loaderExtensions,
     footer,
+    publicPath,
     plugins,
   };
 }


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## What is the current behavior?

Assets processed by esbuild's file loader (e.g., SVGs imported via `import svgUrl from './test.svg'`) do not get the `deploy-url` prefix applied. The `publicPath` option (derived from `deployUrl`) is passed to stylesheet bundling but not to the application code bundler's common options.

Issue Number: #32789

## What is the new behavior?

Pass `publicPath` through to esbuild's common options in `getEsBuildCommonOptions()`, so file loader output paths are correctly prefixed with the deploy-url value.

**No regression risk:** Component stylesheets already explicitly delete `publicPath` before their own bundling (lines 72 and 127 in `component-stylesheets.ts`), preventing double-prefixing.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No