### PR TITLE
fix(@angular-devkit/build-angular): ensure route has leading slash in prerender builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/prerender/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/prerender/index.ts
@@ -217,7 +217,7 @@ async function _renderUniversal(
               inlineCriticalCss: !!normalizedStylesOptimization.inlineCritical,
               minifyCss: !!normalizedStylesOptimization.minify,
               outputPath,
-              route,
+              route: route[0] === '/' ? route : '/' + route,
               serverBundlePath,
             };
 


### PR DESCRIPTION


Ensures that the route always starts with a leading slash when calling the render function, preventing potential issues with relative paths or incorrect URL resolution during prerendering.
