### PR TITLE
fix(@angular/ssr):  introduce trustProxyHeaders option to safely vali…

### DIFF
--- a/goldens/public-api/angular/ssr/index.api.md
+++ b/goldens/public-api/angular/ssr/index.api.md
@@ -14,12 +14,14 @@ export class AngularAppEngine {
     constructor(options?: AngularAppEngineOptions);
     handle(request: Request, requestContext?: unknown): Promise<Response | null>;
     static ɵallowStaticRouteRender: boolean;
+    static ɵdisableAllowedHostsCheck: boolean;
     static ɵhooks: Hooks;
 }
 
 // @public
 export interface AngularAppEngineOptions {
     allowedHosts?: readonly string[];
+    trustProxyHeaders?: boolean | readonly string[];
 }
 
 // @public

--- a/goldens/public-api/angular/ssr/node/index.api.md
+++ b/goldens/public-api/angular/ssr/node/index.api.md
@@ -55,7 +55,7 @@ export interface CommonEngineRenderOptions {
 export function createNodeRequestHandler<T extends NodeRequestHandlerFunction>(handler: T): T;
 
 // @public
-export function createWebRequestFromNodeRequest(nodeRequest: IncomingMessage | Http2ServerRequest): Request;
+export function createWebRequestFromNodeRequest(nodeRequest: IncomingMessage | Http2ServerRequest, trustProxyHeaders?: boolean | readonly string[]): Request;
 
 // @public
 export function isMainModule(url: string): boolean;

--- a/packages/angular/ssr/node/src/app-engine.ts
+++ b/packages/angular/ssr/node/src/app-engine.ts
@@ -29,6 +29,7 @@ export interface AngularNodeAppEngineOptions extends AngularAppEngineOptions {}
  */
 export class AngularNodeAppEngine {
   private readonly angularAppEngine: AngularAppEngine;
+  private readonly trustProxyHeaders?: boolean | readonly string[];
 
   /**
    * Creates a new instance of the Angular Node.js server application engine.
@@ -39,6 +40,7 @@ export class AngularNodeAppEngine {
       ...options,
       allowedHosts: [...getAllowedHostsFromEnv(), ...(options?.allowedHosts ?? [])],
     });
+    this.trustProxyHeaders = options?.trustProxyHeaders;
 
     attachNodeGlobalErrorHandlers();
   }
@@ -76,7 +78,9 @@ export class AngularNodeAppEngine {
     requestContext?: unknown,
   ): Promise<Response | null> {
     const webRequest =
-      request instanceof Request ? request : createWebRequestFromNodeRequest(request);
+      request instanceof Request
+        ? request
+        : createWebRequestFromNodeRequest(request, this.trustProxyHeaders);
 
     return this.angularAppEngine.handle(webRequest, requestContext);
   }

--- a/packages/angular/ssr/node/src/request.ts
+++ b/packages/angular/ssr/node/src/request.ts
@@ -8,7 +8,11 @@
 
 import type { IncomingHttpHeaders, IncomingMessage } from 'node:http';
 import type { Http2ServerRequest } from 'node:http2';
-import { getFirstHeaderValue } from '../../src/utils/validation';
+import {
+  getFirstHeaderValue,
+  isProxyHeaderAllowed,
+  normalizeTrustProxyHeaders,
+} from '../../src/utils/validation';
 
 /**
  * A set containing all the pseudo-headers defined in the HTTP/2 specification.
@@ -17,7 +21,13 @@ import { getFirstHeaderValue } from '../../src/utils/validation';
  * as they are not allowed to be set directly using the `Node.js` Undici API or
  * the web `Headers` API.
  */
-const HTTP2_PSEUDO_HEADERS = new Set([':method', ':scheme', ':authority', ':path', ':status']);
+const HTTP2_PSEUDO_HEADERS: ReadonlySet<string> = new Set([
+  ':method',
+  ':scheme',
+  ':authority',
+  ':path',
+  ':status',
+]);
 
 /**
  * Converts a Node.js `IncomingMessage` or `Http2ServerRequest` into a
@@ -27,16 +37,25 @@ const HTTP2_PSEUDO_HEADERS = new Set([':method', ':scheme', ':authority', ':path
  * be used by web platform APIs.
  *
  * @param nodeRequest - The Node.js request object (`IncomingMessage` or `Http2ServerRequest`) to convert.
+ * @param trustProxyHeaders - A boolean or an array of proxy headers to trust when constructing the request URL.
+ *
+ * @remarks
+ * When `trustProxyHeaders` is enabled, headers such as `X-Forwarded-Host` and
+ * `X-Forwarded-Prefix` should ideally be strictly validated at a higher infrastructure
+ * level (e.g., at the reverse proxy or API gateway) before reaching the application.
+ *
  * @returns A Web Standard `Request` object.
  */
 export function createWebRequestFromNodeRequest(
   nodeRequest: IncomingMessage | Http2ServerRequest,
+  trustProxyHeaders?: boolean | readonly string[],
 ): Request {
+  const trustProxyHeadersNormalized = normalizeTrustProxyHeaders(trustProxyHeaders);
   const { headers, method = 'GET' } = nodeRequest;
   const withBody = method !== 'GET' && method !== 'HEAD';
   const referrer = headers.referer && URL.canParse(headers.referer) ? headers.referer : undefined;
 
-  return new Request(createRequestUrl(nodeRequest), {
+  return new Request(createRequestUrl(nodeRequest, trustProxyHeadersNormalized), {
     method,
     headers: createRequestHeaders(headers),
     body: withBody ? nodeRequest : undefined,
@@ -75,20 +94,34 @@ function createRequestHeaders(nodeHeaders: IncomingHttpHeaders): Headers {
  * Creates a `URL` object from a Node.js `IncomingMessage`, taking into account the protocol, host, and port.
  *
  * @param nodeRequest - The Node.js `IncomingMessage` or `Http2ServerRequest` object to extract URL information from.
+ * @param trustProxyHeaders - A set of allowed proxy headers.
+ *
+ * @remarks
+ * When `trustProxyHeaders` is enabled, headers such as `X-Forwarded-Host` and
+ * `X-Forwarded-Prefix` should ideally be strictly validated at a higher infrastructure
+ * level (e.g., at the reverse proxy or API gateway) before reaching the application.
+ *
  * @returns A `URL` object representing the request URL.
  */
-export function createRequestUrl(nodeRequest: IncomingMessage | Http2ServerRequest): URL {
+export function createRequestUrl(
+  nodeRequest: IncomingMessage | Http2ServerRequest,
+  trustProxyHeaders: ReadonlySet<string>,
+): URL {
   const {
     headers,
     socket,
     url = '',
     originalUrl,
   } = nodeRequest as IncomingMessage & { originalUrl?: string };
+
   const protocol =
-    getFirstHeaderValue(headers['x-forwarded-proto']) ??
+    getAllowedProxyHeaderValue(headers, 'x-forwarded-proto', trustProxyHeaders) ??
     ('encrypted' in socket && socket.encrypted ? 'https' : 'http');
+
   const hostname =
-    getFirstHeaderValue(headers['x-forwarded-host']) ?? headers.host ?? headers[':authority'];
+    getAllowedProxyHeaderValue(headers, 'x-forwarded-host', trustProxyHeaders) ??
+    headers.host ??
+    headers[':authority'];
 
   if (Array.isArray(hostname)) {
     throw new Error('host value cannot be an array.');
@@ -96,11 +129,29 @@ export function createRequestUrl(nodeRequest: IncomingMessage | Http2ServerReque
 
   let hostnameWithPort = hostname;
   if (!hostname?.includes(':')) {
-    const port = getFirstHeaderValue(headers['x-forwarded-port']);
+    const port = getAllowedProxyHeaderValue(headers, 'x-forwarded-port', trustProxyHeaders);
     if (port) {
       hostnameWithPort += `:${port}`;
     }
   }
 
   return new URL(`${protocol}://${hostnameWithPort}${originalUrl ?? url}`);
+}
+
+/**
+ * Gets the first value of an allowed proxy header.
+ *
+ * @param headers - The Node.js incoming HTTP headers.
+ * @param headerName - The name of the proxy header to retrieve.
+ * @param trustProxyHeaders - A set of allowed proxy headers.
+ * @returns The value of the allowed proxy header, or `undefined` if not allowed or not present.
+ */
+function getAllowedProxyHeaderValue(
+  headers: IncomingHttpHeaders,
+  headerName: string,
+  trustProxyHeaders: ReadonlySet<string>,
+): string | undefined {
+  return isProxyHeaderAllowed(headerName, trustProxyHeaders)
+    ? getFirstHeaderValue(headers[headerName])
+    : undefined;
 }

--- a/packages/angular/ssr/node/test/BUILD.bazel
+++ b/packages/angular/ssr/node/test/BUILD.bazel
@@ -7,6 +7,7 @@ ts_project(
     srcs = glob(["**/*_spec.ts"]),
     deps = [
         "//:node_modules/@types/node",
+        "//packages/angular/ssr",
         "//packages/angular/ssr/node",
     ],
 )

--- a/packages/angular/ssr/node/test/request_spec.ts
+++ b/packages/angular/ssr/node/test/request_spec.ts
@@ -7,8 +7,8 @@
  */
 
 import { IncomingMessage } from 'node:http';
-import { Http2ServerRequest } from 'node:http2';
 import { Socket } from 'node:net';
+import { normalizeTrustProxyHeaders } from '../../src/utils/validation';
 import { createRequestUrl } from '../src/request';
 
 // Helper to create a mock request object for testing.
@@ -26,18 +26,6 @@ function createRequest(details: {
   } as unknown as IncomingMessage;
 }
 
-// Helper to create a mock Http2ServerRequest object for testing.
-function createHttp2Request(details: {
-  headers: Record<string, string | string[] | undefined>;
-  url?: string;
-}): Http2ServerRequest {
-  return {
-    headers: details.headers,
-    socket: new Socket(),
-    url: details.url,
-  } as Http2ServerRequest;
-}
-
 describe('createRequestUrl', () => {
   it('should create a http URL with hostname and port from the host header', () => {
     const url = createRequestUrl(
@@ -45,6 +33,7 @@ describe('createRequestUrl', () => {
         headers: { host: 'localhost:8080' },
         url: '/test',
       }),
+      new Set(),
     );
     expect(url.href).toBe('http://localhost:8080/test');
   });
@@ -56,6 +45,7 @@ describe('createRequestUrl', () => {
         encryptedSocket: true,
         url: '/test',
       }),
+      new Set(),
     );
     expect(url.href).toBe('https://example.com/test');
   });
@@ -67,6 +57,7 @@ describe('createRequestUrl', () => {
         encryptedSocket: true,
         url: '',
       }),
+      new Set(),
     );
     expect(url.href).toBe('https://example.com/');
   });
@@ -78,6 +69,7 @@ describe('createRequestUrl', () => {
         encryptedSocket: true,
         url: '/test?a=1',
       }),
+      new Set(),
     );
     expect(url.href).toBe('https://example.com/test?a=1');
   });
@@ -90,6 +82,7 @@ describe('createRequestUrl', () => {
         url: '/test',
         originalUrl: '/original',
       }),
+      new Set(),
     );
     expect(url.href).toBe('https://example.com/original');
   });
@@ -102,6 +95,7 @@ describe('createRequestUrl', () => {
         url: undefined,
         originalUrl: undefined,
       }),
+      new Set(),
     );
     expect(url.href).toBe('https://example.com/');
   });
@@ -112,6 +106,7 @@ describe('createRequestUrl', () => {
         headers: { host: 'localhost:8080' },
         url: '//example.com/test',
       }),
+      new Set(),
     );
     expect(url.href).toBe('http://localhost:8080//example.com/test');
   });
@@ -123,6 +118,7 @@ describe('createRequestUrl', () => {
         url: '/test',
         originalUrl: '//example.com/original',
       }),
+      new Set(),
     );
     expect(url.href).toBe('http://localhost:8080//example.com/original');
   });
@@ -137,6 +133,7 @@ describe('createRequestUrl', () => {
         },
         url: '/test',
       }),
+      normalizeTrustProxyHeaders(true),
     );
     expect(url.href).toBe('https://example.com/test');
   });
@@ -152,6 +149,7 @@ describe('createRequestUrl', () => {
         },
         url: '/test',
       }),
+      normalizeTrustProxyHeaders(true),
     );
     expect(url.href).toBe('https://example.com:8443/test');
   });

--- a/packages/angular/ssr/src/app-engine.ts
+++ b/packages/angular/ssr/src/app-engine.ts
@@ -11,7 +11,11 @@ import { Hooks } from './hooks';
 import { getPotentialLocaleIdFromUrl, getPreferredLocale } from './i18n';
 import { EntryPointExports, getAngularAppEngineManifest } from './manifest';
 import { joinUrlParts } from './utils/url';
-import { cloneRequestAndPatchHeaders, validateRequest } from './utils/validation';
+import {
+  normalizeTrustProxyHeaders,
+  sanitizeRequestHeaders,
+  validateRequest,
+} from './utils/validation';
 
 /**
  * Options for the Angular server application engine.
@@ -21,6 +25,22 @@ export interface AngularAppEngineOptions {
    * A set of allowed hostnames for the server application.
    */
   allowedHosts?: readonly string[];
+
+  /**
+   * Extends the scope of trusted proxy headers (`X-Forwarded-*`).
+   *
+   * @remarks
+   * When `trustProxyHeaders` is enabled, headers such as `X-Forwarded-Host` and
+   * `X-Forwarded-Prefix` should ideally be strictly validated at a higher infrastructure
+   * level (e.g., at the reverse proxy or API gateway) before reaching the application.
+   *
+   * If a `string[]` is provided, only those proxy headers are allowed.
+   * If `true`, all proxy headers are allowed.
+   * If `false`, proxy headers are ignored.
+   *
+   * @default undefined
+   */
+  trustProxyHeaders?: boolean | readonly string[];
 }
 
 /**
@@ -52,6 +72,13 @@ export class AngularAppEngine {
   static ɵhooks = /* #__PURE__*/ new Hooks();
 
   /**
+   * A flag to disable the allowed hosts check.
+   *
+   * @private
+   */
+  static ɵdisableAllowedHostsCheck = false;
+
+  /**
    * The manifest for the server application.
    */
   private readonly manifest = getAngularAppEngineManifest();
@@ -69,6 +96,11 @@ export class AngularAppEngine {
   );
 
   /**
+   * The normalized allowed proxy headers.
+   */
+  private readonly trustProxyHeaders: ReadonlySet<string>;
+
+  /**
    * A cache that holds entry points, keyed by their potential locale string.
    */
   private readonly entryPointsCache = new Map<string, Promise<EntryPointExports>>();
@@ -78,7 +110,23 @@ export class AngularAppEngine {
    * @param options Options for the Angular server application engine.
    */
   constructor(options?: AngularAppEngineOptions) {
-    this.allowedHosts = new Set([...(options?.allowedHosts ?? []), ...this.manifest.allowedHosts]);
+    this.allowedHosts = this.getAllowedHosts(options);
+    this.trustProxyHeaders = normalizeTrustProxyHeaders(options?.trustProxyHeaders);
+  }
+
+  private getAllowedHosts(options: AngularAppEngineOptions | undefined): ReadonlySet<string> {
+    const allowedHosts = new Set([...(options?.allowedHosts ?? []), ...this.manifest.allowedHosts]);
+
+    if (allowedHosts.has('*')) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Allowing all hosts via "*" is a security risk. This configuration should only be used when ' +
+          'validation for "Host" and "X-Forwarded-Host" headers is performed in another layer, such as a load balancer or reverse proxy. ' +
+          'For more information see: https://angular.dev/best-practices/security#preventing-server-side-request-forgery-ssrf',
+      );
+    }
+
+    return allowedHosts;
   }
 
   /**
@@ -106,23 +154,24 @@ export class AngularAppEngine {
    */
   async handle(request: Request, requestContext?: unknown): Promise<Response | null> {
     const allowedHost = this.allowedHosts;
+    const { request: securedRequest, deoptToCSR } = sanitizeRequestHeaders(
+      request,
+      this.trustProxyHeaders,
+    );
 
     try {
-      validateRequest(request, allowedHost);
+      validateRequest(securedRequest, allowedHost, AngularAppEngine.ɵdisableAllowedHostsCheck);
     } catch (error) {
-      return this.handleValidationError(error as Error, request);
+      return this.handleValidationError(error as Error, securedRequest);
     }
-
-    // Clone request with patched headers to prevent unallowed host header access.
-    const { request: securedRequest, onError: onHeaderValidationError } =
-      cloneRequestAndPatchHeaders(request, allowedHost);
 
     const serverApp = await this.getAngularServerAppForRequest(securedRequest);
     if (serverApp) {
-      return Promise.race([
-        onHeaderValidationError.then((error) => this.handleValidationError(error, securedRequest)),
-        serverApp.handle(securedRequest, requestContext),
-      ]);
+      if (deoptToCSR) {
+        return serverApp.serveClientSidePage();
+      }
+
+      return serverApp.handle(securedRequest, requestContext);
     }
 
     if (this.supportedLocales.length > 1) {

--- a/packages/angular/ssr/src/app.ts
+++ b/packages/angular/ssr/src/app.ts
@@ -175,8 +175,7 @@ export class AngularServerApp {
       return null;
     }
 
-    const { redirectTo, status, renderMode, headers } = matchedRoute;
-
+    const { redirectTo, status, renderMode, headers, preload } = matchedRoute;
     if (redirectTo !== undefined) {
       return createRedirectResponse(
         joinUrlParts(

--- a/packages/angular/ssr/src/utils/validation.ts
+++ b/packages/angular/ssr/src/utils/validation.ts
@@ -7,9 +7,20 @@
  */
 
 /**
+ * Common X-Forwarded-* headers.
+ */
+const X_FORWARDED_HEADERS = new Set([
+  'x-forwarded-for',
+  'x-forwarded-host',
+  'x-forwarded-port',
+  'x-forwarded-proto',
+  'x-forwarded-prefix',
+]);
+
+/**
  * The set of headers that should be validated for host header injection attacks.
  */
-const HOST_HEADERS_TO_VALIDATE: ReadonlySet<string> = new Set(['host', 'x-forwarded-host']);
+const HOST_HEADERS_TO_VALIDATE: ReadonlyArray<string> = ['host', 'x-forwarded-host'];
 
 /**
  * Regular expression to validate that the port is a numeric value.
@@ -22,14 +33,9 @@ const VALID_PORT_REGEX = /^\d+$/;
 const VALID_PROTO_REGEX = /^https?$/i;
 
 /**
- * Regular expression to validate that the host is a valid hostname.
- */
-const VALID_HOST_REGEX = /^[a-z0-9.:-]+$/i;
-
-/**
  * Regular expression to validate that the prefix is valid.
  */
-const INVALID_PREFIX_REGEX = /^(?:\\|\/[/\\])|(?:^|[/\\])\.\.?(?:[/\\]|$)/;
+const VALID_PREFIX_REGEX = /^\/([a-z0-9_-]+\/)*[a-z0-9_-]*$/i;
 
 /**
  * Extracts the first value from a multi-value header string.
@@ -58,9 +64,16 @@ export function getFirstHeaderValue(
  * @param allowedHosts - A set of allowed hostnames.
  * @throws Error if any of the validated headers contain invalid values.
  */
-export function validateRequest(request: Request, allowedHosts: ReadonlySet<string>): void {
-  validateHeaders(request);
-  validateUrl(new URL(request.url), allowedHosts);
+export function validateRequest(
+  request: Request,
+  allowedHosts: ReadonlySet<string>,
+  disableHostCheck: boolean,
+): void {
+  validateHeaders(request, allowedHosts, disableHostCheck);
+
+  if (!disableHostCheck) {
+    validateUrl(new URL(request.url), allowedHosts);
+  }
 }
 
 /**
@@ -78,106 +91,47 @@ export function validateUrl(url: URL, allowedHosts: ReadonlySet<string>): void {
 }
 
 /**
- * Clones a request and patches the `get` method of the request headers to validate the host headers.
- * @param request - The request to validate.
- * @param allowedHosts - A set of allowed hostnames.
- * @returns An object containing the cloned request and a promise that resolves to an error
- * if any of the validated headers contain invalid values.
+ * Sanitizes the proxy headers of a request by removing unallowed `X-Forwarded-*` headers.
+ * If no headers need to be removed, the original request is returned without cloning.
+ *
+ * @param request - The incoming `Request` object to sanitize.
+ * @param trustProxyHeaders - A set of allowed proxy headers.
+ * @returns An object containing the sanitized request, or the original request if no changes were needed.
  */
-export function cloneRequestAndPatchHeaders(
+export function sanitizeRequestHeaders(
   request: Request,
-  allowedHosts: ReadonlySet<string>,
-): { request: Request; onError: Promise<Error> } {
-  let onError: (value: Error) => void;
-  const onErrorPromise = new Promise<Error>((resolve) => {
-    onError = resolve;
-  });
+  trustProxyHeaders: ReadonlySet<string>,
+): { request: Request; deoptToCSR: boolean } {
+  const keysToDelete: string[] = [];
+  let deoptToCSR = false;
+
+  for (const [key] of request.headers) {
+    const lowerKey = key.toLowerCase();
+    if (lowerKey.startsWith('x-forwarded-') && !isProxyHeaderAllowed(lowerKey, trustProxyHeaders)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Received "${key}" header but "trustProxyHeaders" was not set up to allow it.\n` +
+          `For more information, see https://angular.dev/best-practices/security#configuring-trusted-proxy-headers`,
+      );
+      deoptToCSR = true;
+      keysToDelete.push(key);
+    }
+  }
+
+  if (keysToDelete.length === 0) {
+    return { request, deoptToCSR };
+  }
 
   const clonedReq = new Request(request.clone(), {
     signal: request.signal,
   });
 
   const headers = clonedReq.headers;
-
-  const originalGet = headers.get;
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-  (headers.get as typeof originalGet) = function (name) {
-    const value = originalGet.call(headers, name);
-    if (!value) {
-      return value;
-    }
-
-    validateHeader(name, value, allowedHosts, onError);
-
-    return value;
-  };
-
-  const originalValues = headers.values;
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-  (headers.values as typeof originalValues) = function () {
-    for (const name of HOST_HEADERS_TO_VALIDATE) {
-      validateHeader(name, originalGet.call(headers, name), allowedHosts, onError);
-    }
-
-    return originalValues.call(headers);
-  };
-
-  const originalEntries = headers.entries;
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-  (headers.entries as typeof originalEntries) = function () {
-    const iterator = originalEntries.call(headers);
-
-    return {
-      next() {
-        const result = iterator.next();
-        if (!result.done) {
-          const [key, value] = result.value;
-          validateHeader(key, value, allowedHosts, onError);
-        }
-
-        return result;
-      },
-      [Symbol.iterator]() {
-        return this;
-      },
-    };
-  };
-
-  // Ensure for...of loops use the new patched entries
-  (headers[Symbol.iterator] as typeof originalEntries) = headers.entries;
-
-  return { request: clonedReq, onError: onErrorPromise };
-}
-
-/**
- * Validates a specific header value against the allowed hosts.
- * @param name - The name of the header to validate.
- * @param value - The value of the header to validate.
- * @param allowedHosts - A set of allowed hostnames.
- * @param onError - A callback function to call if the header value is invalid.
- * @throws Error if the header value is invalid.
- */
-function validateHeader(
-  name: string,
-  value: string | null,
-  allowedHosts: ReadonlySet<string>,
-  onError: (value: Error) => void,
-): void {
-  if (!value) {
-    return;
+  for (const key of keysToDelete) {
+    headers.delete(key);
   }
 
-  if (!HOST_HEADERS_TO_VALIDATE.has(name.toLowerCase())) {
-    return;
-  }
-
-  try {
-    verifyHostAllowed(name, value, allowedHosts);
-  } catch (error) {
-    onError(error as Error);
-
-    throw error;
-  }
+  return { request: clonedReq, deoptToCSR };
 }
 
 /**
@@ -193,19 +147,20 @@ function verifyHostAllowed(
   headerValue: string,
   allowedHosts: ReadonlySet<string>,
 ): void {
-  const value = getFirstHeaderValue(headerValue);
-  if (!value) {
-    return;
-  }
-
-  const url = `http://${value}`;
+  const url = `http://${headerValue}`;
   if (!URL.canParse(url)) {
     throw new Error(`Header "${headerName}" contains an invalid value and cannot be parsed.`);
   }
 
-  const { hostname } = new URL(url);
+  const { hostname, pathname, search, hash, username, password } = new URL(url);
+  if (pathname !== '/' || search || hash || username || password) {
+    throw new Error(
+      `Header "${headerName}" with value "${headerValue}" contains characters that are not allowed.`,
+    );
+  }
+
   if (!isHostAllowed(hostname, allowedHosts)) {
-    throw new Error(`Header "${headerName}" with value "${value}" is not allowed.`);
+    throw new Error(`Header "${headerName}" with value "${headerValue}" is not allowed.`);
   }
 }
 
@@ -238,14 +193,20 @@ function isHostAllowed(hostname: string, allowedHosts: ReadonlySet<string>): boo
  * Validates the headers of an incoming request.
  *
  * @param request - The incoming `Request` object containing the headers to validate.
+ * @param allowedHosts - A set of allowed hostnames.
+ * @param disableHostCheck - Whether to disable the host check.
  * @throws Error if any of the validated headers contain invalid values.
  */
-function validateHeaders(request: Request): void {
+function validateHeaders(
+  request: Request,
+  allowedHosts: ReadonlySet<string>,
+  disableHostCheck: boolean,
+): void {
   const headers = request.headers;
   for (const headerName of HOST_HEADERS_TO_VALIDATE) {
     const headerValue = getFirstHeaderValue(headers.get(headerName));
-    if (headerValue && !VALID_HOST_REGEX.test(headerValue)) {
-      throw new Error(`Header "${headerName}" contains characters that are not allowed.`);
+    if (headerValue && !disableHostCheck) {
+      verifyHostAllowed(headerName, headerValue, allowedHosts);
     }
   }
 
@@ -260,9 +221,47 @@ function validateHeaders(request: Request): void {
   }
 
   const xForwardedPrefix = getFirstHeaderValue(headers.get('x-forwarded-prefix'));
-  if (xForwardedPrefix && INVALID_PREFIX_REGEX.test(xForwardedPrefix)) {
+  if (xForwardedPrefix && !VALID_PREFIX_REGEX.test(xForwardedPrefix)) {
     throw new Error(
-      'Header "x-forwarded-prefix" must not start with "\\" or multiple "/" or contain ".", ".." path segments.',
+      'Header "x-forwarded-prefix" is invalid. It must start with a "/" and contain ' +
+        'only alphanumeric characters, hyphens, and underscores, separated by single slashes.',
     );
   }
+}
+
+/**
+ * Checks if a specific proxy header is allowed.
+ *
+ * @param headerName - The name of the proxy header to check.
+ * @param trustProxyHeaders - A set of allowed proxy headers.
+ * @returns `true` if the header is allowed, `false` otherwise.
+ */
+export function isProxyHeaderAllowed(
+  headerName: string,
+  trustProxyHeaders: ReadonlySet<string>,
+): boolean {
+  return trustProxyHeaders.has(headerName.toLowerCase());
+}
+
+/**
+ * Normalizes the `trustProxyHeaders` option to a consistent representation.
+ * @param trustProxyHeaders The input `trustProxyHeaders` value.
+ * @returns A `Set<string>` of normalized header names.
+ */
+export function normalizeTrustProxyHeaders(
+  trustProxyHeaders: boolean | readonly string[] | undefined,
+): ReadonlySet<string> {
+  if (trustProxyHeaders === undefined) {
+    return new Set(['x-forwarded-host', 'x-forwarded-proto']);
+  }
+
+  if (trustProxyHeaders === false) {
+    return new Set();
+  }
+
+  if (trustProxyHeaders === true) {
+    return X_FORWARDED_HEADERS;
+  }
+
+  return new Set(trustProxyHeaders.map((h) => h.toLowerCase()));
 }

--- a/packages/angular/ssr/test/app-engine_spec.ts
+++ b/packages/angular/ssr/test/app-engine_spec.ts
@@ -108,7 +108,7 @@ describe('AngularAppEngine', () => {
         basePath: '/',
       });
 
-      appEngine = new AngularAppEngine();
+      appEngine = new AngularAppEngine({ trustProxyHeaders: true });
     });
 
     describe('handle', () => {
@@ -164,6 +164,21 @@ describe('AngularAppEngine', () => {
         expect(response?.status).toBe(302);
         expect(response?.headers.get('Location')).toBe('/it');
         expect(response?.headers.get('Vary')).toBe('Accept-Language');
+      });
+
+      it('should completely ignore proxy headers if not allowed', async () => {
+        const strictEngine = new AngularAppEngine({ trustProxyHeaders: false });
+        const request = new Request('https://example.com', {
+          headers: {
+            'Accept-Language': 'it',
+            'X-Forwarded-Prefix': '/app',
+          },
+        });
+
+        // The strictEngine will ignore the prefix
+        const response = await strictEngine.handle(request);
+        expect(response?.status).toBe(302);
+        expect(response?.headers.get('Location')).toBe('/it');
       });
 
       it('should return null for requests to file-like resources in a locale', async () => {
@@ -315,7 +330,7 @@ describe('AngularAppEngine', () => {
           supportedLocales: { 'en-US': '' },
         });
 
-        appEngine = new AngularAppEngine();
+        appEngine = new AngularAppEngine({ trustProxyHeaders: true });
       });
 
       beforeEach(() => {
@@ -371,10 +386,12 @@ describe('AngularAppEngine', () => {
         expect(response).not.toBeNull();
         expect(response?.status).toBe(400);
         expect(await response?.text()).toContain(
-          'Header "host" contains characters that are not allowed.',
+          'Header "host" with value "example.com/evil" contains characters that are not allowed.',
         );
         expect(consoleErrorSpy).toHaveBeenCalledWith(
-          jasmine.stringMatching('Header "host" contains characters that are not allowed.'),
+          jasmine.stringMatching(
+            'Header "host" with value "example.com/evil" contains characters that are not allowed.',
+          ),
         );
       });
     });
@@ -425,7 +442,9 @@ describe('AngularAppEngine', () => {
         expect(response).not.toBeNull();
         expect(await response?.text()).toContain('<title>CSR page</title>');
         expect(consoleErrorSpy).toHaveBeenCalledWith(
-          jasmine.stringMatching('Header "host" contains characters that are not allowed.'),
+          jasmine.stringMatching(
+            'Header "host" with value "example.com/evil" contains characters that are not allowed.',
+          ),
         );
       });
     });

--- a/packages/angular/ssr/test/utils/validation_spec.ts
+++ b/packages/angular/ssr/test/utils/validation_spec.ts
@@ -7,8 +7,9 @@
  */
 
 import {
-  cloneRequestAndPatchHeaders,
   getFirstHeaderValue,
+  normalizeTrustProxyHeaders,
+  sanitizeRequestHeaders,
   validateRequest,
   validateUrl,
 } from '../../src/utils/validation';
@@ -77,13 +78,13 @@ describe('Validation Utils', () => {
         },
       });
 
-      expect(() => validateRequest(req, allowedHosts)).not.toThrow();
+      expect(() => validateRequest(req, allowedHosts, false)).not.toThrow();
     });
 
     it('should throw if URL hostname is invalid', () => {
       const req = new Request('http://evil.com');
 
-      expect(() => validateRequest(req, allowedHosts)).toThrowError(
+      expect(() => validateRequest(req, allowedHosts, false)).toThrowError(
         /URL with hostname "evil.com" is not allowed/,
       );
     });
@@ -93,7 +94,7 @@ describe('Validation Utils', () => {
         headers: { 'x-forwarded-port': 'abc' },
       });
 
-      expect(() => validateRequest(req, allowedHosts)).toThrowError(
+      expect(() => validateRequest(req, allowedHosts, false)).toThrowError(
         'Header "x-forwarded-port" must be a numeric value.',
       );
     });
@@ -102,7 +103,7 @@ describe('Validation Utils', () => {
       const req = new Request('http://example.com', {
         headers: { 'x-forwarded-proto': 'ftp' },
       });
-      expect(() => validateRequest(req, allowedHosts)).toThrowError(
+      expect(() => validateRequest(req, allowedHosts, false)).toThrowError(
         'Header "x-forwarded-proto" must be either "http" or "https".',
       );
     });
@@ -111,8 +112,17 @@ describe('Validation Utils', () => {
       const req = new Request('http://example.com', {
         headers: { 'host': 'example.com/bad' },
       });
-      expect(() => validateRequest(req, allowedHosts)).toThrowError(
-        'Header "host" contains characters that are not allowed.',
+      expect(() => validateRequest(req, allowedHosts, false)).toThrowError(
+        'Header "host" with value "example.com/bad" contains characters that are not allowed.',
+      );
+    });
+
+    it('should throw if host contains invalid characters', () => {
+      const req = new Request('http://example.com', {
+        headers: { 'host': 'example.com?query=1' },
+      });
+      expect(() => validateRequest(req, allowedHosts, false)).toThrowError(
+        'Header "host" with value "example.com?query=1" contains characters that are not allowed.',
       );
     });
 
@@ -120,31 +130,18 @@ describe('Validation Utils', () => {
       const req = new Request('http://example.com', {
         headers: { 'x-forwarded-host': 'example.com/bad' },
       });
-      expect(() => validateRequest(req, allowedHosts)).toThrowError(
-        'Header "x-forwarded-host" contains characters that are not allowed.',
+      expect(() => validateRequest(req, allowedHosts, false)).toThrowError(
+        'Header "x-forwarded-host" with value "example.com/bad" contains characters that are not allowed.',
       );
     });
 
-    it('should throw error if x-forwarded-prefix starts with a backslash or multiple slashes', () => {
-      const inputs = ['//evil', '\\\\evil', '/\\evil', '\\/evil', '\\evil'];
-
-      for (const prefix of inputs) {
-        const request = new Request('https://example.com', {
-          headers: {
-            'x-forwarded-prefix': prefix,
-          },
-        });
-
-        expect(() => validateRequest(request, allowedHosts))
-          .withContext(`Prefix: "${prefix}"`)
-          .toThrowError(
-            'Header "x-forwarded-prefix" must not start with "\\" or multiple "/" or contain ".", ".." path segments.',
-          );
-      }
-    });
-
-    it('should throw error if x-forwarded-prefix contains dot segments', () => {
+    it('should throw error if x-forwarded-prefix is invalid', () => {
       const inputs = [
+        '//evil',
+        '\\\\evil',
+        '/\\evil',
+        '\\/evil',
+        '\\evil',
         '/./',
         '/../',
         '/foo/./bar',
@@ -159,6 +156,11 @@ describe('Validation Utils', () => {
         '/foo/..\\bar',
         '.',
         '..',
+        'https://attacker.com',
+        '%2f%2f',
+        '%5C',
+        'http://localhost',
+        'foo',
       ];
 
       for (const prefix of inputs) {
@@ -168,16 +170,17 @@ describe('Validation Utils', () => {
           },
         });
 
-        expect(() => validateRequest(request, allowedHosts))
+        expect(() => validateRequest(request, allowedHosts, false))
           .withContext(`Prefix: "${prefix}"`)
           .toThrowError(
-            'Header "x-forwarded-prefix" must not start with "\\" or multiple "/" or contain ".", ".." path segments.',
+            'Header "x-forwarded-prefix" is invalid. It must start with a "/" and contain ' +
+              'only alphanumeric characters, hyphens, and underscores, separated by single slashes.',
           );
       }
     });
 
-    it('should validate x-forwarded-prefix with valid dot usage', () => {
-      const inputs = ['/foo.bar', '/foo.bar/baz', '/v1.2', '/.well-known'];
+    it('should validate x-forwarded-prefix with valid usage', () => {
+      const inputs = ['/foo', '/foo/baz', '/v1', '/app_name', '/', '/my-app'];
 
       for (const prefix of inputs) {
         const request = new Request('https://example.com', {
@@ -186,122 +189,85 @@ describe('Validation Utils', () => {
           },
         });
 
-        expect(() => validateRequest(request, allowedHosts))
+        expect(() => validateRequest(request, allowedHosts, false))
           .withContext(`Prefix: "${prefix}"`)
           .not.toThrow();
       }
     });
   });
 
-  describe('cloneRequestAndPatchHeaders', () => {
-    const allowedHosts = new Set(['example.com', '*.valid.com']);
-
-    it('should validate host header when accessed via get()', async () => {
+  describe('sanitizeRequestHeaders', () => {
+    it('should allow x-forwarded-host and x-forwarded-proto when undefined', () => {
       const req = new Request('http://example.com', {
-        headers: { 'host': 'evil.com' },
+        headers: {
+          'host': 'example.com',
+          'x-forwarded-host': 'proxy.com',
+          'x-forwarded-proto': 'https',
+        },
       });
-      const { request: secured, onError } = cloneRequestAndPatchHeaders(req, allowedHosts);
-
-      expect(() => secured.headers.get('host')).toThrowError(
-        'Header "host" with value "evil.com" is not allowed.',
+      const { request: secured } = sanitizeRequestHeaders(
+        req,
+        normalizeTrustProxyHeaders(undefined),
       );
-      await expectAsync(onError).toBeResolvedTo(
-        jasmine.objectContaining({
-          message: jasmine.stringMatching('Header "host" with value "evil.com" is not allowed'),
-        }),
-      );
-    });
 
-    it('should allow valid host header', () => {
-      const req = new Request('http://example.com', {
-        headers: { 'host': 'example.com' },
-      });
-      const { request: secured } = cloneRequestAndPatchHeaders(req, allowedHosts);
       expect(secured.headers.get('host')).toBe('example.com');
+      expect(secured.headers.get('x-forwarded-host')).toBe('proxy.com');
+      expect(secured.headers.get('x-forwarded-proto')).toBe('https');
     });
 
-    it('should validate x-forwarded-host header', async () => {
+    it('should set deoptToCSR when x-forwarded-prefix is present and undefined', () => {
       const req = new Request('http://example.com', {
-        headers: { 'x-forwarded-host': 'evil.com' },
+        headers: {
+          'x-forwarded-prefix': '/prefix',
+        },
       });
-      const { request: secured, onError } = cloneRequestAndPatchHeaders(req, allowedHosts);
+      const { deoptToCSR } = sanitizeRequestHeaders(req, normalizeTrustProxyHeaders(undefined));
 
-      expect(() => secured.headers.get('x-forwarded-host')).toThrowError(
-        'Header "x-forwarded-host" with value "evil.com" is not allowed.',
-      );
-      await expectAsync(onError).toBeResolvedTo(
-        jasmine.objectContaining({
-          message: jasmine.stringMatching(
-            'Header "x-forwarded-host" with value "evil.com" is not allowed',
-          ),
-        }),
-      );
+      expect(deoptToCSR).toBeTrue();
     });
 
-    it('should allow accessing other headers without validation', () => {
+    it('should retain allowed proxy headers when explicitly provided', () => {
+      const trustProxyHeaders = new Set(['x-forwarded-host']);
+      const req = new Request('http://example.com', {
+        headers: {
+          'host': 'example.com',
+          'x-forwarded-host': 'proxy.com',
+          'x-forwarded-proto': 'https',
+        },
+      });
+      const { request: secured } = sanitizeRequestHeaders(req, trustProxyHeaders);
+
+      expect(secured.headers.get('host')).toBe('example.com');
+      expect(secured.headers.get('x-forwarded-host')).toBe('proxy.com');
+      expect(secured.headers.has('x-forwarded-proto')).toBeFalse();
+    });
+
+    it('should retain all proxy headers when trustProxyHeaders is true', () => {
+      const req = new Request('http://example.com', {
+        headers: {
+          'host': 'example.com',
+          'x-forwarded-host': 'proxy.com',
+          'x-forwarded-proto': 'https',
+        },
+      });
+      const { request: secured } = sanitizeRequestHeaders(req, normalizeTrustProxyHeaders(true));
+
+      expect(secured.headers.get('host')).toBe('example.com');
+      expect(secured.headers.get('x-forwarded-host')).toBe('proxy.com');
+      expect(secured.headers.get('x-forwarded-proto')).toBe('https');
+    });
+
+    it('should not clone the request if no proxy headers need to be removed', () => {
       const req = new Request('http://example.com', {
         headers: { 'accept': 'application/json' },
       });
-      const { request: secured } = cloneRequestAndPatchHeaders(req, allowedHosts);
+      const { request: secured } = sanitizeRequestHeaders(
+        req,
+        normalizeTrustProxyHeaders(undefined),
+      );
 
+      expect(secured).toBe(req);
       expect(secured.headers.get('accept')).toBe('application/json');
-    });
-
-    it('should validate headers when iterating with entries()', async () => {
-      const req = new Request('http://example.com', {
-        headers: { 'host': 'evil.com' },
-      });
-      const { request: secured, onError } = cloneRequestAndPatchHeaders(req, allowedHosts);
-
-      expect(() => {
-        for (const _ of secured.headers.entries()) {
-          // access the header to trigger the validation
-        }
-      }).toThrowError('Header "host" with value "evil.com" is not allowed.');
-
-      await expectAsync(onError).toBeResolvedTo(
-        jasmine.objectContaining({
-          message: jasmine.stringMatching('Header "host" with value "evil.com" is not allowed.'),
-        }),
-      );
-    });
-
-    it('should validate headers when iterating with values()', async () => {
-      const req = new Request('http://example.com', {
-        headers: { 'host': 'evil.com' },
-      });
-      const { request: secured, onError } = cloneRequestAndPatchHeaders(req, allowedHosts);
-
-      expect(() => {
-        for (const _ of secured.headers.values()) {
-          // access the header to trigger the validation
-        }
-      }).toThrowError('Header "host" with value "evil.com" is not allowed.');
-
-      await expectAsync(onError).toBeResolvedTo(
-        jasmine.objectContaining({
-          message: jasmine.stringMatching('Header "host" with value "evil.com" is not allowed.'),
-        }),
-      );
-    });
-
-    it('should validate headers when iterating with for...of', async () => {
-      const req = new Request('http://example.com', {
-        headers: { 'host': 'evil.com' },
-      });
-      const { request: secured, onError } = cloneRequestAndPatchHeaders(req, allowedHosts);
-
-      expect(() => {
-        for (const _ of secured.headers) {
-          // access the header to trigger the validation
-        }
-      }).toThrowError('Header "host" with value "evil.com" is not allowed.');
-
-      await expectAsync(onError).toBeResolvedTo(
-        jasmine.objectContaining({
-          message: jasmine.stringMatching('Header "host" with value "evil.com" is not allowed.'),
-        }),
-      );
     });
   });
 });

--- a/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
@@ -82,10 +82,11 @@ async function _renderUniversal(
         localeDirectory,
       );
 
+      const route = options.route;
       let html: string = await renderWorker.run({
         serverBundlePath,
         document: indexHtml,
-        url: options.route,
+        url: route?.[0] === '/' ? route : '/' + route,
       });
 
       // Overwrite the client index file.

--- a/packages/angular_devkit/build_angular/src/builders/prerender/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/prerender/index.ts
@@ -209,7 +209,7 @@ async function _renderUniversal(
               inlineCriticalCss: !!normalizedStylesOptimization.inlineCritical,
               minifyCss: !!normalizedStylesOptimization.minify,
               outputPath,
-              route,
+              route: route[0] === '/' ? route : '/' + route,
               serverBundlePath,
             };
 

--- a/packages/angular_devkit/build_angular/src/tools/webpack/utils/helpers.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/utils/helpers.ts
@@ -9,6 +9,7 @@
 import type { ObjectPattern } from 'copy-webpack-plugin';
 import glob from 'fast-glob';
 import { createHash } from 'node:crypto';
+import { createRequire } from 'node:module';
 import * as path from 'node:path';
 import type { Configuration, WebpackOptionsNormalized } from 'webpack';
 import {
@@ -314,7 +315,8 @@ export function getStatsOptions(verbose = false): WebpackStatsOptions {
  */
 export function isPackageInstalled(root: string, name: string): boolean {
   try {
-    require.resolve(name, { paths: [root] });
+    const resolve = createRequire(root + '/').resolve;
+    resolve(name);
 
     return true;
   } catch {


### PR DESCRIPTION
…date and sanitize proxy headers

This commit adds the `trustProxyHeaders` option to `AngularAppEngineOptions` and `AngularNodeAppEngineOptions` to configure, validate, and sanitize `X-Forwarded-*` headers.
- When `trustProxyHeaders` is `undefined` (default):
  - Allows `X-Forwarded-Host` and `X-Forwarded-Proto`.
  - Intercepts `X-Forwarded-Prefix` and triggers a dynamic CSR deoptimization to skip SSR if present.
  - Logs an informative message when receiving any other `X-Forwarded-*` headers.
- When `false`:
  - Ignores and strips all proxy headers from the request.
- When `true`:
  - Trusts all proxy headers.
- When a string array:
  - Allows only the proxy headers provided inside the array.

