### PR TITLE
fix(@angular/cli): fix broken img ref in ai-tutor

### DIFF
--- a/packages/angular/cli/src/commands/mcp/resources/ai-tutor.md
+++ b/packages/angular/cli/src/commands/mcp/resources/ai-tutor.md
@@ -660,7 +660,7 @@ touch src/app/mock-recipes.ts
   id: 1,
   name: 'Spaghetti Carbonara',
   description: 'A classic Italian pasta dish.',
-  imgUrl: '[https://via.placeholder.com/300x200.png?text=Spaghetti+Carbonara](https://via.placeholder.com/300x200.png?text=Spaghetti+Carbonara)',
+  imgUrl: 'INSERT_IMAGE_URL',
   ingredients: [
   { name: 'Spaghetti', quantity: 200, unit: 'g' },
   { name: 'Guanciale', quantity: 100, unit: 'g' },
@@ -673,7 +673,7 @@ touch src/app/mock-recipes.ts
   id: 2,
   name: 'Caprese Salad',
   description: 'A simple and refreshing Italian salad.',
-  imgUrl: '[https://via.placeholder.com/300x200.png?text=Caprese+Salad](https://via.placeholder.com/300x200.png?text=Caprese+Salad)',
+  imgUrl: 'INSERT_IMAGE_URL',
   ingredients: [
   { name: 'Tomatoes', quantity: 4, unit: 'each' },
   { name: 'Fresh Mozzarella', quantity: 200, unit: 'g' },
@@ -717,7 +717,7 @@ touch src/app/mock-recipes.ts
   id: 1,
   name: 'Spaghetti Carbonara',
   description: 'A classic Italian pasta dish.',
-  imgUrl: '[https://via.placeholder.com/300x200.png?text=Spaghetti+Carbonara](https://via.placeholder.com/300x200.png?text=Spaghetti+Carbonara)',
+  imgUrl: 'INSERT_IMAGE_URL',
   isFavorite: true,
   ingredients: [
   { name: 'Spaghetti', quantity: 200, unit: 'g' },
@@ -731,7 +731,7 @@ touch src/app/mock-recipes.ts
   id: 2,
   name: 'Caprese Salad',
   description: 'A simple and refreshing Italian salad.',
-  imgUrl: '[https://via.placeholder.com/300x200.png?text=Caprese+Salad](https://via.placeholder.com/300x200.png?text=Caprese+Salad)',
+  imgUrl: 'INSERT_IMAGE_URL',
   isFavorite: false,
   ingredients: [
   { name: 'Tomatoes', quantity: 4, unit: 'each' },
@@ -786,8 +786,7 @@ touch src/app/mock-recipes.ts
       name: 'Spaghetti Carbonara',
       description: 'A classic Italian pasta dish.',
       authorEmail: 'mario@italy.com', // Add this
-      imgUrl:
-        '[https://via.placeholder.com/300x200.png?text=Spaghetti+Carbonara](https://via.placeholder.com/300x200.png?text=Spaghetti+Carbonara)',
+      imgUrl: 'INSERT_IMAGE_URL',
       isFavorite: true,
       ingredients: [
         { name: 'Spaghetti', quantity: 200, unit: 'g' },


### PR DESCRIPTION
replacing the existing link with `INSERT_IMAGE_URL` makes the model insert a working link or the user can insert themselves

Fixes #32908

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 32908

## What is the new behavior?

The model should insert a working link when populating the files or the user can update themselves

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
