### PR TITLE
fix(@angular/build): correct misleading error message for top-level await

### DIFF
--- a/packages/angular/build/src/builders/application/execute-build.ts
+++ b/packages/angular/build/src/builders/application/execute-build.ts
@@ -167,19 +167,14 @@ export async function executeBuild(
     if (!isZonelessApp(options.polyfills)) {
       for (const error of bundlingResult.errors) {
         if (error.text?.startsWith(TOP_LEVEL_AWAIT_ERROR_TEXT)) {
-          error.notes = [
-            {
-              text:
-                'Top-level await is not supported in applications that use Zone.js. ' +
-                'Consider removing Zone.js or moving this code into an async function.',
-              location: null,
-            },
-            {
-              text: 'For more information about zoneless Angular applications, visit: https://angular.dev/guide/zoneless',
-              location: null,
-            },
-            ...(error.notes ?? []),
-          ];
+          error.notes ??= [];
+          error.notes.push({
+            text:
+              'Top-level await is not supported in applications that use Zone.js. ' +
+              'Consider removing Zone.js or moving this code into an async function. \n' +
+              'For more information about zoneless Angular applications, visit: https://angular.dev/guide/zoneless',
+            location: null,
+          });
         }
       }
     }

--- a/packages/angular/build/src/builders/application/execute-build.ts
+++ b/packages/angular/build/src/builders/application/execute-build.ts
@@ -38,6 +38,10 @@ import { inlineI18n, loadActiveTranslations } from './i18n';
 import { NormalizedApplicationBuildOptions } from './options';
 import { createComponentStyleBundler, setupBundlerContexts } from './setup-bundling';
 
+/** The esbuild error text prefix used to detect top-level await errors. */
+const TOP_LEVEL_AWAIT_ERROR_TEXT =
+  'Top-level await is not available in the configured target environment';
+
 // eslint-disable-next-line max-lines-per-function
 export async function executeBuild(
   options: NormalizedApplicationBuildOptions,
@@ -162,11 +166,7 @@ export async function executeBuild(
     // the actual reason is that async/await is downleveled for Zone.js compatibility.
     if (!isZonelessApp(options.polyfills)) {
       for (const error of bundlingResult.errors) {
-        if (
-          error.text?.startsWith(
-            'Top-level await is not available in the configured target environment',
-          )
-        ) {
+        if (error.text?.startsWith(TOP_LEVEL_AWAIT_ERROR_TEXT)) {
           error.notes = [
             {
               text:

--- a/packages/angular/build/src/builders/application/execute-build.ts
+++ b/packages/angular/build/src/builders/application/execute-build.ts
@@ -21,6 +21,7 @@ import { extractLicenses } from '../../tools/esbuild/license-extractor';
 import { profileAsync } from '../../tools/esbuild/profiling';
 import {
   calculateEstimatedTransferSizes,
+  isZonelessApp,
   logBuildStats,
   transformSupportedBrowsersToTargets,
 } from '../../tools/esbuild/utils';
@@ -156,6 +157,33 @@ export async function executeBuild(
 
   // Return if the bundling has errors
   if (bundlingResult.errors) {
+    // If Zone.js is used, augment top-level await errors with a more helpful message.
+    // esbuild's default error mentions "target environment" with browser versions, but
+    // the actual reason is that async/await is downleveled for Zone.js compatibility.
+    if (!isZonelessApp(options.polyfills)) {
+      for (const error of bundlingResult.errors) {
+        if (
+          error.text?.startsWith(
+            'Top-level await is not available in the configured target environment',
+          )
+        ) {
+          error.notes = [
+            {
+              text:
+                'Top-level await is not supported in applications that use Zone.js. ' +
+                'Consider removing Zone.js or moving this code into an async function.',
+              location: null,
+            },
+            {
+              text: 'For more information about zoneless Angular applications, visit: https://angular.dev/guide/zoneless',
+              location: null,
+            },
+            ...(error.notes ?? []),
+          ];
+        }
+      }
+    }
+
     executionResult.addErrors(bundlingResult.errors);
 
     return executionResult;

--- a/packages/angular/build/src/builders/application/execute-build.ts
+++ b/packages/angular/build/src/builders/application/execute-build.ts
@@ -19,6 +19,7 @@ import { extractLicenses } from '../../tools/esbuild/license-extractor';
 import { profileAsync } from '../../tools/esbuild/profiling';
 import {
   calculateEstimatedTransferSizes,
+  isZonelessApp,
   logBuildStats,
   transformSupportedBrowsersToTargets,
 } from '../../tools/esbuild/utils';
@@ -34,6 +35,10 @@ import { executePostBundleSteps } from './execute-post-bundle';
 import { inlineI18n, loadActiveTranslations } from './i18n';
 import { NormalizedApplicationBuildOptions } from './options';
 import { createComponentStyleBundler, setupBundlerContexts } from './setup-bundling';
+
+/** The esbuild error text prefix used to detect top-level await errors. */
+const TOP_LEVEL_AWAIT_ERROR_TEXT =
+  'Top-level await is not available in the configured target environment';
 
 // eslint-disable-next-line max-lines-per-function
 export async function executeBuild(
@@ -157,6 +162,24 @@ export async function executeBuild(
 
   // Return if the bundling has errors
   if (bundlingResult.errors) {
+    // If Zone.js is used, augment top-level await errors with a more helpful message.
+    // esbuild's default error mentions "target environment" with browser versions, but
+    // the actual reason is that async/await is downleveled for Zone.js compatibility.
+    if (!isZonelessApp(options.polyfills)) {
+      for (const error of bundlingResult.errors) {
+        if (error.text?.startsWith(TOP_LEVEL_AWAIT_ERROR_TEXT)) {
+          error.notes ??= [];
+          error.notes.push({
+            text:
+              'Top-level await is not supported in applications that use Zone.js. ' +
+              'Consider removing Zone.js or moving this code into an async function. \n' +
+              'For more information about zoneless Angular applications, visit: https://angular.dev/guide/zoneless',
+            location: null,
+          });
+        }
+      }
+    }
+
     executionResult.addErrors(bundlingResult.errors);
 
     return executionResult;

--- a/packages/angular/build/src/builders/application/execute-build.ts
+++ b/packages/angular/build/src/builders/application/execute-build.ts
@@ -19,7 +19,11 @@ import { LOCALE_DATA_BASE_MODULE } from '../../tools/esbuild/i18n-locale-plugin'
 import { extractLicenses } from '../../tools/esbuild/license-extractor';
 import { profileAsync } from '../../tools/esbuild/profiling';
 import { transformSupportedBrowsersToTargets } from '../../tools/esbuild/target';
-import { calculateEstimatedTransferSizes, logBuildStats } from '../../tools/esbuild/utils';
+import {
+  calculateEstimatedTransferSizes,
+  isZonelessApp,
+  logBuildStats,
+} from '../../tools/esbuild/utils';
 import { BudgetCalculatorResult, checkBudgets } from '../../utils/bundle-calculator';
 import { optimizeChunksThreshold } from '../../utils/environment-options';
 import { resolveAssets } from '../../utils/resolve-assets';
@@ -32,6 +36,10 @@ import { executePostBundleSteps } from './execute-post-bundle';
 import { inlineI18n, loadActiveTranslations } from './i18n';
 import { NormalizedApplicationBuildOptions } from './options';
 import { createComponentStyleBundler, setupBundlerContexts } from './setup-bundling';
+
+/** The esbuild error text prefix used to detect top-level await errors. */
+const TOP_LEVEL_AWAIT_ERROR_TEXT =
+  'Top-level await is not available in the configured target environment';
 
 // eslint-disable-next-line max-lines-per-function
 export async function executeBuild(
@@ -170,6 +178,24 @@ export async function executeBuild(
 
     // Return if the bundling has errors
     if (bundlingResult.errors) {
+      // If Zone.js is used, augment top-level await errors with a more helpful message.
+      // esbuild's default error mentions "target environment" with browser versions, but
+      // the actual reason is that async/await is downleveled for Zone.js compatibility.
+      if (!isZonelessApp(options.polyfills)) {
+        for (const error of bundlingResult.errors) {
+          if (error.text?.startsWith(TOP_LEVEL_AWAIT_ERROR_TEXT)) {
+            error.notes ??= [];
+            error.notes.push({
+              text:
+                'Top-level await is not supported in applications that use Zone.js. ' +
+                'Consider removing Zone.js or moving this code into an async function. \n' +
+                'For more information about zoneless Angular applications, visit: https://angular.dev/guide/zoneless',
+              location: null,
+            });
+          }
+        }
+      }
+
       executionResult.addErrors(bundlingResult.errors);
 
       return executionResult;

--- a/packages/angular/build/src/builders/application/tests/behavior/top-level-await-error_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/top-level-await-error_spec.ts
@@ -51,14 +51,15 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       });
 
       const { result, logs } = await harness.executeOnce({ outputLogsOnFailure: false });
-      // Without Zone.js, the build may still fail due to target environment constraints,
-      // but the error should NOT contain the Zone.js-specific message
-      const zoneJsErrorPresent = logs.some(
-        (log) =>
-          typeof log.message === 'string' &&
-          log.message.includes('Top-level await is not supported in applications that use Zone.js'),
+      expect(result?.success).toBeTrue();
+      expect(logs).not.toContain(
+        jasmine.objectContaining({
+          level: 'error',
+          message: jasmine.stringContaining(
+            'Top-level await is not supported in applications that use Zone.js',
+          ),
+        }),
       );
-      expect(zoneJsErrorPresent).toBeFalse();
     });
   });
 });

--- a/packages/angular/build/src/builders/application/tests/behavior/top-level-await-error_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/top-level-await-error_spec.ts
@@ -51,8 +51,16 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       });
 
       const { result, logs } = await harness.executeOnce({ outputLogsOnFailure: false });
-      // Without Zone.js, top-level await should be supported and the build should succeed
-      expect(result?.success).toBeTrue();
+      // Without Zone.js, the build may still fail due to target environment constraints,
+      // but the error should NOT contain the Zone.js-specific message
+      const zoneJsErrorPresent = logs.some(
+        (log) =>
+          typeof log.message === 'string' &&
+          log.message.includes(
+            'Top-level await is not supported in applications that use Zone.js',
+          ),
+      );
+      expect(zoneJsErrorPresent).toBeFalse();
     });
   });
 });

--- a/packages/angular/build/src/builders/application/tests/behavior/top-level-await-error_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/top-level-await-error_spec.ts
@@ -56,9 +56,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       const zoneJsErrorPresent = logs.some(
         (log) =>
           typeof log.message === 'string' &&
-          log.message.includes(
-            'Top-level await is not supported in applications that use Zone.js',
-          ),
+          log.message.includes('Top-level await is not supported in applications that use Zone.js'),
       );
       expect(zoneJsErrorPresent).toBeFalse();
     });

--- a/packages/angular/build/src/builders/application/tests/behavior/top-level-await-error_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/top-level-await-error_spec.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { buildApplication } from '../../index';
+import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
+
+describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
+  describe('Behavior: "Top-level await error message"', () => {
+    it('should show a Zone.js-specific error when top-level await is used with Zone.js', async () => {
+      await harness.writeFile(
+        'src/main.ts',
+        `
+        const value = await Promise.resolve('test');
+        console.log(value);
+        `,
+      );
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        polyfills: ['zone.js'],
+      });
+
+      const { result, logs } = await harness.executeOnce({ outputLogsOnFailure: false });
+      expect(result?.success).toBeFalse();
+      expect(logs).toContain(
+        jasmine.objectContaining({
+          message: jasmine.stringMatching(
+            'Top-level await is not supported in applications that use Zone.js',
+          ),
+        }),
+      );
+    });
+
+    it('should not show a Zone.js-specific error when top-level await is used without Zone.js', async () => {
+      await harness.writeFile(
+        'src/main.ts',
+        `
+        const value = await Promise.resolve('test');
+        console.log(value);
+        `,
+      );
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        polyfills: [],
+      });
+
+      const { result, logs } = await harness.executeOnce({ outputLogsOnFailure: false });
+      // Without Zone.js, top-level await should be supported and the build should succeed
+      expect(result?.success).toBeTrue();
+    });
+  });
+});

--- a/packages/angular/build/src/builders/application/tests/behavior/top-level-await-error_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/top-level-await-error_spec.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { buildApplication } from '../../index';
+import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
+
+describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
+  describe('Behavior: "Top-level await error message"', () => {
+    it('should show a Zone.js-specific error when top-level await is used with Zone.js', async () => {
+      await harness.writeFile(
+        'src/main.ts',
+        `
+        // The export makes this file a module, which is required for top-level await.
+        export const value = await Promise.resolve('test');
+        console.log(value);
+        `,
+      );
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        polyfills: ['zone.js'],
+      });
+
+      const { result, logs } = await harness.executeOnce({ outputLogsOnFailure: false });
+      expect(result?.success).toBeFalse();
+      expect(logs).toContain(
+        jasmine.objectContaining({
+          message: jasmine.stringMatching(
+            'Top-level await is not supported in applications that use Zone.js',
+          ),
+        }),
+      );
+    });
+
+    it('should not show a Zone.js-specific error when top-level await is used without Zone.js', async () => {
+      await harness.writeFile(
+        'src/main.ts',
+        `
+        // The export makes this file a module, which is required for top-level await.
+        export const value = await Promise.resolve('test');
+        console.log(value);
+        `,
+      );
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        polyfills: [],
+      });
+
+      const { result, logs } = await harness.executeOnce({ outputLogsOnFailure: false });
+      expect(result?.success).toBeTrue();
+      expect(logs).not.toContain(
+        jasmine.objectContaining({
+          level: 'error',
+          message: jasmine.stringContaining(
+            'Top-level await is not supported in applications that use Zone.js',
+          ),
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## What is the current behavior?

When using top-level `await` in an Angular app with Zone.js, esbuild reports "Top-level await is not available in the configured target environment" with a list of browser versions. This is misleading — all modern browsers support top-level await. The real issue is that Angular disables native async/await when Zone.js is in use (since Zone.js can't intercept it), and top-level await can't be downleveled.

Closes #28904

## What is the new behavior?

When the top-level await error occurs and Zone.js is active, the error is augmented with explanatory notes:
- "Top-level await is not supported in applications that use Zone.js. Consider removing Zone.js or moving this code into an async function."
- A link to the Angular zoneless documentation at https://angular.dev/guide/zoneless

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No