### PR TITLE
ci: re-enable renovate for esbuild packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "baseBranchPatterns": ["main", "21.2.x"],
   "extends": ["github>angular/dev-infra//renovate-presets/default.json5"],
-  "ignoreDeps": ["esbuild", "esbuild-wasm"],
   "ignorePaths": ["tests/e2e/assets/**", "tests/schematics/update/packages/**"],
   "packageRules": [
     {


### PR DESCRIPTION
The upstream regression issue has been addressed, allowing dependency updates for esbuild and esbuild-wasm to resume.