### PR TITLE
build: move TypeScript and Angular Compiler CLI to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,12 +41,15 @@
     "url": "https://github.com/angular/angular-cli/issues"
   },
   "homepage": "https://github.com/angular/angular-cli",
+  "dependencies": {
+    "@angular/compiler-cli": "22.0.0-next.6",
+    "typescript": "6.0.2"
+  },
   "devDependencies": {
     "@angular/animations": "22.0.0-next.6",
     "@angular/cdk": "22.0.0-next.3",
     "@angular/common": "22.0.0-next.6",
     "@angular/compiler": "22.0.0-next.6",
-    "@angular/compiler-cli": "22.0.0-next.6",
     "@angular/core": "22.0.0-next.6",
     "@angular/forms": "22.0.0-next.6",
     "@angular/localize": "22.0.0-next.6",
@@ -129,7 +132,6 @@
     "semver": "7.7.4",
     "source-map-support": "0.5.21",
     "tslib": "2.8.1",
-    "typescript": "6.0.2",
     "undici": "7.24.7",
     "unenv": "^1.10.0",
     "verdaccio": "6.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,13 @@ packageExtensionsChecksum: sha256-V29Z7ZDJEQFju55ZS5zQ23Kb0736+P+eGNolWn/T274=
 importers:
 
   .:
+    dependencies:
+      '@angular/compiler-cli':
+        specifier: 22.0.0-next.6
+        version: 22.0.0-next.6(@angular/compiler@22.0.0-next.6)(typescript@6.0.2)
+      typescript:
+        specifier: 6.0.2
+        version: 6.0.2
     dependenciesMeta:
       esbuild:
         built: true
@@ -31,9 +38,6 @@ importers:
       '@angular/compiler':
         specifier: 22.0.0-next.6
         version: 22.0.0-next.6
-      '@angular/compiler-cli':
-        specifier: 22.0.0-next.6
-        version: 22.0.0-next.6(@angular/compiler@22.0.0-next.6)(typescript@6.0.2)
       '@angular/core':
         specifier: 22.0.0-next.6
         version: 22.0.0-next.6(@angular/compiler@22.0.0-next.6)(rxjs@7.8.2)(zone.js@0.16.1)
@@ -280,9 +284,6 @@ importers:
       tslib:
         specifier: 2.8.1
         version: 2.8.1
-      typescript:
-        specifier: 6.0.2
-        version: 6.0.2
       undici:
         specifier: 7.24.7
         version: 7.24.7


### PR DESCRIPTION
This is needed by rules_angular as otherwise these two packages are not present in the `npm_package_store_infos` using in the symlink package.


See: https://github.com/alan-agius4/dev-infra/blob/6cd21db3992d23e5a8009d5379723a487214e092/bazel/rules/rules_angular/src/private/symlink_package.bzl#L24