### PR TITLE
test(@angular/build): robustly install @angular/animations in e2e test

### DIFF
--- a/tests/e2e/tests/build/chunk-optimizer-animations.ts
+++ b/tests/e2e/tests/build/chunk-optimizer-animations.ts
@@ -1,19 +1,24 @@
 import assert from 'node:assert/strict';
 import { readdir } from 'node:fs/promises';
+import { getGlobalVariable } from '../../utils/env';
 import { readFile, writeFile } from '../../utils/fs';
 import { installPackage } from '../../utils/packages';
 import { execWithEnv } from '../../utils/process';
+import { readNgVersion } from '../../utils/version';
 
 export default async function () {
-  // Read @angular/core version from test project's package.json
-  const projectJson = JSON.parse(await readFile('package.json'));
-  const ngCoreVersion =
-    projectJson.dependencies?.['@angular/core'] ??
-    projectJson.devDependencies?.['@angular/core'] ??
-    'latest';
+  const isSnapshotBuild = getGlobalVariable('argv')['ng-snapshots'];
+  let animationsSpecifier: string;
+  if (isSnapshotBuild) {
+    const snapshots = require('../../ng-snapshot/package.json');
+    animationsSpecifier = snapshots.dependencies['@angular/animations'];
+  } else {
+    const coreVersion = readNgVersion();
+    animationsSpecifier = `@angular/animations@${coreVersion}`;
+  }
 
-  // Install @angular/animations package with matching version
-  await installPackage(`@angular/animations@${ngCoreVersion}`);
+  // Install @angular/animations package
+  await installPackage(animationsSpecifier);
 
   // Configure app.config.ts with provideAnimationsAsync
   const originalConfig = await readFile('src/app/app.config.ts');


### PR DESCRIPTION
Enhance the animations package installation in the E2E test to support snapshot E2E runs by resolving the exact dependency specifier from the ng-snapshot manifest when --ng-snapshots is active. Otherwise, it reads the full installed version of @angular/core directly from the local node_modules to avoid semver issues during package installation.