### PR TITLE
fix(@angular/build): use rootDir for HMR component updates path resolution

### DIFF
--- a/packages/angular/build/src/tools/angular/compilation/aot-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/aot-compilation.ts
@@ -152,7 +152,10 @@ export class AotCompilation extends AngularCompilation {
           continue;
         }
         const componentFilename = node.getSourceFile().fileName;
-        let relativePath = relative(host.getCurrentDirectory(), componentFilename);
+        let relativePath = relative(
+          compilerOptions.rootDir ?? host.getCurrentDirectory(),
+          componentFilename,
+        );
         if (relativePath.startsWith('..')) {
           relativePath = componentFilename;
         }


### PR DESCRIPTION


Use `compilerOptions.rootDir` when calculating the relative path for HMR component updates, falling back to the current directory if not set. This ensures correct path resolution when `rootDir` is configured in `tsconfig`.

Closes #33005 and closes #32998