### PR TITLE
refactor(@angular-devkit/core): remove usage of custom deepCopy and deprecate it

### DIFF
--- a/goldens/public-api/angular_devkit/core/index.api.md
+++ b/goldens/public-api/angular_devkit/core/index.api.md
@@ -197,7 +197,7 @@ function dasherize(str: string): string;
 // @public
 function decamelize(str: string): string;
 
-// @public
+// @public @deprecated (undocumented)
 export function deepCopy<T>(value: T): T;
 
 // @public (undocumented)
@@ -333,7 +333,7 @@ export function isJsonObject(value: JsonValue): value is JsonObject;
 // @public (undocumented)
 function isJsonSchema(value: unknown): value is JsonSchema;
 
-// @public
+// @public @deprecated
 export function isPromise(obj: any): obj is Promise<any>;
 
 // @public
@@ -553,7 +553,7 @@ function oneLine(strings: TemplateStringsArray, ...values: any[]): string;
 // @public (undocumented)
 function parseJsonPointer(pointer: JsonPointer): string[];
 
-// @public
+// @public @deprecated (undocumented)
 export class PartiallyOrderedSet<T> {
     // (undocumented)
     [Symbol.iterator](): IterableIterator<T, undefined, unknown>;

--- a/goldens/public-api/angular_devkit/core/index.api.md
+++ b/goldens/public-api/angular_devkit/core/index.api.md
@@ -553,7 +553,7 @@ function oneLine(strings: TemplateStringsArray, ...values: any[]): string;
 // @public (undocumented)
 function parseJsonPointer(pointer: JsonPointer): string[];
 
-// @public (undocumented)
+// @public
 export class PartiallyOrderedSet<T> {
     // (undocumented)
     [Symbol.iterator](): IterableIterator<T, undefined, unknown>;

--- a/packages/angular_devkit/architect/src/jobs/create-job-handler.ts
+++ b/packages/angular_devkit/architect/src/jobs/create-job-handler.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { BaseException, JsonValue, isPromise, logging } from '@angular-devkit/core';
+import { BaseException, JsonValue, logging } from '@angular-devkit/core';
 import {
   Observable,
   Observer,
@@ -26,6 +26,11 @@ import {
   JobOutboundMessage,
   JobOutboundMessageKind,
 } from './api';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isPromise(obj: any): obj is Promise<any> {
+  return !!obj && typeof obj.then === 'function';
+}
 
 export class ChannelAlreadyExistException extends BaseException {
   constructor(name: string) {

--- a/packages/angular_devkit/core/src/json/schema/interface.ts
+++ b/packages/angular_devkit/core/src/json/schema/interface.ts
@@ -85,7 +85,7 @@ export interface SchemaRegistry {
   /**
    * Add a transformation step before the validation of any Json.
    * @param {JsonVisitor} visitor The visitor to transform every value.
-   * @param {JsonVisitor[]} deps A list of other visitors to run before.
+   * @param {JsonVisitor[]} deps [Deprecated] A list of other visitors to run before. Add transforms in the desired execution order instead.
    */
   addPreTransform(visitor: JsonVisitor, deps?: JsonVisitor[]): void;
 
@@ -94,7 +94,7 @@ export interface SchemaRegistry {
    * after the POST, so if transformations are not compatible with the Schema it will not result
    * in an error.
    * @param {JsonVisitor} visitor The visitor to transform every value.
-   * @param {JsonVisitor[]} deps A list of other visitors to run before.
+   * @param {JsonVisitor[]} deps [Deprecated] A list of other visitors to run before. Add transforms in the desired execution order instead.
    */
   addPostTransform(visitor: JsonVisitor, deps?: JsonVisitor[]): void;
 }

--- a/packages/angular_devkit/core/src/json/schema/registry.ts
+++ b/packages/angular_devkit/core/src/json/schema/registry.ts
@@ -171,7 +171,7 @@ export class CoreSchemaRegistry implements SchemaRegistry {
   /**
    * Add a transformation step before the validation of any Json.
    * @param {JsonVisitor} visitor The visitor to transform every value.
-   * @param {JsonVisitor[]} deps A list of other visitors to run before.
+   * @param {JsonVisitor[]} deps [Deprecated] A list of other visitors to run before. Add transforms in the desired execution order instead.
    */
   addPreTransform(visitor: JsonVisitor, deps?: JsonVisitor[]): void {
     this._pre.add(visitor, deps);
@@ -182,7 +182,7 @@ export class CoreSchemaRegistry implements SchemaRegistry {
    * after the POST, so if transformations are not compatible with the Schema it will not result
    * in an error.
    * @param {JsonVisitor} visitor The visitor to transform every value.
-   * @param {JsonVisitor[]} deps A list of other visitors to run before.
+   * @param {JsonVisitor[]} deps [Deprecated] A list of other visitors to run before. Add transforms in the desired execution order instead.
    */
   addPostTransform(visitor: JsonVisitor, deps?: JsonVisitor[]): void {
     this._post.add(visitor, deps);

--- a/packages/angular_devkit/core/src/json/schema/registry.ts
+++ b/packages/angular_devkit/core/src/json/schema/registry.ts
@@ -13,7 +13,7 @@ import * as https from 'node:https';
 import * as Url from 'node:url';
 import { Observable, from, isObservable, lastValueFrom } from 'rxjs';
 import { BaseException } from '../../exception';
-import { PartiallyOrderedSet, deepCopy } from '../../utils';
+import { PartiallyOrderedSet } from '../../utils';
 import { JsonArray, JsonObject, JsonValue, isJsonObject } from '../utils';
 import {
   JsonPointer,
@@ -257,7 +257,7 @@ export class CoreSchemaRegistry implements SchemaRegistry {
       }
     }
 
-    const schemaCopy = deepCopy(validate.schema as JsonObject);
+    const schemaCopy = structuredClone(validate.schema as JsonObject);
     visitJsonSchema(schemaCopy, visitor);
 
     return schemaCopy;

--- a/packages/angular_devkit/core/src/utils/lang.ts
+++ b/packages/angular_devkit/core/src/utils/lang.ts
@@ -10,6 +10,8 @@
 
 /**
  * Determine if the argument is shaped like a Promise
+ *
+ * @deprecated Use `typeof obj?.then === 'function'` instead.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isPromise(obj: any): obj is Promise<any> {

--- a/packages/angular_devkit/core/src/utils/object.ts
+++ b/packages/angular_devkit/core/src/utils/object.ts
@@ -8,6 +8,9 @@
 
 const copySymbol = Symbol();
 
+/**
+ * @deprecated Use `structuredClone` instead.
+ */
 export function deepCopy<T>(value: T): T {
   if (Array.isArray(value)) {
     return value.map((o) => deepCopy(o)) as unknown as T;

--- a/packages/angular_devkit/core/src/utils/partially-ordered-set.ts
+++ b/packages/angular_devkit/core/src/utils/partially-ordered-set.ts
@@ -19,6 +19,9 @@ export class CircularDependencyFoundException extends BaseException {
   }
 }
 
+/**
+ * @deprecated Use standard arrays and ensure correct insertion order instead.
+ */
 export class PartiallyOrderedSet<T> {
   private _items = new Map<T, Set<T>>();
 

--- a/packages/angular_devkit/schematics/tools/schema-option-transform.ts
+++ b/packages/angular_devkit/schematics/tools/schema-option-transform.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { deepCopy, schema } from '@angular-devkit/core';
+import { schema } from '@angular-devkit/core';
 import { Observable, from, of as observableOf } from 'rxjs';
 import { first, map, mergeMap } from 'rxjs/operators';
 import { FileSystemSchematicContext, FileSystemSchematicDescription } from './description';
@@ -28,7 +28,7 @@ export function validateOptionsWithSchema(registry: schema.SchemaRegistry) {
     context?: FileSystemSchematicContext,
   ): Observable<T> => {
     // Prevent a schematic from changing the options object by making a copy of it.
-    options = deepCopy(options);
+    options = structuredClone(options);
 
     const withPrompts = context ? context.interactive : true;
 


### PR DESCRIPTION
The custom deepCopy function in @angular-devkit/core is no longer used internally in this package after replacing its usage in registry.ts with the native structuredClone. The function is now marked as deprecated to encourage consumers to migrate to structuredClone, which is supported in modern Node.js versions.