### PR TITLE
fix(@angular-devkit/build-angular): fix app-shell route format and improve package resolution

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
@@ -86,10 +86,11 @@ async function _renderUniversal(
         localeDirectory,
       );
 
+      const route = options.route;
       let html: string = await renderWorker.run({
         serverBundlePath,
         document: indexHtml,
-        url: options.route,
+        url: route?.[0] === '/' ? route : '/' + route,
       });
 
       // Overwrite the client index file.

--- a/packages/angular_devkit/build_angular/src/tools/webpack/utils/helpers.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/utils/helpers.ts
@@ -8,6 +8,7 @@
 
 import type { ObjectPattern } from 'copy-webpack-plugin';
 import { createHash } from 'node:crypto';
+import { createRequire } from 'node:module';
 import * as path from 'node:path';
 import { globSync } from 'tinyglobby';
 import type { Configuration, WebpackOptionsNormalized } from 'webpack';
@@ -314,7 +315,8 @@ export function getStatsOptions(verbose = false): WebpackStatsOptions {
  */
 export function isPackageInstalled(root: string, name: string): boolean {
   try {
-    require.resolve(name, { paths: [root] });
+    const resolve = createRequire(root + '/').resolve;
+    resolve(name);
 
     return true;
   } catch {


### PR DESCRIPTION
improve package resolution

- In the `app-shell` builder, ensure the route URL has a leading slash.
- In webpack helpers, use `createRequire` in `isPackageInstalled` to improve package resolution robustness.
