### PR TITLE
fix(@angular/cli): skip CLI version check for migrate-only updates

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite/index.ts
+++ b/packages/angular/build/src/builders/dev-server/vite/index.ts
@@ -146,9 +146,11 @@ export async function* serveWithVite(
     browserOptions.forceI18nFlatOutput = true;
   }
 
-  const { vendor: thirdPartySourcemaps, scripts: scriptsSourcemaps } = normalizeSourceMaps(
-    browserOptions.sourceMap ?? false,
-  );
+  const {
+    vendor: thirdPartySourcemaps,
+    scripts: scriptsSourcemaps,
+    styles: stylesSourcemaps,
+  } = normalizeSourceMaps(browserOptions.sourceMap ?? false);
 
   if (scriptsSourcemaps && browserOptions.server) {
     // https://nodejs.org/api/process.html#processsetsourcemapsenabledval
@@ -184,7 +186,7 @@ export async function* serveWithVite(
     // Always enable JIT linking to support applications built with and without AOT.
     // In a development environment the additional scope information does not
     // have a negative effect unlike production where final output size is relevant.
-    { sourcemap: true, jit: true, thirdPartySourcemaps },
+    { sourcemap: scriptsSourcemaps, jit: true, thirdPartySourcemaps },
     1,
   );
 
@@ -428,6 +430,7 @@ export async function* serveWithVite(
         extensions?.middleware,
         transformers?.indexHtml,
         thirdPartySourcemaps,
+        stylesSourcemaps,
       );
 
       server = await createServer(serverConfiguration);

--- a/packages/angular/build/src/builders/dev-server/vite/server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite/server.ts
@@ -145,6 +145,7 @@ export async function setupServer(
   extensionMiddleware?: Connect.NextHandleFunction[],
   indexHtmlTransformer?: (content: string) => Promise<string>,
   thirdPartySourcemaps = false,
+  stylesSourcemaps = true,
 ): Promise<InlineConfig> {
   const { normalizePath } = await import('vite');
 
@@ -175,7 +176,7 @@ export async function setupServer(
     // We use custom as we do not rely on Vite's htmlFallbackMiddleware and indexHtmlMiddleware.
     appType: 'custom',
     css: {
-      devSourcemap: true,
+      devSourcemap: stylesSourcemaps,
     },
     // Ensure custom 'file' loader build option entries are handled by Vite in application code that
     // reference third-party libraries. Relative usage is handled directly by the build and not Vite.

--- a/packages/angular/cli/src/commands/update/cli.ts
+++ b/packages/angular/cli/src/commands/update/cli.ts
@@ -167,7 +167,9 @@ export default class UpdateCommandModule extends CommandModule<UpdateCommandArgs
 
     // Check if the current installed CLI version is older than the latest compatible version.
     // Skip when running `ng update` without a package name as this will not trigger an actual update.
-    if (!disableVersionCheck && options.packages?.length) {
+    // Also skip when using migrate-only mode (--name or --migrate-only) since migrations run
+    // against the currently installed package version, not a remote one.
+    if (!disableVersionCheck && options.packages?.length && !options.migrateOnly) {
       const cliVersionToInstall = await checkCLIVersion(
         options.packages,
         logger,


### PR DESCRIPTION
## Summary

- When running `ng update @angular/cli --name=use-application-builder`, the CLI fetched and installed the latest version (e.g., v20) as a temporary CLI, even though migrate-only mode operates on the currently installed package version
- This caused incompatible packages to be installed (e.g., `@angular/build@20` on an Angular 18/19 project)
- The fix adds `!options.migrateOnly` to the CLI version check condition, skipping it when using `--name` or `--migrate-only` since migrations run against the installed version

Closes #30696

## Test plan

- [ ] Run `ng update @angular/cli --name=use-application-builder` on an Angular 19 project — should use the installed CLI, not fetch latest
- [ ] Run `ng update @angular/cli` (without --name) — should still check for newer CLI version as before
- [ ] Run `ng update @angular/cli --migrate-only` — should skip CLI version check


