### PR TITLE
fix(@angular/cli): handle npm-aliased and unfetchable packages in ng update

### DIFF
--- a/packages/angular/cli/src/commands/update/schematic/index.ts
+++ b/packages/angular/cli/src/commands/update/schematic/index.ts
@@ -804,6 +804,13 @@ function _formatVersion(version: string | undefined) {
  * @throws When the specifier cannot be parsed.
  */
 function isPkgFromRegistry(name: string, specifier: string): boolean {
+  // npm: aliases (e.g., "npm:real-package@^1.0.0") resolve as registry packages
+  // but the dependency key name differs from the actual package name, so registry
+  // lookups using the alias name would fail with a 404.
+  if (specifier.startsWith('npm:')) {
+    return false;
+  }
+
   const result = npa.resolve(name, specifier);
 
   return !!result.registry;
@@ -854,6 +861,12 @@ export default function (options: UpdateSchema): Rule {
           registry: options.registry,
           usingYarn,
           verbose: options.verbose,
+        }).catch(() => {
+          // Package metadata could not be fetched (e.g. private registry, npm: alias,
+          // JSR package, or AWS CodeArtifact). Return a partial result so the reduce
+          // below can decide whether to warn or error based on whether it was explicitly
+          // requested.
+          return { requestedName: depName } as Partial<NpmRepositoryPackageJson>;
         }),
       ),
     );


### PR DESCRIPTION
## Summary

- `ng update` would fail with a 404 error when `package.json` contains dependencies using npm aliases (`"my-pkg": "npm:real-package@^1.0.0"`) or packages from private/non-npmjs registries
- The `Promise.all()` for fetching package metadata would reject entirely when any single package couldn't be fetched, even if it wasn't part of the update
- The fix filters out `npm:` aliased packages early (since the alias name differs from the real package name) and catches individual fetch errors gracefully, allowing the existing reduce logic to handle missing packages

Closes #28834

## Test plan

- [ ] Run `ng update` on a project with `npm:` aliased dependencies — should complete without error
- [ ] Run `ng update` on a project with private registry packages — should skip unfetchable packages gracefully
- [ ] Run `ng update @angular/core` on a normal project — should work as before


