### PR TITLE
fix(@angular/cli): remove standalone true ref in ai tutor

### DIFF
--- a/packages/angular/cli/src/commands/mcp/resources/ai-tutor.md
+++ b/packages/angular/cli/src/commands/mcp/resources/ai-tutor.md
@@ -361,7 +361,6 @@ When teaching or generating code for Phase 5 (Signal Forms), you **must** strict
 
   @Component({
     selector: 'app-example',
-    standalone: true,
     imports: [Field],
     template: `
       <form (submit)="save($event)">


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 32909

## What is the new behavior?

AI Tutor should no longer give examples with `standalone: true`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
