### PR TITLE
fix(package-manager): prevent CWE-78 OS command injection across all Windows spawn paths

### DIFF
--- a/packages/angular/cli/src/package-managers/host.ts
+++ b/packages/angular/cli/src/package-managers/host.ts
@@ -115,6 +115,7 @@ export const NodeJS_HOST: Host = {
   createTempDirectory: (baseDir?: string) =>
     mkdtemp(join(baseDir ?? tmpdir(), 'angular-cli-tmp-packages-')),
   deleteDirectory: (path: string) => rm(path, { recursive: true, force: true }),
+
   runCommand: async (
     command: string,
     args: readonly string[],
@@ -142,9 +143,11 @@ export const NodeJS_HOST: Host = {
           NPM_CONFIG_UPDATE_NOTIFIER: 'false',
         },
       } satisfies SpawnOptions;
-      const childProcess = isWin32
-        ? spawn(`${command} ${args.join(' ')}`, spawnOptions)
-        : spawn(command, args, spawnOptions);
+
+      // FIXED: Use safe array form to prevent OS Command Injection (CWE-78)
+      // Previously used unsafe string concatenation on Windows (`shell: true` + args.join)
+      // Now always uses safe array form while preserving shell behavior
+      const childProcess = spawn(command, args, spawnOptions);
 
       let stdout = '';
       childProcess.stdout?.on('data', (data) => (stdout += data.toString()));
@@ -165,7 +168,6 @@ export const NodeJS_HOST: Host = {
         if (err.name === 'AbortError') {
           const message = `Process timed out.`;
           reject(new PackageManagerError(message, stdout, stderr, null));
-
           return;
         }
         const message = `Process failed with error: ${err.message}`;

--- a/packages/angular/cli/src/package-managers/host.ts
+++ b/packages/angular/cli/src/package-managers/host.ts
@@ -131,7 +131,7 @@ export const NodeJS_HOST: Host = {
 
     return new Promise((resolve, reject) => {
       const spawnOptions = {
-        shell: isWin32,
+        shell: false,
         stdio: options.stdio ?? 'pipe',
         signal,
         cwd: options.cwd,
@@ -144,10 +144,14 @@ export const NodeJS_HOST: Host = {
         },
       } satisfies SpawnOptions;
 
-      // FIXED: Use safe array form to prevent OS Command Injection (CWE-78)
-      // Previously used unsafe string concatenation on Windows (`shell: true` + args.join)
-      // Now always uses safe array form while preserving shell behavior
-      const childProcess = spawn(command, args, spawnOptions);
+      // FIXED (CWE-78): On Windows npm/yarn/pnpm are .cmd scripts that need a shell.
+      // spawn(cmd, args, {shell:true}) has Node.js join the args internally — the
+      // previous PR only removed the explicit join; injection still existed.
+      // Correct fix: invoke cmd.exe directly with shell:false. cmd.exe is a real
+      // .exe so no shell wrapper is needed. Args as array = no metachar injection.
+      const childProcess = isWin32
+        ? spawn('cmd.exe', ['/d', '/s', '/c', command, ...args], spawnOptions)
+        : spawn(command, args, spawnOptions);
 
       let stdout = '';
       childProcess.stdout?.on('data', (data) => (stdout += data.toString()));

--- a/packages/angular/cli/src/package-managers/host.ts
+++ b/packages/angular/cli/src/package-managers/host.ts
@@ -172,6 +172,7 @@ export const NodeJS_HOST: Host = {
         if (err.name === 'AbortError') {
           const message = `Process timed out.`;
           reject(new PackageManagerError(message, stdout, stderr, null));
+
           return;
         }
         const message = `Process failed with error: ${err.message}`;

--- a/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/index.ts
@@ -231,7 +231,7 @@ function startNodeServer(
   const path = join(outputPath, 'main.js');
   const env = { ...process.env, PORT: '' + port, NG_ALLOWED_HOSTS: host ?? 'localhost' };
 
-  const args = ['--enable-source-maps', `"${path}"`];
+  const args = ['--enable-source-maps', path];
   if (inspectMode) {
     args.unshift('--inspect-brk');
   }

--- a/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/index.ts
@@ -238,7 +238,8 @@ function startNodeServer(
 
   return of(null).pipe(
     delay(0), // Avoid EADDRINUSE error since it will cause the kill event to be finish.
-    switchMap(() => spawnAsObservable('node', args, { env, shell: true })),
+    // shell:true removed — spawnAsObservable handles Windows safely via cmd.exe
+    switchMap(() => spawnAsObservable('node', args, { env })),
     tap((res) => log({ stderr: res.stderr, stdout: res.stdout }, logger)),
     ignoreElements(),
     // Emit a signal after the process has been started

--- a/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/utils.ts
+++ b/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/utils.ts
@@ -7,8 +7,8 @@
  */
 
 import { SpawnOptions, spawn } from 'node:child_process';
-import { platform } from 'node:os';
 import { AddressInfo, createConnection, createServer } from 'node:net';
+import { platform } from 'node:os';
 import { Observable, mergeMap, retryWhen, throwError, timer } from 'rxjs';
 
 export function getAvailablePort(): Promise<number> {

--- a/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/utils.ts
+++ b/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/utils.ts
@@ -7,6 +7,7 @@
  */
 
 import { SpawnOptions, spawn } from 'node:child_process';
+import { platform } from 'node:os';
 import { AddressInfo, createConnection, createServer } from 'node:net';
 import { Observable, mergeMap, retryWhen, throwError, timer } from 'rxjs';
 
@@ -29,7 +30,13 @@ export function spawnAsObservable(
   options: SpawnOptions = {},
 ): Observable<{ stdout?: string; stderr?: string }> {
   return new Observable((obs) => {
-    const proc = spawn(`${command} ${args.join(' ')}`, options);
+    // FIXED (CWE-78): raw args.join + shell:true allows injection via
+    // a crafted outputPath/serverScript value in angular.json.
+    // Invoke cmd.exe directly on Windows (shell:false) — no escaping needed.
+    const isWin32 = platform() === 'win32';
+    const proc = isWin32
+      ? spawn('cmd.exe', ['/d', '/s', '/c', command, ...args], { ...options, shell: false })
+      : spawn(command, args, { ...options, shell: false });
     if (proc.stdout) {
       proc.stdout.on('data', (data) => obs.next({ stdout: data.toString() }));
     }

--- a/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
+++ b/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
@@ -9,43 +9,6 @@
 import { BaseException } from '@angular-devkit/core';
 import { SpawnOptions, spawn } from 'node:child_process';
 
-/**
- * Escapes a single argument for safe use with Windows cmd.exe.
- * Prevents OS command injection (CWE-78) by wrapping in double quotes
- * and correctly escaping embedded quotes and backslashes.
- *
- * Algorithm: https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/
- */
-function escapeArgForWindowsShell(arg: string): string {
-  // FIX A: empty string must produce a quoted empty token.
-  // Returning bare '' causes cmd.exe to drop the arg silently,
-  // shifting all subsequent args by one (argument confusion).
-  if (!arg) return '""';
-  // Fast path: only shell-safe chars, no quoting needed
-  if (/^[a-zA-Z0-9_\-./\\:@]+$/.test(arg)) {
-    return arg;
-  }
-  // FIX B: escape % BEFORE wrapping in double-quotes.
-  // cmd.exe expands %VAR% before evaluating quote context, so
-  // %COMSPEC% inside "..." still expands (BatBadBut / CVE-2024-3566).
-  // %% disables expansion and becomes a literal percent sign.
-  arg = arg.replace(/%/g, '%%');
-  let result = '"';
-  let slashes = 0;
-  for (const char of arg) {
-    if (char === '\\') {
-      slashes++;
-    } else if (char === '"') {
-      result += '\\'.repeat(slashes * 2 + 1) + '"';
-      slashes = 0;
-    } else {
-      result += '\\'.repeat(slashes) + char;
-      slashes = 0;
-    }
-  }
-  result += '\\'.repeat(slashes * 2) + '"';
-  return result;
-}
 
 
 import * as path from 'node:path';

--- a/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
+++ b/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
@@ -117,7 +117,7 @@ export default function (
 
     const bufferedOutput: { stream: NodeJS.WriteStream; data: Buffer }[] = [];
     const spawnOptions: SpawnOptions = {
-      shell: true,
+      shell: false,
       cwd: path.join(rootDirectory, options.workingDirectory || ''),
     };
     if (options.hideOutput) {
@@ -166,15 +166,20 @@ export default function (
         // Workaround for https://github.com/sindresorhus/ora/issues/136.
         discardStdin: process.platform != 'win32',
       }).start();
-      // SECURITY FIX (CWE-78): escape each arg individually instead of raw concatenation.
-      const escapedArgs =
-        spawnOptions.shell === true
-          ? args.map(escapeArgForWindowsShell).join(' ')
-          : args.join(' ');
-      const childProcess = spawn(
-        `${taskPackageManagerName} ${escapedArgs}`,
-        spawnOptions,
-      ).on(
+      // SECURITY FIX (CWE-78): never concatenate args as a raw shell string.
+      // On Windows, package managers are .cmd scripts requiring a shell, but
+      // instead of shell:true + string concat (injection vector), we invoke
+      // cmd.exe directly with shell:false and pass each arg as an array element.
+      // Node.js then controls quoting — metacharacters in args are never
+      // interpreted by cmd.exe as shell operators.
+      const isWin32 = process.platform === 'win32';
+      const childProcess = isWin32
+        ? spawn(
+            'cmd.exe',
+            ['/d', '/s', '/c', taskPackageManagerName, ...args],
+            { ...spawnOptions, shell: false },
+          ).on(
+        : spawn(taskPackageManagerName, args, { ...spawnOptions, shell: false }).on(
         'close',
         (code: number) => {
           if (code === 0) {

--- a/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
+++ b/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
@@ -9,8 +9,6 @@
 import { BaseException } from '@angular-devkit/core';
 import { SpawnOptions, spawn } from 'node:child_process';
 
-
-
 import * as path from 'node:path';
 import ora from 'ora';
 import { TaskExecutor, UnsuccessfulWorkflowExecution } from '../../src';

--- a/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
+++ b/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
@@ -136,13 +136,15 @@ export default function (
       // Node.js then controls quoting — metacharacters in args are never
       // interpreted by cmd.exe as shell operators.
       const isWin32 = process.platform === 'win32';
-      const childProcess = isWin32
-        ? spawn(
-            'cmd.exe',
-            ['/d', '/s', '/c', taskPackageManagerName, ...args],
-            { ...spawnOptions, shell: false },
-          ).on(
-        : spawn(taskPackageManagerName, args, { ...spawnOptions, shell: false }).on(
+      const childProcess = (
+        isWin32
+          ? spawn(
+              'cmd.exe',
+              ['/d', '/s', '/c', taskPackageManagerName, ...args],
+              { ...spawnOptions, shell: false },
+            )
+          : spawn(taskPackageManagerName, args, { ...spawnOptions, shell: false })
+      ).on(
         'close',
         (code: number) => {
           if (code === 0) {

--- a/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
+++ b/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
@@ -17,10 +17,19 @@ import { SpawnOptions, spawn } from 'node:child_process';
  * Algorithm: https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/
  */
 function escapeArgForWindowsShell(arg: string): string {
-  // Fast path: only safe characters present
-  if (arg === '' || /^[a-zA-Z0-9_\-./\\:@]+$/.test(arg)) {
+  // FIX A: empty string must produce a quoted empty token.
+  // Returning bare '' causes cmd.exe to drop the arg silently,
+  // shifting all subsequent args by one (argument confusion).
+  if (!arg) return '""';
+  // Fast path: only shell-safe chars, no quoting needed
+  if (/^[a-zA-Z0-9_\-./\\:@]+$/.test(arg)) {
     return arg;
   }
+  // FIX B: escape % BEFORE wrapping in double-quotes.
+  // cmd.exe expands %VAR% before evaluating quote context, so
+  // %COMSPEC% inside "..." still expands (BatBadBut / CVE-2024-3566).
+  // %% disables expansion and becomes a literal percent sign.
+  arg = arg.replace(/%/g, '%%');
   let result = '"';
   let slashes = 0;
   for (const char of arg) {

--- a/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
+++ b/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
@@ -8,6 +8,37 @@
 
 import { BaseException } from '@angular-devkit/core';
 import { SpawnOptions, spawn } from 'node:child_process';
+
+/**
+ * Escapes a single argument for safe use with Windows cmd.exe.
+ * Prevents OS command injection (CWE-78) by wrapping in double quotes
+ * and correctly escaping embedded quotes and backslashes.
+ *
+ * Algorithm: https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/
+ */
+function escapeArgForWindowsShell(arg: string): string {
+  // Fast path: only safe characters present
+  if (arg === '' || /^[a-zA-Z0-9_\-./\\:@]+$/.test(arg)) {
+    return arg;
+  }
+  let result = '"';
+  let slashes = 0;
+  for (const char of arg) {
+    if (char === '\\') {
+      slashes++;
+    } else if (char === '"') {
+      result += '\\'.repeat(slashes * 2 + 1) + '"';
+      slashes = 0;
+    } else {
+      result += '\\'.repeat(slashes) + char;
+      slashes = 0;
+    }
+  }
+  result += '\\'.repeat(slashes * 2) + '"';
+  return result;
+}
+
+
 import * as path from 'node:path';
 import ora from 'ora';
 import { TaskExecutor, UnsuccessfulWorkflowExecution } from '../../src';
@@ -126,7 +157,15 @@ export default function (
         // Workaround for https://github.com/sindresorhus/ora/issues/136.
         discardStdin: process.platform != 'win32',
       }).start();
-      const childProcess = spawn(`${taskPackageManagerName} ${args.join(' ')}`, spawnOptions).on(
+      // SECURITY FIX (CWE-78): escape each arg individually instead of raw concatenation.
+      const escapedArgs =
+        spawnOptions.shell === true
+          ? args.map(escapeArgForWindowsShell).join(' ')
+          : args.join(' ');
+      const childProcess = spawn(
+        `${taskPackageManagerName} ${escapedArgs}`,
+        spawnOptions,
+      ).on(
         'close',
         (code: number) => {
           if (code === 0) {

--- a/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
+++ b/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
@@ -116,7 +116,7 @@ export default function (
     }
 
     if (factoryOptions.registry) {
-      args.push(`--registry="${factoryOptions.registry}"`);
+      args.push('--registry', factoryOptions.registry);
     }
 
     if (factoryOptions.force) {

--- a/packages/schematics/angular/workspace/index.ts
+++ b/packages/schematics/angular/workspace/index.ts
@@ -25,7 +25,15 @@ export default function (options: WorkspaceOptions): Rule {
     const packageManager = options.packageManager;
     let packageManagerWithVersion: string | undefined;
 
+    const ALLOWED_PKG_MANAGERS = new Set(['npm', 'yarn', 'pnpm', 'bun', 'cnpm']);
     if (packageManager) {
+      // FIXED (CWE-78): packageManager is user-supplied with no runtime enum
+      // validation (SCAN C = zero hits). Enforce an allowlist before execSync.
+      if (!ALLOWED_PKG_MANAGERS.has(packageManager)) {
+        throw new Error(
+          `Invalid packageManager: "${packageManager}". Allowed: npm, yarn, pnpm, bun, cnpm`,
+        );
+      }
       let packageManagerVersion: string | undefined;
       try {
         packageManagerVersion = execSync(`${packageManager} --version`, {


### PR DESCRIPTION
## Problem

Five locations in Angular CLI concatenated user-controlled arguments
into a raw shell string executed by `cmd.exe` with `shell: true`.
Any shell metacharacter (`&`, `|`, `>`, `^`) in a crafted package
specifier or `--package-manager` flag value silently injects and
executes arbitrary OS commands alongside the legitimate process.

| File | Injection vector |
|------|-----------------|
| `package-managers/host.ts` | `ng add <pkg>`, `ng update` |
| `tasks/package-manager/executor.ts` | Any schematic `NodePackageInstallTask` |
| `ssr-dev-server/utils.ts` | SSR dev-server process spawn |
| `ssr-dev-server/index.ts` | `spawnAsObservable` with stray `shell:true` |
| `schematics/angular/workspace/index.ts` | `ng new --package-manager=<value>` |

## Fix

**Windows spawn paths** (`host.ts`, `executor.ts`, `utils.ts`):
Replace `spawn(\`${cmd} ${args.join(' ')}\`, { shell: true })` with
direct `cmd.exe` array invocation using `shell: false`. Node.js
controls argument quoting — metacharacters never reach cmd.exe as
shell operators.
```typescript
// BEFORE — unsafe
spawn(`${command} ${args.join(' ')}`, { shell: isWin32 })

// AFTER — safe
spawn('cmd.exe', ['/d', '/s', '/c', command, ...args], { shell: false })
```

**`ssr-dev-server/index.ts`**: Remove stray `shell: true` from the
`spawnAsObservable` call-site. Platform dispatch is handled inside
`utils.ts`.

**`workspace/index.ts`**: Add `ALLOWED_PKG_MANAGERS` Set guard before
`execSync(\`${packageManager} --version\`)`. Only `npm`, `yarn`,
`pnpm`, `bun`, `cnpm` accepted — blocks all-platform injection via
`ng new --package-manager`.

## Relation to prior work

Follows the fix pattern from #32678 which patched the analogous
`repo-init/executor.ts` path. This PR closes all five remaining
vulnerable locations.

## Verification
```bash
grep -rn "args\.join(' ')\|shell: true\|shell: isWin32" \
  packages/angular/cli/src/package-managers/host.ts \
  packages/angular_devkit/schematics/tasks/package-manager/executor.ts \
  packages/angular_devkit/build_angular/src/builders/ssr-dev-server/utils.ts \
  packages/angular_devkit/build_angular/src/builders/ssr-dev-server/index.ts \
  packages/schematics/angular/workspace/index.ts | grep -v "^\s*//"
# Expected: zero output
```

**CWE:** CWE-78 — Improper Neutralisation of Special Elements in an OS Command