### PR TITLE
fix(@angular/cli): gracefully skip unfetchable packages during ng update

### DIFF
--- a/packages/angular/cli/src/commands/update/schematic/index.ts
+++ b/packages/angular/cli/src/commands/update/schematic/index.ts
@@ -854,6 +854,16 @@ export default function (options: UpdateSchema): Rule {
           registry: options.registry,
           usingYarn,
           verbose: options.verbose,
+        }).catch((error: unknown) => {
+          // If the package cannot be fetched (e.g. private registry, JSR, AWS CodeArtifact,
+          // or local workspace packages), return a partial object so the reduce below can
+          // decide whether to warn or hard-fail based on whether it was explicitly requested.
+          const message = error instanceof Error ? error.message : String(error);
+          logger.warn(
+            `Package '${depName}' could not be fetched from the registry: ${message}`,
+          );
+
+          return { requestedName: depName } as Partial<NpmRepositoryPackageJson>;
         }),
       ),
     );

--- a/packages/angular/cli/src/commands/update/schematic/index.ts
+++ b/packages/angular/cli/src/commands/update/schematic/index.ts
@@ -858,7 +858,7 @@ export default function (options: UpdateSchema): Rule {
           // If the package cannot be fetched (e.g. private registry, JSR, AWS CodeArtifact,
           // or local workspace packages), return a partial object so the reduce below can
           // decide whether to warn or hard-fail based on whether it was explicitly requested.
-          const message = (error as { message?: string }).message ?? String(error);
+          const message = error instanceof Error ? error.message : (error as any)?.message ?? String(error);
           logger.warn(
             `Package '${depName}' could not be fetched from the registry: ${message}`,
           );

--- a/packages/angular/cli/src/commands/update/schematic/index.ts
+++ b/packages/angular/cli/src/commands/update/schematic/index.ts
@@ -858,7 +858,7 @@ export default function (options: UpdateSchema): Rule {
           // If the package cannot be fetched (e.g. private registry, JSR, AWS CodeArtifact,
           // or local workspace packages), return a partial object so the reduce below can
           // decide whether to warn or hard-fail based on whether it was explicitly requested.
-          const message = error instanceof Error ? error.message : String(error);
+          const message = (error as { message?: string }).message ?? String(error);
           logger.warn(
             `Package '${depName}' could not be fetched from the registry: ${message}`,
           );

--- a/packages/angular/cli/src/commands/update/schematic/index_spec.ts
+++ b/packages/angular/cli/src/commands/update/schematic/index_spec.ts
@@ -336,6 +336,48 @@ describe('@schematics/update', () => {
     expect(resultTreeContent.endsWith('}')).toBeTrue();
   });
 
+  it('skips packages that cannot be fetched from the registry and continues updating others', async () => {
+    // Regression test for https://github.com/angular/angular-cli/issues/28834
+    // Packages from private registries, JSR, AWS CodeArtifact, or local workspaces
+    // may resolve as npm-registry packages (pass isPkgFromRegistry) but fail to fetch
+    // with a 404.  The schematic should warn and skip them rather than hard-failing.
+    const inputTree = new UnitTestTree(
+      new HostTree(
+        new virtualFs.test.TestHost({
+          '/package.json': JSON.stringify({
+            name: 'blah',
+            dependencies: {
+              // A real package that can be updated:
+              '@angular-devkit-tests/update-base': '1.0.0',
+              // A scoped package that does not exist on the npm registry (simulates a
+              // private / JSR / CodeArtifact package that passes the registry specifier
+              // check but returns a 404 when fetched):
+              '@private-nonexistent/package-ng-update-issue-28834': '1.0.0',
+            },
+          }),
+        }),
+      ),
+    );
+
+    const messages: string[] = [];
+    schematicRunner.logger.subscribe((x) => messages.push(x.message));
+
+    // Should NOT throw even though one package cannot be fetched.
+    const resultTree = await schematicRunner.runSchematic('update', undefined, inputTree);
+
+    // The unfetchable package should be warned about.
+    expect(
+      messages.some((m) => m.includes('@private-nonexistent/package-ng-update-issue-28834')),
+    ).toBeTrue();
+
+    // The package.json should be unchanged (nothing to update in no-packages mode).
+    const { dependencies } = resultTree.readJson('/package.json') as {
+      dependencies: Record<string, string>;
+    };
+    expect(dependencies['@angular-devkit-tests/update-base']).toBe('1.0.0');
+    expect(dependencies['@private-nonexistent/package-ng-update-issue-28834']).toBe('1.0.0');
+  }, 45000);
+
   it('updates group members to the same version as the targeted package', async () => {
     const packageJsonContent = `{
       "name": "test",

--- a/packages/angular/cli/src/commands/update/schematic/index_spec.ts
+++ b/packages/angular/cli/src/commands/update/schematic/index_spec.ts
@@ -336,18 +336,19 @@ describe('@schematics/update', () => {
     expect(resultTreeContent.endsWith('}')).toBeTrue();
   });
 
-  it('skips packages that cannot be fetched from the registry and continues updating others', async () => {
+  it('continues updating others when one package fetch fails', async () => {
     // Regression test for https://github.com/angular/angular-cli/issues/28834
     // Packages from private registries, JSR, AWS CodeArtifact, or local workspaces
     // may resolve as npm-registry packages (pass isPkgFromRegistry) but fail to fetch
-    // with a 404.  The schematic should warn and skip them rather than hard-failing.
+    // with a 404.  The schematic should warn and skip them rather than hard-failing,
+    // and other explicitly-requested packages should still be updated.
     const inputTree = new UnitTestTree(
       new HostTree(
         new virtualFs.test.TestHost({
           '/package.json': JSON.stringify({
             name: 'blah',
             dependencies: {
-              // A real package that can be updated:
+              // A real package that should be updated:
               '@angular-devkit-tests/update-base': '1.0.0',
               // A scoped package that does not exist on the npm registry (simulates a
               // private / JSR / CodeArtifact package that passes the registry specifier
@@ -363,18 +364,22 @@ describe('@schematics/update', () => {
     schematicRunner.logger.subscribe((x) => messages.push(x.message));
 
     // Should NOT throw even though one package cannot be fetched.
-    const resultTree = await schematicRunner.runSchematic('update', undefined, inputTree);
+    const resultTree = await schematicRunner.runSchematic(
+      'update',
+      { packages: ['@angular-devkit-tests/update-base'] },
+      inputTree,
+    );
 
-    // The unfetchable package should be warned about.
+    // The unfetchable package should produce a warning.
     expect(
       messages.some((m) => m.includes('@private-nonexistent/package-ng-update-issue-28834')),
     ).toBeTrue();
 
-    // The package.json should be unchanged (nothing to update in no-packages mode).
+    // The valid package should have been updated despite the other package failing.
     const { dependencies } = resultTree.readJson('/package.json') as {
       dependencies: Record<string, string>;
     };
-    expect(dependencies['@angular-devkit-tests/update-base']).toBe('1.0.0');
+    expect(dependencies['@angular-devkit-tests/update-base']).toBe('1.1.0');
     expect(dependencies['@private-nonexistent/package-ng-update-issue-28834']).toBe('1.0.0');
   }, 45000);
 


### PR DESCRIPTION
## Problem

`ng update` hard-fails when `package.json` contains packages that pass
the `isPkgFromRegistry` check (i.e., they are specified as plain semver
ranges) but cannot actually be fetched from the registry. This affects
JSR packages (`@std/toml`), private/scoped packages on corporate
registries (AWS CodeArtifact), and local workspace packages referenced
by name. The error looks like:

```
Migration failed: 404 Not Found - GET https://registry.npmjs.org/@std%2ftoml - Not found
```

## Root Cause

In `packages/angular/cli/src/commands/update/schematic/index.ts`, all
package metadata is fetched via `Promise.all(deps.map(getNpmPackageJson))`.
If any single fetch rejects (404, ENOTFOUND, auth error), the entire
`Promise.all` rejects and kills the update before any package is
processed.

The code that follows the `Promise.all` already handles the "package not
found" case gracefully (it distinguishes between auto-discovered packages
and explicitly-requested ones), but it never gets a chance to run when
the fetch itself throws.

## Fix

Attach a `.catch()` to each individual `getNpmPackageJson` call. On
failure the catch emits a warning like:

```
Package '@std/toml' could not be fetched from the registry: 404 Not Found ...
```

and returns the same sentinel shape (`{ requestedName }`) that the
existing reduce block already knows how to handle:

- Auto-discovered dependencies (not passed on the CLI): skipped with a warning, rest of update continues.
- Explicitly requested packages (`ng update @some/pkg`): still produce a `SchematicsException` so the user gets a clear error.

## New Behavior

```
$ ng update
Package '@std/toml' could not be fetched from the registry: 404 Not Found - GET https://registry.npmjs.org/@std%2ftoml - Not found
We analyzed your package.json, there are some packages to update: ...
```

Instead of:
```
Migration failed: 404 Not Found - GET https://registry.npmjs.org/@std%2ftoml - Not found
```

## Test

Added a regression test in `index_spec.ts` that puts a non-existent
scoped package (`@private-nonexistent/package-ng-update-issue-28834`)
alongside a real one, runs the schematic, and asserts it completes
without throwing while emitting a warning for the unfetchable package.

Closes #28834