### PR TITLE
fix(@angular/build): allow serving node_modules assets in monorepo setups

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite/server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite/server.ts
@@ -8,7 +8,7 @@
 
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import type { Connect, InlineConfig, SSROptions, ServerOptions } from 'vite';
+import { type Connect, type InlineConfig, type SSROptions, type ServerOptions, searchForPackageRoot } from 'vite';
 import type { ComponentStyleRecord } from '../../../tools/vite/middlewares';
 import {
   ServerSsrMode,
@@ -75,9 +75,12 @@ async function createServerConfig(
       // The first two are required for Vite to function in prebundling mode (the default) and to load
       // the Vite client-side code for browser reloading. These would be available by default but when
       // the `allow` option is explicitly configured, they must be included manually.
+      // The package root search handles monorepo setups where node_modules may be hoisted
+      // to a parent directory above the Angular workspace root.
       allow: [
         cacheDir,
         join(serverOptions.workspaceRoot, 'node_modules'),
+        searchForPackageRoot(serverOptions.workspaceRoot),
         ...[...assets.values()].map(({ source }) => source),
       ],
     },


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## What is the current behavior?

In monorepo setups where `node_modules` are hoisted to a parent directory above the Angular workspace root, assets loaded from those packages (e.g., font files referenced in CSS from a library in root `node_modules`) are blocked by Vite's dev server with a **403 Forbidden** error.

This happens because Angular explicitly sets `server.fs.allow`, which overrides Vite's default package root auto-detection. The explicit list only includes `{workspaceRoot}/node_modules`, missing the monorepo root's `node_modules`.

Issue Number: #31016

## What is the new behavior?

Uses Vite's built-in `searchForPackageRoot()` to find the actual package installation root (which traverses up from the workspace root to find the nearest directory with `package.json` + `node_modules`). This directory is added to `fs.allow`, allowing access to hoisted node_modules in monorepo setups.

From [Vite docs](https://vite.dev/config/server-options.html#server-fs-allow):
> When `server.fs.allow` is set, the auto workspace root detection will be disabled. To extend the original behavior, a utility `searchForPackageRoot` is exposed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No