### PR TITLE
refactor(@schematics/angular): remove redundant `withEventReplay` from `provideClientHydration`

### DIFF
--- a/packages/schematics/angular/server/index.ts
+++ b/packages/schematics/angular/server/index.ts
@@ -248,10 +248,7 @@ const serverSchematic: RuleFactory<ServerOptions> = createProjectSchematic(
       addRootProvider(
         options.project,
         ({ code, external }) =>
-          code`${external('provideClientHydration', '@angular/platform-browser')}(${external(
-            'withEventReplay',
-            '@angular/platform-browser',
-          )}())`,
+          code`${external('provideClientHydration', '@angular/platform-browser')}()`,
       ),
     ]);
   },

--- a/packages/schematics/angular/server/index_spec.ts
+++ b/packages/schematics/angular/server/index_spec.ts
@@ -172,7 +172,7 @@ describe('Server Schematic', () => {
     it(`should add 'provideClientHydration' to the providers list`, async () => {
       const tree = await schematicRunner.runSchematic('server', defaultOptions, appTree);
       const contents = tree.readContent('/projects/bar/src/app/app-module.ts');
-      expect(contents).toContain(`provideClientHydration(withEventReplay())`);
+      expect(contents).toContain(`provideClientHydration()`);
     });
   });
 
@@ -257,7 +257,7 @@ describe('Server Schematic', () => {
     it(`should add 'provideClientHydration' to the providers list`, async () => {
       const tree = await schematicRunner.runSchematic('server', defaultOptions, appTree);
       const contents = tree.readContent('/projects/bar/src/app/app.config.ts');
-      expect(contents).toContain(`provideClientHydration(withEventReplay())`);
+      expect(contents).toContain(`provideClientHydration()`);
     });
   });
 


### PR DESCRIPTION


`withEventReplay` and incremental hydration are now enabled by default when using `provideClientHydration()`.

Since incremental hydration automatically depends on and enables event replay, explicitly passing `withEventReplay()` is no longer necessary.

See: https://github.com/angular/angular/pull/68114