### PR TITLE
docs: add spam policy and saved reply

### DIFF
--- a/.github/SAVED_REPLIES.md
+++ b/.github/SAVED_REPLIES.md
@@ -99,3 +99,13 @@ I'd like to remind everyone that **you only have reproducible installs if you us
 
 **It is your responsibility as a library consumer to use lockfiles**. No one wants to do a release with bugs but it sometimes happens, and the best we can do is to fix it as fast as possible with a new release. When you have a couple of thousand total dependencies it is only a matter of time until one of them has a bad release.
 ```
+
+## Angular CLI: Spam (v1)
+
+```
+Woah, looks like you've opened a lot of issues/PRs recently. While we appreciate contributions from the community, triaging and reviewing a large influx of content in a short time period takes time away from other ongoing projects. As a result, we're closing these issues/PRs to maintain the team's focus.
+
+Note that this is not necessarily a rejection of the goals or direction of any of these contributions in particular, so much as a reflection of the team's current capacity and priorities.
+
+You are welcome to open a smaller subset of issues/PRs in accordance with [our policy](https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#spam-policy) focused on the most important and impactful contributions and we will do our best to prioritize a response as soon as possible.
+```

--- a/.github/SAVED_REPLIES.md
+++ b/.github/SAVED_REPLIES.md
@@ -107,5 +107,5 @@ Woah, looks like you've opened a lot of issues/PRs recently. While we appreciate
 
 Note that this is not necessarily a rejection of the goals or direction of any of these contributions in particular, so much as a reflection of the team's current capacity and priorities.
 
-You are welcome to open a smaller subset of issues/PRs in accordance with [our policy](https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#spam-policy) focused on the most important and impactful contributions and we will do our best to prioritize a response as soon as possible.
+You are welcome to open a smaller subset of issues/PRs in accordance with [our policy](https://github.com/angular/angular/blob/main/contributing-docs/spam.md) focused on the most important and impactful contributions and we will do our best to prioritize a response as soon as possible.
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -291,17 +291,7 @@ changes to be accepted, the CLA must be signed. It's a quick process, we promise
 
 ## <a name="spam-policy"></a> Spam Policy
 
-Users who create excessive amounts of issues or PRs in a short time frame, particularly low-quality or low-value contributions, may see those contributions automatically closed without consideration.
-
-Community contributors should limit themselves to no more than 3 open PRs at a single time.
-
-### Why?
-
-Reviewing and shepherding PRs as well as managing large issue counts takes time and energy from the core team. Triaging a PR well enough to understand its goals and implementation takes a significant amount of time, regardless of whether the PR is ultimately accepted. This policy ensures the team is able to balance its limited resources across all contributors and projects.
-
-### Exceptions
-
-If you plan to undertake more significant work that you anticipate will generate many individual PRs, please reach out to the team in a Github issue first to validate that Angular will be able to support and accept your contributions.
+See [Spam Policy](https://github.com/angular/angular/blob/main/contributing-docs/spam.md) for details.
 
 [coc]: https://github.com/angular/code-of-conduct/blob/main/CODE_OF_CONDUCT.md
 [commit-message-format]: https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ to follow:
  - [Coding Rules](#rules)
  - [Commit Message Guidelines](#commit)
  - [Signing the CLA](#cla)
- - [Updating the Public API](#public-api)
+ - [Spam Policy](#spam-policy)
 
 ## <a name="coc"></a> Code of Conduct
 Help us keep Angular open and inclusive. Please read and follow our [Code of Conduct][coc].
@@ -289,6 +289,19 @@ changes to be accepted, the CLA must be signed. It's a quick process, we promise
 * For corporations we'll need you to
   [print, sign and one of scan+email, fax or mail the form][corporate-cla].
 
+## <a name="spam-policy"></a> Spam Policy
+
+Users who create excessive amounts of issues or PRs in a short time frame, particularly low-quality or low-value contributions, may see those contributions automatically closed without consideration.
+
+Community contributors should limit themselves to no more than 3 open PRs at a single time.
+
+### Why?
+
+Reviewing and shepherding PRs as well as managing large issue counts takes time and energy from the core team. Triaging a PR well enough to understand its goals and implementation takes a significant amount of time, regardless of whether the PR is ultimately accepted. This policy ensures the team is able to balance its limited resources across all contributors and projects.
+
+### Exceptions
+
+If you plan to undertake more significant work that you anticipate will generate many individual PRs, please reach out to the team in a Github issue first to validate that Angular will be able to support and accept your contributions.
 
 [coc]: https://github.com/angular/code-of-conduct/blob/main/CODE_OF_CONDUCT.md
 [commit-message-format]: https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -168,7 +168,7 @@ Adding a package to this repository means running two separate commands:
 
 1. `schematics devkit:package PACKAGE_NAME`. This will update the `.monorepo` file, and create the
    base files for the new package (package.json, src/index, etc).
-1. `devkit-admin templates`. This will update the README and all other template files that might
+1. `pnpm admin templates`. This will update the README and all other template files that might
    have changed when adding a new package.
 
 For private packages, you will need to add a `"private": true` key to your package.json manually.

--- a/scripts/templates/contributing.ejs
+++ b/scripts/templates/contributing.ejs
@@ -12,7 +12,7 @@ to follow:
  - [Coding Rules](#rules)
  - [Commit Message Guidelines](#commit)
  - [Signing the CLA](#cla)
- - [Updating the Public API](#public-api)
+ - [Spam Policy](#spam-policy)
 
 ## <a name="coc"></a> Code of Conduct
 Help us keep Angular open and inclusive. Please read and follow our [Code of Conduct][coc].
@@ -280,6 +280,19 @@ changes to be accepted, the CLA must be signed. It's a quick process, we promise
 * For corporations we'll need you to
   [print, sign and one of scan+email, fax or mail the form][corporate-cla].
 
+## <a name="spam-policy"></a> Spam Policy
+
+Users who create excessive amounts of issues or PRs in a short time frame, particularly low-quality or low-value contributions, may see those contributions automatically closed without consideration.
+
+Community contributors should limit themselves to no more than 3 open PRs at a single time.
+
+### Why?
+
+Reviewing and shepherding PRs as well as managing large issue counts takes time and energy from the core team. Triaging a PR well enough to understand its goals and implementation takes a significant amount of time, regardless of whether the PR is ultimately accepted. This policy ensures the team is able to balance its limited resources across all contributors and projects.
+
+### Exceptions
+
+If you plan to undertake more significant work that you anticipate will generate many individual PRs, please reach out to the team in a Github issue first to validate that Angular will be able to support and accept your contributions.
 
 [coc]: https://github.com/angular/code-of-conduct/blob/main/CODE_OF_CONDUCT.md
 [commit-message-format]: https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#

--- a/scripts/templates/contributing.ejs
+++ b/scripts/templates/contributing.ejs
@@ -282,17 +282,7 @@ changes to be accepted, the CLA must be signed. It's a quick process, we promise
 
 ## <a name="spam-policy"></a> Spam Policy
 
-Users who create excessive amounts of issues or PRs in a short time frame, particularly low-quality or low-value contributions, may see those contributions automatically closed without consideration.
-
-Community contributors should limit themselves to no more than 3 open PRs at a single time.
-
-### Why?
-
-Reviewing and shepherding PRs as well as managing large issue counts takes time and energy from the core team. Triaging a PR well enough to understand its goals and implementation takes a significant amount of time, regardless of whether the PR is ultimately accepted. This policy ensures the team is able to balance its limited resources across all contributors and projects.
-
-### Exceptions
-
-If you plan to undertake more significant work that you anticipate will generate many individual PRs, please reach out to the team in a Github issue first to validate that Angular will be able to support and accept your contributions.
+See [Spam Policy](https://github.com/angular/angular/blob/main/contributing-docs/spam.md) for details.
 
 [coc]: https://github.com/angular/code-of-conduct/blob/main/CODE_OF_CONDUCT.md
 [commit-message-format]: https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#

--- a/scripts/validate.mts
+++ b/scripts/validate.mts
@@ -27,7 +27,7 @@ export default async function (options: { verbose: boolean }) {
   await templates();
   if (execSync(`git status --porcelain`).toString()) {
     console.error(
-      'Running templates updated files... Please run "devkit-admin templates" before submitting a PR.',
+      'Running templates updated files... Please run "pnpm admin templates" before submitting a PR.',
     );
     if (!options.verbose) {
       process.exit(2);


### PR DESCRIPTION
Introduces a new spam policy in CONTRIBUTING.md limiting community contributors to no more than 3 open PRs simultaneously to better manage team resources and triage efforts. Also adds a corresponding saved reply for closing excessive issues/PRs.
