### PR TITLE
fix(@angular/build): forward tsconfig paths as Vite aliases for Vitest coverage

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
@@ -378,6 +378,9 @@ export class VitestExecutor implements TestExecutor {
           projectPlugins,
           include,
           watch,
+          tsConfigPath: this.options.tsConfig
+            ? path.join(workspaceRoot, this.options.tsConfig)
+            : undefined,
         }),
       ],
     };

--- a/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
@@ -54,6 +54,59 @@ interface VitestConfigPluginOptions {
   include: string[];
   optimizeDepsInclude: string[];
   watch: boolean;
+  /** Absolute path to the tsconfig file. When provided, its `paths` are forwarded
+   *  as Vite resolve aliases so that import analysis during coverage does not fail
+   *  to resolve tsconfig path aliases (e.g. `#/util`). */
+  tsConfigPath?: string;
+}
+
+/**
+ * Escapes special regex characters in a string so it can be used inside a RegExp.
+ */
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Reads a tsconfig file and converts its `compilerOptions.paths` entries to
+ * Vite-compatible resolve aliases.  This ensures that path aliases such as
+ * `"#/util": ["./src/util"]` are honoured during Vitest coverage processing
+ * where `vite:import-analysis` re-resolves imports from the original source
+ * files (see https://github.com/angular/angular-cli/issues/32891).
+ */
+async function readTsconfigPathAliases(
+  tsConfigPath: string,
+): Promise<{ find: string | RegExp; replacement: string }[]> {
+  try {
+    const raw = await readFile(tsConfigPath, 'utf-8');
+    // tsconfig files may contain C-style comments – strip them before parsing.
+    const json = JSON.parse(raw.replace(/\/\*[\s\S]*?\*\/|\/\/[^\n]*/g, ''));
+    const paths: Record<string, string[]> = json?.compilerOptions?.paths ?? {};
+    const rawBaseUrl: string = json?.compilerOptions?.baseUrl ?? '.';
+    const baseDir = path.isAbsolute(rawBaseUrl)
+      ? rawBaseUrl
+      : path.join(path.dirname(tsConfigPath), rawBaseUrl);
+
+    return Object.entries(paths).flatMap(([pattern, targets]) => {
+      if (!targets.length) {
+        return [];
+      }
+      const target = targets[0];
+      if (pattern.endsWith('/*')) {
+        // Wildcard alias: "@app/*" -> "./src/app/*"
+        const prefix = pattern.slice(0, -2);
+        const targetDir = path.join(baseDir, target.replace(/\/\*$/, ''));
+        return [{
+          find: new RegExp(`^${escapeRegExp(prefix)}\/(.*)$`),
+          replacement: `${targetDir}/$1`,
+        }];
+      }
+      // Exact alias: "#/util" -> "./src/util"
+      return [{ find: pattern, replacement: path.join(baseDir, target) }];
+    });
+  } catch {
+    return [];
+  }
 }
 
 async function findTestEnvironment(
@@ -164,6 +217,10 @@ export async function createVitestConfigPlugin(
 
       const projectResolver = createRequire(projectSourceRoot + '/').resolve;
 
+      const tsconfigAliases = options.tsConfigPath
+        ? await readTsconfigPathAliases(options.tsConfigPath)
+        : [];
+
       const projectDefaults: UserWorkspaceConfig = {
         test: {
           setupFiles,
@@ -179,6 +236,7 @@ export async function createVitestConfigPlugin(
         resolve: {
           mainFields: ['es2020', 'module', 'main'],
           conditions: ['es2015', 'es2020', 'module', ...(browser ? ['browser'] : [])],
+          ...(tsconfigAliases.length ? { alias: tsconfigAliases } : {}),
         },
       };
 

--- a/packages/angular/build/src/builders/unit-test/tests/behavior/vitest-coverage-tsconfig-paths_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/behavior/vitest-coverage-tsconfig-paths_spec.ts
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { execute } from '../../index';
+import {
+  BASE_OPTIONS,
+  UNIT_TEST_BUILDER_INFO,
+  describeBuilder,
+  setupApplicationTarget,
+} from '../setup';
+
+describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
+  describe('Behavior: "Vitest coverage with tsconfig path aliases"', () => {
+    beforeEach(async () => {
+      setupApplicationTarget(harness);
+    });
+
+    it('should resolve tsconfig path aliases during coverage instrumentation', async () => {
+      // Write a utility module that will be imported via a path alias
+      await harness.writeFile(
+        'src/app/util.ts',
+        `export function greet(name: string): string { return \`Hello, \${name}!\`; }`,
+      );
+
+      // Add a path alias "#/util" -> "./src/app/util" to tsconfig
+      await harness.modifyFile('src/tsconfig.spec.json', (content) => {
+        const tsconfig = JSON.parse(content);
+        tsconfig.compilerOptions ??= {};
+        tsconfig.compilerOptions.paths = {
+          '#/*': ['./app/*'],
+        };
+        return JSON.stringify(tsconfig, null, 2);
+      });
+
+      // Write an app component that imports via the alias
+      await harness.writeFile(
+        'src/app/app.component.ts',
+        `
+        import { Component } from '@angular/core';
+        import { greet } from '#/util';
+
+        @Component({
+          selector: 'app-root',
+          template: '<h1>{{ greeting }}</h1>',
+          standalone: true,
+        })
+        export class AppComponent {
+          greeting = greet('world');
+        }
+        `,
+      );
+
+      // Write a spec that exercises the component (and hence imports #/util transitively)
+      await harness.writeFile(
+        'src/app/app.component.spec.ts',
+        `
+        import { TestBed } from '@angular/core/testing';
+        import { AppComponent } from './app.component';
+
+        describe('AppComponent', () => {
+          beforeEach(async () => {
+            await TestBed.configureTestingModule({
+              imports: [AppComponent],
+            }).compileComponents();
+          });
+
+          it('should create the app', () => {
+            const fixture = TestBed.createComponent(AppComponent);
+            expect(fixture.componentInstance).toBeTruthy();
+          });
+        });
+        `,
+      );
+
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        coverage: true,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        coverageReporters: ['json'] as any,
+      });
+
+      // Regression: this used to throw "vite:import-analysis Pre-transform error:
+      // Failed to resolve import" when tsconfig paths were present and coverage was enabled.
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      harness.expectFile('coverage/test/index.html').toExist();
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When a project configures `compilerOptions.paths` in `tsconfig.json` (e.g.
`"#/*": ["./src/app/*"]`) and runs `ng test` with `coverage: true`, Vitest's
`vite:import-analysis` plugin fails during the coverage phase with:

```
Pre-transform error: Failed to resolve import "#/util" from "src/app/app.ts".
Does the file exist?
```

This happens because the Angular CLI's Vitest integration does not forward
tsconfig path aliases to Vite's `resolve.alias` configuration. They are
resolved during compilation (by esbuild) but not during Vitest's own
Vite-based coverage instrumentation pass.

Issue Number: #32891

## What is the new behavior?

The tsconfig file is read at Vitest initialisation time. Its
`compilerOptions.paths` entries are converted to Vite-compatible
`resolve.alias` objects (supporting both exact and wildcard patterns) and
injected into the `projectDefaults.resolve.alias` config that the Angular
CLI passes to the Vitest project workspace.

Path aliases are now resolved correctly during both test execution and
coverage instrumentation.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The fix is intentionally narrow — it only reads `paths` and `baseUrl` from
the tsconfig, leaving all other resolution behaviour unchanged. Comment
syntax in tsconfig files (C-style `/* */` and `//`) is stripped before
JSON parsing to handle real-world configs.

A new behavior spec (`vitest-coverage-tsconfig-paths_spec.ts`) verifies the
fix end-to-end using the builder test harness.
