### PR TITLE
fix: reject port in host header to prevent SSR SSRF bypass

### DIFF
--- a/packages/angular/ssr/src/utils/validation.ts
+++ b/packages/angular/ssr/src/utils/validation.ts
@@ -224,7 +224,12 @@ function verifyHostAllowed(
     throw new Error(`Header "${headerName}" contains an invalid value and cannot be parsed.`);
   }
 
-  const { hostname } = new URL(url);
+  const { hostname, port } = new URL(url);
+  if (port) {
+    throw new Error(
+      `Header "${headerName}" with value "${value}" contains a port and is not allowed.`,
+    );
+  }
   if (!isHostAllowed(hostname, allowedHosts)) {
     throw new Error(`Header "${headerName}" with value "${value}" is not allowed.`);
   }


### PR DESCRIPTION
## Port-based SSRF bypass in SSR host validation

`verifyHostAllowed` extracts `hostname` from the host header using `new URL().hostname`, which strips the port. So `X-Forwarded-Host: localhost:13337` passes validation because hostname is `localhost`, but the port 13337 goes unchecked.

The SSR request URL then uses `localhost:13337` as base. Any relative `HttpClient` calls during rendering go to port 13337 instead of the app's port.

This bypasses the host validation fix from CVE-2026-27739.

## Attack scenario

Attacker sends `X-Forwarded-Host: localhost:13337` to an Angular SSR app behind a reverse proxy. If the app fetches data with `HttpClient` during SSR (e.g. `this.http.get('/api/data')`), the request goes to port 13337 where the attacker runs a service. The response gets rendered into HTML and served to the user.

Default Angular SSR config, nothing special needed.

## Fix

Reject host headers that contain a port in `verifyHostAllowed`. Port should come from `x-forwarded-port` (validated separately), not from the host header.

## Verification

Before: `X-Forwarded-Host: localhost:13337` passes `verifyHostAllowed`.
After: throws error.