### PR TITLE
build: bypass TS 6.0 deprecation warnings for rules_angular update

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,7 +19,7 @@ bazel_dep(name = "aspect_rules_jasmine", version = "2.0.4")
 bazel_dep(name = "rules_angular")
 git_override(
     module_name = "rules_angular",
-    commit = "6c36180c2efebc6526ef0e6a55a6d738c7de6909",
+    commit = "0d390186270572cf0e56f826ca420cb21011a10c",
     remote = "https://github.com/angular/rules_angular.git",
 )
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -427,7 +427,7 @@
     "@@aspect_rules_ts+//ts:extensions.bzl%ext": {
       "general": {
         "bzlTransitiveDigest": "dhTbv9E6UfT1WJmmu3ORRPO6AKFJvgBjBxu+BO+u1RY=",
-        "usagesDigest": "M9vJ1ahjqDb8ONBLGfZdvp4Vq1o4Y6Xjfv/ZY7PlnYo=",
+        "usagesDigest": "ixhEGTq9m8RnVX8NzQrTSzJTXApIjZ/AKMZnWquJj8Q=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -445,8 +445,8 @@
           "rules_angular_npm_typescript": {
             "repoRuleId": "@@aspect_rules_ts+//ts/private:npm_repositories.bzl%http_archive_version",
             "attributes": {
-              "version": "5.9.3",
-              "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+              "version": "6.0.2",
+              "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
               "urls": [
                 "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"
               ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "esModuleInterop": true,
     "module": "commonjs",
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
     "noEmitOnError": true,
     "stripInternal": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
Enable ignoreDeprecations to resolve a conflict introduced by updating rules_angular. The update fixes a version mismatch where the worker's TypeScript was prioritized over the repo's version. Compiling with the repo's TypeScript now requires this flag due to the deprecation of moduleResolution: "node".
