### PR TITLE
fix(@angular/build): invalidate cached SCSS errors when source files are corrected

### DIFF
--- a/packages/angular/build/src/builders/application/tests/behavior/rebuild-global_styles_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/rebuild-global_styles_spec.ts
@@ -11,6 +11,11 @@ import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setu
 
 describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
   describe('Behavior: "Rebuilds when global stylesheets change"', () => {
+    const CSS_AQUA = 'color: aqua';
+    const CSS_BLUE = 'color: blue';
+    const SCSS_AQUA = '$primary: aqua;';
+    const SCSS_BROKEN = '$primary: aqua\n$broken;';
+
     beforeEach(async () => {
       // Application code is not needed for styles tests
       await harness.writeFile('src/main.ts', 'console.log("TEST");');
@@ -30,8 +35,8 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
         [
           async ({ result }) => {
             expect(result?.success).toBe(true);
-            harness.expectFile('dist/browser/styles.css').content.toContain('color: aqua');
-            harness.expectFile('dist/browser/styles.css').content.not.toContain('color: blue');
+            harness.expectFile('dist/browser/styles.css').content.toContain(CSS_AQUA);
+            harness.expectFile('dist/browser/styles.css').content.not.toContain(CSS_BLUE);
 
             await harness.writeFile(
               'src/a.scss',
@@ -45,8 +50,8 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
           },
           ({ result }) => {
             expect(result?.success).toBe(true);
-            harness.expectFile('dist/browser/styles.css').content.not.toContain('color: aqua');
-            harness.expectFile('dist/browser/styles.css').content.toContain('color: blue');
+            harness.expectFile('dist/browser/styles.css').content.not.toContain(CSS_AQUA);
+            harness.expectFile('dist/browser/styles.css').content.toContain(CSS_BLUE);
           },
         ],
         { outputLogsOnFailure: false },
@@ -72,25 +77,20 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
           },
           async ({ result }) => {
             expect(result?.success).toBe(true);
-            harness.expectFile('dist/browser/styles.css').content.toContain('color: aqua');
-            harness.expectFile('dist/browser/styles.css').content.not.toContain('color: blue');
+            harness.expectFile('dist/browser/styles.css').content.toContain(CSS_AQUA);
+            harness.expectFile('dist/browser/styles.css').content.not.toContain(CSS_BLUE);
 
             await harness.writeFile('src/a.scss', '$primary: blue;\\nh1 { color: $primary; }');
           },
           ({ result }) => {
             expect(result?.success).toBe(true);
-            harness.expectFile('dist/browser/styles.css').content.not.toContain('color: aqua');
-            harness.expectFile('dist/browser/styles.css').content.toContain('color: blue');
+            harness.expectFile('dist/browser/styles.css').content.not.toContain(CSS_AQUA);
+            harness.expectFile('dist/browser/styles.css').content.toContain(CSS_BLUE);
           },
         ],
         { outputLogsOnFailure: false },
       );
     });
-
-    const SCSS_AQUA = '$primary: aqua;';
-    const SCSS_BROKEN = '$primary: aqua\n$broken;';
-    const CSS_AQUA = 'color: aqua';
-    const CSS_BLUE = 'color: blue';
 
     it('recovers from error in SCSS partial after fix on rebuild using @use', async () => {
       harness.useTarget('build', {
@@ -178,23 +178,23 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
           },
           async ({ result }) => {
             expect(result?.success).toBe(true);
-            harness.expectFile('dist/browser/styles.css').content.toContain('color: aqua');
-            harness.expectFile('dist/browser/styles.css').content.not.toContain('color: blue');
+            harness.expectFile('dist/browser/styles.css').content.toContain(CSS_AQUA);
+            harness.expectFile('dist/browser/styles.css').content.not.toContain(CSS_BLUE);
 
             harness.expectFile('dist/browser/other.css').content.toContain('color: green');
-            harness.expectFile('dist/browser/other.css').content.toContain('color: aqua');
-            harness.expectFile('dist/browser/other.css').content.not.toContain('color: blue');
+            harness.expectFile('dist/browser/other.css').content.toContain(CSS_AQUA);
+            harness.expectFile('dist/browser/other.css').content.not.toContain(CSS_BLUE);
 
             await harness.writeFile('src/a.scss', '$primary: blue;\\nh1 { color: $primary; }');
           },
           ({ result }) => {
             expect(result?.success).toBe(true);
-            harness.expectFile('dist/browser/styles.css').content.not.toContain('color: aqua');
-            harness.expectFile('dist/browser/styles.css').content.toContain('color: blue');
+            harness.expectFile('dist/browser/styles.css').content.not.toContain(CSS_AQUA);
+            harness.expectFile('dist/browser/styles.css').content.toContain(CSS_BLUE);
 
             harness.expectFile('dist/browser/other.css').content.toContain('color: green');
-            harness.expectFile('dist/browser/other.css').content.not.toContain('color: aqua');
-            harness.expectFile('dist/browser/other.css').content.toContain('color: blue');
+            harness.expectFile('dist/browser/other.css').content.not.toContain(CSS_AQUA);
+            harness.expectFile('dist/browser/other.css').content.toContain(CSS_BLUE);
           },
         ],
         { outputLogsOnFailure: false },

--- a/packages/angular/build/src/builders/application/tests/behavior/rebuild-global_styles_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/rebuild-global_styles_spec.ts
@@ -87,6 +87,11 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       );
     });
 
+    const SCSS_AQUA = '$primary: aqua;';
+    const SCSS_BROKEN = '$primary: aqua\n$broken;';
+    const CSS_AQUA = 'color: aqua';
+    const CSS_BLUE = 'color: blue';
+
     it('recovers from error in SCSS partial after fix on rebuild using @use', async () => {
       harness.useTarget('build', {
         ...BASE_OPTIONS,
@@ -95,16 +100,16 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       });
 
       await harness.writeFile('src/styles.scss', "@use './variables' as v;\nh1 { color: v.$primary; }");
-      await harness.writeFile('src/variables.scss', '$primary: aqua;');
+      await harness.writeFile('src/variables.scss', SCSS_AQUA);
 
       await harness.executeWithCases(
         [
           async ({ result }) => {
             expect(result?.success).toBe(true);
-            harness.expectFile('dist/browser/styles.css').content.toContain('color: aqua');
+            harness.expectFile('dist/browser/styles.css').content.toContain(CSS_AQUA);
 
             // Introduce a syntax error in the imported partial
-            await harness.writeFile('src/variables.scss', '$primary: aqua\n$broken;');
+            await harness.writeFile('src/variables.scss', SCSS_BROKEN);
           },
           async ({ result }) => {
             expect(result?.success).toBe(false);
@@ -114,8 +119,8 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
           },
           ({ result }) => {
             expect(result?.success).toBe(true);
-            harness.expectFile('dist/browser/styles.css').content.not.toContain('color: aqua');
-            harness.expectFile('dist/browser/styles.css').content.toContain('color: blue');
+            harness.expectFile('dist/browser/styles.css').content.not.toContain(CSS_AQUA);
+            harness.expectFile('dist/browser/styles.css').content.toContain(CSS_BLUE);
           },
         ],
         { outputLogsOnFailure: false },
@@ -131,7 +136,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
       await harness.writeFile('src/styles.scss', "@use './variables' as v;\nh1 { color: v.$primary; }");
       // Start with an error in the partial
-      await harness.writeFile('src/variables.scss', '$primary: aqua\n$broken;');
+      await harness.writeFile('src/variables.scss', SCSS_BROKEN);
 
       await harness.executeWithCases(
         [
@@ -139,11 +144,11 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
             expect(result?.success).toBe(false);
 
             // Fix the partial
-            await harness.writeFile('src/variables.scss', '$primary: aqua;');
+            await harness.writeFile('src/variables.scss', SCSS_AQUA);
           },
           ({ result }) => {
             expect(result?.success).toBe(true);
-            harness.expectFile('dist/browser/styles.css').content.toContain('color: aqua');
+            harness.expectFile('dist/browser/styles.css').content.toContain(CSS_AQUA);
           },
         ],
         { outputLogsOnFailure: false },

--- a/packages/angular/build/src/builders/application/tests/behavior/rebuild-global_styles_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/rebuild-global_styles_spec.ts
@@ -87,6 +87,69 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       );
     });
 
+    it('recovers from error in SCSS partial after fix on rebuild using @use', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        watch: true,
+        styles: ['src/styles.scss'],
+      });
+
+      await harness.writeFile('src/styles.scss', "@use './variables' as v;\nh1 { color: v.$primary; }");
+      await harness.writeFile('src/variables.scss', '$primary: aqua;');
+
+      await harness.executeWithCases(
+        [
+          async ({ result }) => {
+            expect(result?.success).toBe(true);
+            harness.expectFile('dist/browser/styles.css').content.toContain('color: aqua');
+
+            // Introduce a syntax error in the imported partial
+            await harness.writeFile('src/variables.scss', '$primary: aqua\n$broken;');
+          },
+          async ({ result }) => {
+            expect(result?.success).toBe(false);
+
+            // Fix the partial — the cached error should be cleared
+            await harness.writeFile('src/variables.scss', '$primary: blue;');
+          },
+          ({ result }) => {
+            expect(result?.success).toBe(true);
+            harness.expectFile('dist/browser/styles.css').content.not.toContain('color: aqua');
+            harness.expectFile('dist/browser/styles.css').content.toContain('color: blue');
+          },
+        ],
+        { outputLogsOnFailure: false },
+      );
+    });
+
+    it('recovers from error in SCSS partial after fix on initial build using @use', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        watch: true,
+        styles: ['src/styles.scss'],
+      });
+
+      await harness.writeFile('src/styles.scss', "@use './variables' as v;\nh1 { color: v.$primary; }");
+      // Start with an error in the partial
+      await harness.writeFile('src/variables.scss', '$primary: aqua\n$broken;');
+
+      await harness.executeWithCases(
+        [
+          async ({ result }) => {
+            expect(result?.success).toBe(false);
+
+            // Fix the partial
+            await harness.writeFile('src/variables.scss', '$primary: aqua;');
+          },
+          ({ result }) => {
+            expect(result?.success).toBe(true);
+            harness.expectFile('dist/browser/styles.css').content.toContain('color: aqua');
+          },
+        ],
+        { outputLogsOnFailure: false },
+      );
+    });
+
     it('rebuilds dependent Sass stylesheets after error on initial build from import', async () => {
       harness.useTarget('build', {
         ...BASE_OPTIONS,

--- a/packages/angular/build/src/tools/esbuild/load-result-cache.ts
+++ b/packages/angular/build/src/tools/esbuild/load-result-cache.ts
@@ -70,7 +70,13 @@ export class MemoryLoadResultCache implements LoadResultCache {
   }
 
   invalidate(path: string): boolean {
-    const affectedPaths = this.#fileDependencies.get(path);
+    // Normalize the path to match how watch file paths are stored in `put()`.
+    // Without normalization, paths produced by `fileURLToPath()` or `path.join()`
+    // during error reporting may use different separators than the normalized paths
+    // stored as keys in `#fileDependencies`, causing the lookup to fail and leaving
+    // stale error results in the cache after the source file is corrected.
+    const normalizedPath = normalize(path);
+    const affectedPaths = this.#fileDependencies.get(normalizedPath);
     let found = false;
 
     if (affectedPaths) {
@@ -79,7 +85,7 @@ export class MemoryLoadResultCache implements LoadResultCache {
           found = true;
         }
       }
-      this.#fileDependencies.delete(path);
+      this.#fileDependencies.delete(normalizedPath);
     }
 
     return found;


### PR DESCRIPTION
## Problem

When a SCSS partial (or any Sass dependency) contains an error during `ng serve`, fixing the file does not clear the error in watch mode. The stale error remains cached even after the source is corrected. Fixes #32744.

## Root Cause

`MemoryLoadResultCache.put()` stores file dependencies using `normalize(watchFile)` to ensure OS-consistent path separators. However, `invalidate()` looked up dependencies using the raw, un-normalized path. During Sass error reporting, `watchFiles` are populated via `extractFilesFromStack()` (which uses `path.join(cwd, relativePath)`) and `fileURLToPath()` — both produce paths that may use different separators. The resulting path mismatch caused `invalidate()` to silently fail to find the cache entry, leaving the stale error result in `#loadResults`. On the next rebuild, `createCachedLoad()` returned the stale (error) result from the cache instead of re-compiling the now-fixed SCSS.

## Fix

Normalize the path inside `invalidate()` (using the same `normalize()` call that `put()` uses) before looking up the key in `#fileDependencies`. This ensures the invalidation lookup always matches the stored entry regardless of how the path was formatted by the caller.

## Changes

- `packages/angular/build/src/tools/esbuild/load-result-cache.ts` — normalize `path` in `invalidate()` to match how keys are stored in `put()`
- `packages/angular/build/src/builders/application/tests/behavior/rebuild-global_styles_spec.ts` — add two regression tests covering the `@use` partial error scenario (rebuild after error introduced mid-watch, and recovery from error present at initial build)

## Test plan

- [ ] `bazel test //packages/angular/build:application_integration_tests` — new tests `recovers from error in SCSS partial after fix on rebuild using @use` and `recovers from error in SCSS partial after fix on initial build using @use` pass
- [ ] Existing `rebuilds Sass stylesheet after error on rebuild from import` and related tests continue to pass