### PR TITLE
fix(@angular/build): allow configuring Access-Control-Allow-Origin via headers option

### DIFF
--- a/packages/angular/build/src/builders/dev-server/tests/options/headers_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/options/headers_spec.ts
@@ -37,6 +37,20 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
       expect(await response?.headers.get('x-custom')).toBe('foo');
     });
 
+    it('should include configured Access-Control-Allow-Origin header', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+        headers: {
+          'Access-Control-Allow-Origin': 'http://example.com',
+        },
+      });
+
+      const { result, response } = await executeOnceAndFetch(harness, '/main.js');
+
+      expect(result?.success).toBeTrue();
+      expect(await response?.headers.get('access-control-allow-origin')).toBe('http://example.com');
+    });
+
     it('media resource response headers should include configured header', async () => {
       await harness.writeFiles({
         'src/styles.css': `h1 { background: url('./test.svg')}`,

--- a/packages/angular/build/src/builders/dev-server/tests/options/headers_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/options/headers_spec.ts
@@ -51,6 +51,17 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
       expect(await response?.headers.get('access-control-allow-origin')).toBe('http://example.com');
     });
 
+    it('should not include Access-Control-Allow-Origin header by default', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result, response } = await executeOnceAndFetch(harness, '/main.js');
+
+      expect(result?.success).toBeTrue();
+      expect(await response?.headers.has('access-control-allow-origin')).toBeFalse();
+    });
+
     it('media resource response headers should include configured header', async () => {
       await harness.writeFiles({
         'src/styles.css': `h1 { background: url('./test.svg')}`,

--- a/packages/angular/build/src/builders/dev-server/vite/server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite/server.ts
@@ -62,9 +62,6 @@ async function createServerConfig(
     ws: serverOptions.liveReload === false && serverOptions.hmr === false ? false : undefined,
     proxy,
     cors: {
-      // This will add the header `Access-Control-Allow-Origin: http://example.com`,
-      // where `http://example.com` is the requesting origin.
-      origin: true,
       // Allow preflight requests to be proxied.
       preflightContinue: true,
     },


### PR DESCRIPTION


Removes the default Vite CORS origin: true configuration, allowing custom Access-Control-Allow-Origin header configurations to take effect when using the development server.

BREAKING CHANGE: The development server (ng serve) no longer automatically mirrors the request origin in the Access-Control-Allow-Origin response header by default. If your application relies on cross-origin requests during local development, you must now explicitly configure the required CORS headers using the headers option in your angular.json configuration.

Fixes #32923