### PR TITLE
fix(@angular/cli): ignore EBADF file system errors during MCP project scan

### DIFF
--- a/packages/angular/cli/src/commands/mcp/tools/projects.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/projects.ts
@@ -149,7 +149,7 @@ their types, and their locations.
 });
 
 const EXCLUDED_DIRS = new Set(['node_modules', 'dist', 'out', 'coverage']);
-const IGNORED_FILE_SYSTEM_ERRORS = new Set(['EACCES', 'EPERM', 'ENOENT', 'EBUSY']);
+const IGNORED_FILE_SYSTEM_ERRORS = new Set(['EACCES', 'EPERM', 'ENOENT', 'EBUSY', 'EBADF']);
 
 function isIgnorableFileError(error: Error & { code?: string }): boolean {
   return !!error.code && IGNORED_FILE_SYSTEM_ERRORS.has(error.code);


### PR DESCRIPTION
File crawling concurrency occasionally surfaces temporary EBADF descriptors on specialized filesystems. This catches and ignores them, guaranteeing completion of background discovery loops.