### PR TITLE
fix(@angular/build): isolate Vite cache per build configuration in dev server

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite/server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite/server.ts
@@ -162,7 +162,14 @@ export async function setupServer(
    */
   const preTransformRequests =
     externalMetadata.explicitBrowser.length === 0 && ssrMode === ServerSsrMode.NoSsr;
-  const cacheDir = join(serverOptions.cacheOptions.path, serverOptions.buildTarget.project, 'vite');
+  // Include the build configuration in the cache path to prevent conflicts when running
+  // multiple dev server instances with different configurations (e.g., different locales).
+  const cacheDir = join(
+    serverOptions.cacheOptions.path,
+    serverOptions.buildTarget.project,
+    'vite',
+    serverOptions.buildTarget.configuration ?? '',
+  );
 
   const configuration: InlineConfig = {
     configFile: false,


### PR DESCRIPTION
## Summary

- Running two `ng serve` instances for the same project with different configurations (e.g., different locales) caused "504 Outdated Optimize Dep" errors
- Both instances shared the same Vite optimizer cache directory (`<cache>/<project>/vite`), so when one instance updated the cache, the other detected stale metadata
- The fix includes the build configuration name in the cache path (`<cache>/<project>/vite/<configuration>`), isolating each instance's cache

Closes #31700

## Test plan

- [ ] Run two `ng serve` instances with different configurations concurrently — no 504 errors
- [ ] Single `ng serve` instance still works correctly
- [ ] Cache directory is properly created with configuration suffix


