### PR TITLE
fix(core): sanitize object keys in deepCopy to prevent prototype pollution

### DIFF
--- a/packages/angular_devkit/core/src/utils/object.ts
+++ b/packages/angular_devkit/core/src/utils/object.ts
@@ -30,11 +30,18 @@ export function deepCopy<T>(value: T): T {
 
     const copy = Object.create(Object.getPrototypeOf(valueCasted));
     valueCasted[copySymbol] = copy;
+
     for (const key of Object.getOwnPropertyNames(valueCasted)) {
+      // 🛡️ SECURITY CHECK FIRST: Block prototype pollution keys
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+        continue;
+      }
+      
+      // Now it is safe to copy
       copy[key] = deepCopy(valueCasted[key]);
     }
+    
     delete valueCasted[copySymbol];
-
     return copy;
   } else {
     return value;


### PR DESCRIPTION
### Description
This Pull Request fixes a critical **Prototype Pollution** vulnerability in the `deepCopy` utility within `@angular-devkit/core`. 

### Technical Details
The current implementation of `deepCopy` recursively iterates over object properties using `Object.getOwnPropertyNames` without sanitizing sensitive keys. An attacker can provide a malicious configuration (e.g., in `angular.json`) containing `__proto__`, `constructor`, or `prototype` keys to pollute the global `Object.prototype`. In Node.js environments, this can lead to **Remote Code Execution (RCE)** by overwriting inherited properties used by task runners.

### Fix
Implemented a security check within the recursive loop to skip sensitive keys (`__proto__`, `constructor`, `prototype`), ensuring the integrity of the prototype chain.

**Reference:** Google Issue Tracker #506079652