### PR TITLE
docs: reference vitest-base config

### DIFF
--- a/packages/angular/build/src/builders/unit-test/schema.json
+++ b/packages/angular/build/src/builders/unit-test/schema.json
@@ -21,7 +21,7 @@
     },
     "runnerConfig": {
       "type": ["string", "boolean"],
-      "description": "Specifies the configuration file for the selected test runner. If a string is provided, it will be used as the path to the configuration file. If `true`, the builder will search for a default configuration file (e.g., `vitest.config.ts` or `karma.conf.js`). If `false`, no external configuration file will be used.\\nFor Vitest, this enables advanced options and the use of custom plugins. Please note that while the file is loaded, the Angular team does not provide direct support for its specific contents or any third-party plugins used within it.",
+      "description": "Specifies the configuration file for the selected test runner. If a string is provided, it will be used as the path to the configuration file. If `true`, the builder will search for a default configuration file (e.g., `vitest-base.config.ts` or `karma.conf.js`). If `false`, no external configuration file will be used.\\nFor Vitest, this enables advanced options and the use of custom plugins. Please note that while the file is loaded, the Angular team does not provide direct support for its specific contents or any third-party plugins used within it.",
       "default": false
     },
     "browsers": {

--- a/packages/schematics/angular/migrations/migrate-karma-to-vitest/karma-processor.ts
+++ b/packages/schematics/angular/migrations/migrate-karma-to-vitest/karma-processor.ts
@@ -158,7 +158,8 @@ export async function processKarmaConfig(
       context.logger.warn(
         `Project "${projectName}" uses a custom Karma configuration file "${karmaConfig}". ` +
           `Tests have been migrated to use Vitest, but you may need to manually migrate custom settings ` +
-          `from this Karma config to a Vitest config (e.g. vitest.config.ts).`,
+          `from this Karma config to a Vitest config (e.g. "vitest-base.config.ts") ` +
+          `and set the "runnerConfig" option to true.`,
       );
       manualMigrationFiles.push(karmaConfig);
     }


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Current documentation mistakenly still references `vitest.config.ts` as an example to apply Vite config customizations.

## What is the new behavior?

Documentation now references the correct `vitest-base.config.ts` as an example to apply Vite config customizations, both in the unit test schema and the Karma-to-Vite migration message.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

- Original change: https://github.com/angular/angular-cli/pull/31621