### PR TITLE
fix(@schematics/angular): add missing imports for focus and skip APIs in refactor-jasmine-vitest

### DIFF
--- a/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.ts
@@ -59,16 +59,20 @@ import { RefactorReporter } from './utils/refactor-reporter';
 const BLANK_LINE_PLACEHOLDER = '// __PRESERVE_BLANK_LINE__';
 
 /**
- * Vitest function names that should be imported when using the --add-imports option.
+ * Jasmine to Vitest imports map that should be employed when the --add-imports option is used.
  */
-const VITEST_FUNCTION_NAMES = new Set([
-  'describe',
-  'it',
-  'expect',
-  'beforeEach',
-  'afterEach',
-  'beforeAll',
-  'afterAll',
+const JASMINE_TO_VITEST_IMPORT = new Map<string, string>([
+  ['describe', 'describe'],
+  ['fdescribe', 'describe'],
+  ['xdescribe', 'describe'],
+  ['it', 'it'],
+  ['fit', 'it'],
+  ['xit', 'it'],
+  ['expect', 'expect'],
+  ['beforeEach', 'beforeEach'],
+  ['afterEach', 'afterEach'],
+  ['beforeAll', 'beforeAll'],
+  ['afterAll', 'afterAll'],
 ]);
 
 /**
@@ -200,8 +204,9 @@ export function transformJasmineToVitest(
       if (ts.isCallExpression(transformedNode)) {
         if (options.addImports && ts.isIdentifier(transformedNode.expression)) {
           const name = transformedNode.expression.text;
-          if (VITEST_FUNCTION_NAMES.has(name)) {
-            addVitestValueImport(pendingVitestValueImports, name);
+          const importSpecifierName = JASMINE_TO_VITEST_IMPORT.get(name);
+          if (importSpecifierName) {
+            addVitestValueImport(pendingVitestValueImports, importSpecifierName);
           }
         }
 

--- a/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer_add-imports_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer_add-imports_spec.ts
@@ -116,4 +116,38 @@ describe('Jasmine to Vitest Transformer - addImports option', () => {
       `;
     await expectTransformation(input, expected, true);
   });
+
+  it('should add imports for transformed global functions with different Vitest names', async () => {
+    await expectTransformation(
+      `
+        fdescribe('My Suite', () => {
+          xit('should skip', () => {});
+        });
+      `,
+      `
+        import { describe, it } from 'vitest';
+
+        describe.only('My Suite', () => {
+          it.skip('should skip', () => {});
+        });
+      `,
+      true,
+    );
+
+    await expectTransformation(
+      `
+        xdescribe('My Suite', () => {
+          fit('should focus', () => {});
+        });
+      `,
+      `
+        import { describe, it } from 'vitest';
+
+        describe.skip('My Suite', () => {
+          it.only('should focus', () => {});
+        });
+      `,
+      true,
+    );
+  });
 });


### PR DESCRIPTION
`xdescribe`, `fdescribe`, `xit` and `fit` Vitest equivalents use a slightly different API. This change handles the `--add-imports` aspect where the appropriate functions are imported for these specific APIs.

Fixes #33021