### PR TITLE
fix(@angular/build): respect sourceMap configuration in dev server

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite/index.ts
+++ b/packages/angular/build/src/builders/dev-server/vite/index.ts
@@ -146,9 +146,11 @@ export async function* serveWithVite(
     browserOptions.forceI18nFlatOutput = true;
   }
 
-  const { vendor: thirdPartySourcemaps, scripts: scriptsSourcemaps } = normalizeSourceMaps(
-    browserOptions.sourceMap ?? false,
-  );
+  const {
+    vendor: thirdPartySourcemaps,
+    scripts: scriptsSourcemaps,
+    styles: stylesSourcemaps,
+  } = normalizeSourceMaps(browserOptions.sourceMap ?? false);
 
   if (scriptsSourcemaps && browserOptions.server) {
     // https://nodejs.org/api/process.html#processsetsourcemapsenabledval
@@ -184,7 +186,7 @@ export async function* serveWithVite(
     // Always enable JIT linking to support applications built with and without AOT.
     // In a development environment the additional scope information does not
     // have a negative effect unlike production where final output size is relevant.
-    { sourcemap: true, jit: true, thirdPartySourcemaps },
+    { sourcemap: scriptsSourcemaps, jit: true, thirdPartySourcemaps },
     1,
   );
 
@@ -428,6 +430,7 @@ export async function* serveWithVite(
         extensions?.middleware,
         transformers?.indexHtml,
         thirdPartySourcemaps,
+        stylesSourcemaps,
       );
 
       server = await createServer(serverConfiguration);

--- a/packages/angular/build/src/builders/dev-server/vite/server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite/server.ts
@@ -145,6 +145,7 @@ export async function setupServer(
   extensionMiddleware?: Connect.NextHandleFunction[],
   indexHtmlTransformer?: (content: string) => Promise<string>,
   thirdPartySourcemaps = false,
+  stylesSourcemaps = true,
 ): Promise<InlineConfig> {
   const { normalizePath } = await import('vite');
 
@@ -175,7 +176,7 @@ export async function setupServer(
     // We use custom as we do not rely on Vite's htmlFallbackMiddleware and indexHtmlMiddleware.
     appType: 'custom',
     css: {
-      devSourcemap: true,
+      devSourcemap: stylesSourcemaps,
     },
     // Ensure custom 'file' loader build option entries are handled by Vite in application code that
     // reference third-party libraries. Relative usage is handled directly by the build and not Vite.


### PR DESCRIPTION
## Summary

- The dev server was ignoring the `sourceMap` configuration from `angular.json`, always injecting inline source maps into all served files even when explicitly disabled
- `css.devSourcemap` was hardcoded to `true` instead of using the `styles` source map setting
- The prebundle `JavaScriptTransformer` was created with `sourcemap: true` hardcoded, causing Vite's dependency prebundling to always generate source maps for third-party packages
- The fix passes the normalized `scripts` and `styles` source map settings through to the Vite configuration

Closes #31331

## Test plan

- [ ] Run `ng serve` with `"sourceMap": false` in angular.json and verify no inline source maps in served JS/CSS files
- [ ] Run `ng serve` with default config and verify source maps still work
- [ ] Run `ng serve` with granular config `{"scripts": false, "styles": true}` and verify only CSS has source maps


