### PR TITLE
refactor: remove X-Forwarded-Prefix from Vary header in SSR redirect utility

### DIFF
--- a/packages/angular/ssr/src/utils/redirect.ts
+++ b/packages/angular/ssr/src/utils/redirect.ts
@@ -50,18 +50,6 @@ export function createRedirectResponse(
     );
   }
 
-  // Ensure unique values for Vary header
-  const varyArray = resHeaders.get('Vary')?.split(',') ?? [];
-  const varySet = new Set(['X-Forwarded-Prefix']);
-  for (const vary of varyArray) {
-    const value = vary.trim();
-
-    if (value) {
-      varySet.add(value);
-    }
-  }
-
-  resHeaders.set('Vary', [...varySet].join(', '));
   resHeaders.set('Location', location);
 
   return new Response(null, {

--- a/packages/angular/ssr/test/app-engine_spec.ts
+++ b/packages/angular/ssr/test/app-engine_spec.ts
@@ -160,7 +160,7 @@ describe('AngularAppEngine', () => {
         const response = await appEngine.handle(request);
         expect(response?.status).toBe(302);
         expect(response?.headers.get('Location')).toBe('/it');
-        expect(response?.headers.get('Vary')).toBe('X-Forwarded-Prefix, Accept-Language');
+        expect(response?.headers.get('Vary')).toBe('Accept-Language');
       });
 
       it('should include forwarded prefix in locale redirect location when present', async () => {
@@ -174,7 +174,7 @@ describe('AngularAppEngine', () => {
         const response = await appEngine.handle(request);
         expect(response?.status).toBe(302);
         expect(response?.headers.get('Location')).toBe('/app/it');
-        expect(response?.headers.get('Vary')).toBe('X-Forwarded-Prefix, Accept-Language');
+        expect(response?.headers.get('Vary')).toBe('Accept-Language');
       });
 
       it('should completely ignore proxy headers if not allowed', async () => {

--- a/packages/angular/ssr/test/utils/redirect_spec.ts
+++ b/packages/angular/ssr/test/utils/redirect_spec.ts
@@ -14,7 +14,6 @@ describe('Redirect Utils', () => {
       const response = createRedirectResponse('/home');
       expect(response.status).toBe(302);
       expect(response.headers.get('Location')).toBe('/home');
-      expect(response.headers.get('Vary')).toBe('X-Forwarded-Prefix');
     });
 
     it('should create a redirect response with a custom status', () => {
@@ -27,23 +26,6 @@ describe('Redirect Utils', () => {
       const response = createRedirectResponse('/home', 302, { 'X-Custom': 'value' });
       expect(response.headers.get('X-Custom')).toBe('value');
       expect(response.headers.get('Location')).toBe('/home');
-      expect(response.headers.get('Vary')).toBe('X-Forwarded-Prefix');
-    });
-
-    it('should append to Vary header instead of overriding it', () => {
-      const response = createRedirectResponse('/home', 302, {
-        'Location': '/evil',
-        'Vary': 'Host',
-      });
-      expect(response.headers.get('Location')).toBe('/home');
-      expect(response.headers.get('Vary')).toBe('X-Forwarded-Prefix, Host');
-    });
-
-    it('should NOT add duplicate X-Forwarded-Prefix if already present in Vary header', () => {
-      const response = createRedirectResponse('/home', 302, {
-        'Vary': 'X-Forwarded-Prefix, Host',
-      });
-      expect(response.headers.get('Vary')).toBe('X-Forwarded-Prefix, Host');
     });
 
     it('should warn if Location header is provided in extra headers in dev mode', () => {


### PR DESCRIPTION


This is no longer needed since now `X-Forwarded-Prefix` is validated by the users.
