### PR TITLE
fix(@angular/build): reject outputPath that escapes workspace root

### DIFF
--- a/packages/angular/build/src/builders/application/options.ts
+++ b/packages/angular/build/src/builders/application/options.ts
@@ -308,14 +308,21 @@ export async function normalizeOptions(
   }
 
   const outputPath = options.outputPath ?? path.join(workspaceRoot, 'dist', projectName);
+  const resolvedOutputBase = path.resolve(
+    workspaceRoot,
+    typeof outputPath === 'string' ? outputPath : outputPath.base,
+  );
+  if (!resolvedOutputBase.startsWith(workspaceRoot + path.sep)) {
+    throw new Error(
+      `Output path '${resolvedOutputBase}' must be inside the project root directory '${workspaceRoot}'.`,
+    );
+  }
   const outputOptions: NormalizedOutputOptions = {
     browser: 'browser',
     server: 'server',
     media: 'media',
     ...(typeof outputPath === 'string' ? undefined : outputPath),
-    base: normalizeDirectoryPath(
-      path.resolve(workspaceRoot, typeof outputPath === 'string' ? outputPath : outputPath.base),
-    ),
+    base: normalizeDirectoryPath(resolvedOutputBase),
     clean: options.deleteOutputPath ?? true,
     // For app-shell and SSG server files are not required by users.
     // Omit these when SSR is not enabled.

--- a/packages/angular/build/src/builders/application/tests/options/output-path_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/output-path_spec.ts
@@ -260,6 +260,22 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
           }),
         );
       });
+
+      it('should error when the output path escapes the workspace root', async () => {
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          polyfills: [],
+          outputPath: '../dist',
+        });
+
+        const { result, error } = await harness.executeOnce({
+          outputLogsOnException: false,
+          outputLogsOnFailure: false,
+        });
+
+        expect(result).toBeUndefined();
+        expect(error?.message).toMatch(/must be inside the project root directory/);
+      });
     });
   });
 });

--- a/packages/angular/build/src/utils/delete-output-dir.ts
+++ b/packages/angular/build/src/utils/delete-output-dir.ts
@@ -7,19 +7,25 @@
  */
 
 import { readdir, rm } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
+import { join, resolve, sep } from 'node:path';
 
 /**
- * Delete an output directory, but error out if it's the root of the project.
+ * Delete an output directory, but error out if it's the root of the project or outside it.
  */
 export async function deleteOutputDir(
   root: string,
   outputPath: string,
   emptyOnlyDirectories?: string[],
 ): Promise<void> {
+  const resolvedRoot = resolve(root);
   const resolvedOutputPath = resolve(root, outputPath);
-  if (resolvedOutputPath === root) {
+  if (resolvedOutputPath === resolvedRoot) {
     throw new Error('Output path MUST not be project root directory!');
+  }
+  if (!resolvedOutputPath.startsWith(resolvedRoot + sep)) {
+    throw new Error(
+      `Output path '${resolvedOutputPath}' MUST be inside the project root '${resolvedRoot}'.`,
+    );
   }
 
   const directoriesToEmpty = emptyOnlyDirectories

--- a/packages/angular/build/src/utils/delete-output-dir_spec.ts
+++ b/packages/angular/build/src/utils/delete-output-dir_spec.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { deleteOutputDir } from './delete-output-dir';
+
+describe('deleteOutputDir', () => {
+    let workspaceRoot: string;
+
+    beforeEach(async () => {
+        workspaceRoot = await mkdtemp(join(tmpdir(), 'angular-cli-test-'));
+        await mkdir(join(workspaceRoot, 'dist'), { recursive: true });
+        await writeFile(join(workspaceRoot, 'dist', 'file.txt'), 'test');
+    });
+
+    afterEach(async () => {
+        await rm(workspaceRoot, { recursive: true, force: true });
+    });
+
+    it('should reject deleting the project root directory', async () => {
+        await expectAsync(deleteOutputDir(workspaceRoot, '.')).toBeRejectedWithError(
+            'Output path MUST not be project root directory!',
+        );
+    });
+
+    it('should reject deleting a path outside the project root', async () => {
+        await expectAsync(deleteOutputDir(workspaceRoot, '..')).toBeRejectedWithError(
+            new RegExp(`Output path '.*' MUST be inside the project root '${workspaceRoot}'.`),
+        );
+    });
+});


### PR DESCRIPTION
Prevent a malicious angular.json from setting outputPath outside the workspace root (e.g. ".."), which caused the default application builder to recursively delete the workspace parent directory and sibling content before writing build output there.

**Current behavior:**

normalizeOptions() resolves the user-supplied outputPath (e.g. "..") relative to workspaceRoot without validating that the result stays inside the workspace. deleteOutputDir() only rejects a path that is exactly equal to the workspace root; it accepts any other path, including ancestors or siblings.

A malicious angular.json with build.options.outputPath set to ".." causes a default ng build to:
1. Resolve the output base to the workspace's parent directory.
2. Recursively delete every entry under that parent (including the workspace itself and any sibling files/directories) as part of normal pre-build cleanup.
3. Write browser build artefacts into the parent directory.
4. Crash with ENOENT when it later tries to read assets from the now-deleted workspace.

a single ng build can destroy the victim workspace and writable sibling content, then write build output into an attacker-chosen parent directory.

**New behavior:**

Two defence-in-depth guards are added:

1. Early validation in normalizeOptions() (packages/angular/build/src/builders/application/options.ts)

   After resolving the output base, the function now checks that it is a strict descendant of workspaceRoot. If not, it throws immediately before any filesystem work begins:

     Error: Output path '<resolved>' must be inside the project root
     directory '<workspaceRoot>'.

2. Boundary check in deleteOutputDir() (packages/angular/build/src/utils/delete-output-dir.ts)

   The deletion helper now rejects any outputPath whose resolved form is not a strict descendant of the workspace root (previously it only rejected an exact match). This acts as a last-resort guard even if upstream validation is bypassed:

     Error: Output path '<resolved>' MUST be inside the project root '<root>'.

**Breaking change:** None.

outputPath values that already point inside the workspace are unaffected. Only values that resolve to a path at or above workspaceRoot are now rejected with a clear error, which was never a supported or intended configuration.

Before the fix the workspace was deleted and the build wrote output into the parent directory. After the fix the build aborts immediately with the new error message and nothing outside the workspace is touched.

Fixes security report output-path-outside-workspace-deletion.

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ ] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
