### PR TITLE
fix(@angular/cli): handle pnpm catalog: protocol in ng update

### DIFF
--- a/packages/angular/cli/src/commands/update/schematic/index.ts
+++ b/packages/angular/cli/src/commands/update/schematic/index.ts
@@ -773,11 +773,31 @@ function _getAllDependencies(tree: Tree): Array<readonly [string, VersionRange]>
     '/package.json',
   ) as PackageManifest;
 
-  return [
+  const allDeps = [
     ...(Object.entries(peerDependencies || {}) as Array<[string, VersionRange]>),
     ...(Object.entries(devDependencies || {}) as Array<[string, VersionRange]>),
     ...(Object.entries(dependencies || {}) as Array<[string, VersionRange]>),
   ];
+
+  // Resolve pnpm catalog: protocol references to actual version ranges.
+  // The catalog: protocol is not a valid semver range and must be resolved
+  // before downstream processing.
+  return allDeps.map(([name, specifier]) => {
+    if (!specifier.startsWith('catalog:')) {
+      return [name, specifier] as const;
+    }
+
+    // Fall back to the installed version from node_modules
+    const pkgJsonPath = `/node_modules/${name}/package.json`;
+    if (tree.exists(pkgJsonPath)) {
+      const { version } = tree.readJson(pkgJsonPath) as PackageManifest;
+      if (version) {
+        return [name, `^${version}` as VersionRange] as const;
+      }
+    }
+
+    return [name, specifier] as const;
+  });
 }
 
 function _formatVersion(version: string | undefined) {
@@ -804,6 +824,11 @@ function _formatVersion(version: string | undefined) {
  * @throws When the specifier cannot be parsed.
  */
 function isPkgFromRegistry(name: string, specifier: string): boolean {
+  // pnpm catalog: protocol always references registry packages
+  if (specifier.startsWith('catalog:')) {
+    return true;
+  }
+
   const result = npa.resolve(name, specifier);
 
   return !!result.registry;

--- a/packages/angular/cli/src/commands/update/schematic/index_spec.ts
+++ b/packages/angular/cli/src/commands/update/schematic/index_spec.ts
@@ -97,6 +97,35 @@ describe('@schematics/update', () => {
     expect(dependencies['@angular-devkit-tests/update-base']).toBe('1.1.0');
   });
 
+  it('should not error with pnpm catalog: protocol', async () => {
+    const newTree = new UnitTestTree(
+      new HostTree(
+        new virtualFs.test.TestHost({
+          '/package.json': `{
+        "name": "blah",
+        "dependencies": {
+          "@angular-devkit-tests/update-base": "catalog:"
+        }
+      }`,
+          '/node_modules/@angular-devkit-tests/update-base/package.json': `{
+        "name": "@angular-devkit-tests/update-base",
+        "version": "1.0.0"
+      }`,
+        }),
+      ),
+    );
+
+    const resultTree = await schematicRunner.runSchematic(
+      'update',
+      {
+        packages: ['@angular-devkit-tests/update-base'],
+      },
+      newTree,
+    );
+    const { dependencies } = JSON.parse(resultTree.readContent('/package.json'));
+    expect(dependencies['@angular-devkit-tests/update-base']).toBe('1.1.0');
+  });
+
   it('updates Angular as compatible with Angular N-1', async () => {
     // Add the basic migration package.
     const content = virtualFs.fileBufferToString(host.sync.read(normalize('/package.json')));


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## What is the current behavior?

When using pnpm's `catalog:` protocol for dependency versions in `package.json` (e.g., `"@angular/core": "catalog:"`), `ng update` fails because:

1. `isPkgFromRegistry()` uses `npm-package-arg` to parse the specifier, which doesn't recognize `catalog:` — causing all catalog dependencies to be skipped with "Package X was not found on the registry"
2. Even if they pass through, `catalog:` is not a valid semver range, so version resolution fails

Issue Number: #30443

## What is the new behavior?

Two targeted fixes:

1. **`isPkgFromRegistry()`** now recognizes `catalog:` specifiers as referencing registry packages (they always do — catalogs are just version aliases defined in `pnpm-workspace.yaml`)

2. **`_getAllDependencies()`** resolves `catalog:` specifiers to `^<installed-version>` by reading the actual installed version from `node_modules/<pkg>/package.json`. This provides a valid semver range for all downstream processing (version comparison, satisfying version lookup, etc.)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No