### PR TITLE
refactor(@schematics/angular): remove explicit strict true in tsconfig template for TS6 compatibility

### DIFF
--- a/packages/schematics/angular/workspace/files/tsconfig.json.template
+++ b/packages/schematics/angular/workspace/files/tsconfig.json.template
@@ -3,11 +3,11 @@
 {
   "compileOnSave": false,
   "compilerOptions": {<% if (strict) { %>
-    "strict": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,<% } %>
+    "noFallthroughCasesInSwitch": true,<% } else { %>
+    "strict": false,<% } %>
     "skipLibCheck": true,
     "isolatedModules": true,
     "experimentalDecorators": true,

--- a/packages/schematics/angular/workspace/index_spec.ts
+++ b/packages/schematics/angular/workspace/index_spec.ts
@@ -98,7 +98,7 @@ describe('Workspace Schematic', () => {
     const { compilerOptions, angularCompilerOptions } = parseJson(
       tree.readContent('tsconfig.json').toString(),
     );
-    expect(compilerOptions.strict).toBeUndefined();
+    expect(compilerOptions.strict).toBeFalse();
     expect(angularCompilerOptions.strictTemplates).toBeFalse();
     expect(angularCompilerOptions.strictInputAccessModifiers).toBeUndefined();
     expect(angularCompilerOptions.strictInjectionParameters).toBeUndefined();
@@ -112,7 +112,7 @@ describe('Workspace Schematic', () => {
     const { compilerOptions, angularCompilerOptions } = parseJson(
       tree.readContent('tsconfig.json').toString(),
     );
-    expect(compilerOptions.strict).toBeTrue();
+    expect(compilerOptions.strict).toBeUndefined();
     expect(angularCompilerOptions.strictTemplates).toBeUndefined();
     expect(angularCompilerOptions.strictInputAccessModifiers).toBeTrue();
     expect(angularCompilerOptions.strictInjectionParameters).toBeTrue();


### PR DESCRIPTION


TypeScript 6 enables strict mode by default. This change updates the workspace schematic's `tsconfig.json` template to omit `"strict": true` when strict mode is desired (relying on the default), and explicitly sets `"strict": false` when it is disabled.