### PR TITLE
refactor(@schematics/angular): remove empty constructor from directive template

### DIFF
--- a/packages/schematics/angular/directive/files/__name@dasherize__.__type@dasherize__.ts.template
+++ b/packages/schematics/angular/directive/files/__name@dasherize__.__type@dasherize__.ts.template
@@ -5,7 +5,4 @@ import { Directive } from '@angular/core';
   standalone: false,<%}%>
 })
 export class <%= classifiedName %> {
-
-  constructor() { }
-
 }


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ ] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The directive template generates an empty constructor, which not really useful in modern Angular where `inject` is preferred.

## What is the new behavior?

Align directive template with the component template cleanup done in 301b5669a724261d53444d5172334966903078c0.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
