### PR TITLE
refactor: narrow down typescript peer dependency

### DIFF
--- a/packages/angular/build/package.json
+++ b/packages/angular/build/package.json
@@ -74,7 +74,7 @@
     "postcss": "^8.4.0",
     "tailwindcss": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "tslib": "^2.3.0",
-    "typescript": ">=5.9 <6.1",
+    "typescript": ">=6.0 <6.1",
     "vitest": "^4.0.8"
   },
   "peerDependenciesMeta": {

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -81,7 +81,7 @@
     "karma": "^6.3.0",
     "ng-packagr": "0.0.0-NG-PACKAGR-PEER-DEP",
     "tailwindcss": "^2.0.0 || ^3.0.0 || ^4.0.0",
-    "typescript": ">=5.9 <6.1"
+    "typescript": ">=6.0 <6.1"
   },
   "peerDependenciesMeta": {
     "@angular/core": {

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/angular/angular-cli/tree/main/packages/ngtools/webpack",
   "peerDependencies": {
     "@angular/compiler-cli": "0.0.0-ANGULAR-FW-PEER-DEP",
-    "typescript": ">=5.9 <6.1",
+    "typescript": ">=6.0 <6.1",
     "webpack": "^5.54.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Narrows the peer dependency ranges to disallow TypeScript 5.9 which is no longer supported by the compiler.
