### PR TITLE
build: safeguard terminal styling in devkit admin script

### DIFF
--- a/scripts/devkit-admin.mts
+++ b/scripts/devkit-admin.mts
@@ -33,12 +33,16 @@ process.chdir(path.join(scriptDir, '..'));
 
 const originalConsole = { ...console };
 console.warn = function (...args) {
-  const [m, ...rest] = args;
-  originalConsole.warn(styleText(['yellow'], m), ...rest);
+  if (typeof args[0] === 'string') {
+    args[0] = styleText(['yellow'], args[0]);
+  }
+  originalConsole.warn(...args);
 };
 console.error = function (...args) {
-  const [m, ...rest] = args;
-  originalConsole.error(styleText(['red'], m), ...rest);
+  if (typeof args[0] === 'string') {
+    args[0] = styleText(['red'], args[0]);
+  }
+  originalConsole.error(...args);
 };
 
 try {
@@ -47,6 +51,6 @@ try {
   process.exitCode = typeof exitCode === 'number' ? exitCode : 0;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } catch (err: any) {
-  console.error(err.stack);
+  console.error(err.stack ?? err);
   process.exitCode = 99;
 }


### PR DESCRIPTION
Prior to this change, if an unhandled promise rejection or error occurred that lacked a `stack` property, the `console.error` wrapper in `devkit-admin.mts` would receive `undefined`. Attempting to pass `undefined` to Node's `util.styleText` caused an unexpected `ERR_INVALID_ARG_TYPE` crash instead of printing the original error.

This commit updates the `console.warn` and `console.error` overrides to ensure they only apply `styleText` to strings. It also updates the top-level try-catch block to fallback to the original error object if `err.stack` is undefined, preventing silent suppression.