### PR TITLE
Use `t.buildUndefinedNode` instead of `Scope#buildUndefinedNode`

### DIFF
--- a/packages/angular/build/src/tools/babel/plugins/elide-angular-metadata.ts
+++ b/packages/angular/build/src/tools/babel/plugins/elide-angular-metadata.ts
@@ -48,7 +48,7 @@ const angularMetadataFunctions: Record<string, (args: NodePath[]) => boolean> = 
  *
  * @returns A babel plugin object instance.
  */
-export default function (): PluginObj {
+export default function ({ types: t }): PluginObj {
   return {
     visitor: {
       CallExpression(path) {
@@ -79,7 +79,7 @@ export default function (): PluginObj {
           if (parent && (parent.isFunctionExpression() || parent.isArrowFunctionExpression())) {
             // Replace the metadata function with `void 0` which is the equivalent return value
             // of the metadata function.
-            path.replaceWith(path.scope.buildUndefinedNode());
+            path.replaceWith(t.buildUndefinedNode());
           }
         }
       },

--- a/packages/angular/build/src/tools/babel/plugins/elide-angular-metadata.ts
+++ b/packages/angular/build/src/tools/babel/plugins/elide-angular-metadata.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import type { NodePath, PluginObj } from '@babel/core';
+import type { types as BabelTypes, NodePath, PluginObj } from '@babel/core';
 
 /**
  * The name of the Angular class metadata function created by the Angular compiler.
@@ -48,7 +48,7 @@ const angularMetadataFunctions: Record<string, (args: NodePath[]) => boolean> = 
  *
  * @returns A babel plugin object instance.
  */
-export default function ({ types: t }): PluginObj {
+export default function ({ types: t }: { types: typeof BabelTypes }): PluginObj {
   return {
     visitor: {
       CallExpression(path) {


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ ] (TODO) The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current/new behavior?

Babel 8 is _likely_ going to remove the variant on `Scope#`, since this method has not needed scope-specific information in ages.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

This package depends on Babel 7.29.0, which supports `t.buildUndefinedNode`.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Ref https://github.com/babel/babel/pull/17937