### PR TITLE
fix(@angular/cli): detect ng-add schematics after install

### DIFF
--- a/packages/angular/cli/src/commands/add/cli.ts
+++ b/packages/angular/cli/src/commands/add/cli.ts
@@ -591,6 +591,7 @@ export default class AddCommandModule
           join(context.collectionName, 'package.json'),
         );
 
+        await this.refreshInstalledPackageInfo(context, resolvedCollectionPath, false);
         context.collectionName = dirname(resolvedCollectionPath);
       } else {
         await packageManager.add(
@@ -603,6 +604,8 @@ export default class AddCommandModule
             registry,
           },
         );
+
+        await this.refreshInstalledPackageInfo(context);
       }
     } catch (e) {
       if (e instanceof PackageManagerError) {
@@ -613,6 +616,34 @@ export default class AddCommandModule
       }
 
       throw e;
+    }
+  }
+
+  private async refreshInstalledPackageInfo(
+    context: AddCommandTaskContext,
+    installedPackagePath?: string,
+    updateCollectionName = true,
+  ): Promise<void> {
+    installedPackagePath ??= this.resolvePackageJson(context.collectionName ?? '');
+    if (!installedPackagePath) {
+      return;
+    }
+
+    try {
+      const installedManifest = JSON.parse(
+        await fs.readFile(installedPackagePath, 'utf-8'),
+      ) as PackageManifest;
+
+      context.hasSchematics = !!installedManifest.schematics;
+      if (updateCollectionName) {
+        context.collectionName = installedManifest.name;
+      }
+      context.homepage = installedManifest.homepage ?? context.homepage;
+    } catch (e) {
+      assertIsError(e);
+      this.context.logger.debug(
+        `Unable to read installed package information from '${installedPackagePath}': ${e.message}`,
+      );
     }
   }
 

--- a/packages/angular/cli/src/commands/add/cli_spec.ts
+++ b/packages/angular/cli/src/commands/add/cli_spec.ts
@@ -1,0 +1,194 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { logging } from '@angular-devkit/core';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Argv } from 'yargs';
+import type { CommandContext } from '../../command-builder/definitions';
+import type { PackageManager, PackageManifest } from '../../package-managers';
+import AddCommandModule from './cli';
+
+describe('AddCommandModule', () => {
+  let root: string;
+  let logger: logging.Logger;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'angular-cli-add-'));
+    logger = {
+      info: jasmine.createSpy('info'),
+      error: jasmine.createSpy('error'),
+      warn: jasmine.createSpy('warn'),
+      debug: jasmine.createSpy('debug'),
+      fatal: jasmine.createSpy('fatal'),
+    } as unknown as logging.Logger;
+
+    await writeFile(join(root, 'package.json'), '{}');
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('uses the installed package manifest to detect ng-add schematics', async () => {
+    const packageName = '@private/package';
+    const packageManager = createPackageManager({
+      async add() {
+        await writeInstalledPackageManifest(packageName, {
+          name: packageName,
+          version: '1.0.0',
+          schematics: './collection.json',
+        });
+      },
+      getManifest: jasmine
+        .createSpy('getManifest')
+        .and.resolveTo({ name: packageName, version: '1.0.0' }),
+    });
+    const command = createCommand(packageManager);
+    const { createSchematic } = mockSchematicWorkflow(command);
+
+    const result = await command.run({
+      collection: `${packageName}@1.0.0`,
+      defaults: false,
+      dryRun: false,
+      force: false,
+      interactive: false,
+      skipConfirmation: true,
+    });
+
+    expect(result).toBe(0);
+    expect(packageManager.add).toHaveBeenCalled();
+    expect(createSchematic).toHaveBeenCalledWith('ng-add', true);
+    expect(command.executeSchematic).toHaveBeenCalledWith(
+      jasmine.objectContaining({ collection: packageName }),
+    );
+  });
+
+  it('uses the temporary package manifest to detect ng-add schematics', async () => {
+    const packageName = '@private/package';
+    const workingDirectory = join(root, 'temp-install');
+    const packageManager = createPackageManager({
+      async acquireTempPackage() {
+        await writeInstalledPackageManifest(
+          packageName,
+          {
+            name: packageName,
+            version: '1.0.0',
+            schematics: './collection.json',
+          },
+          workingDirectory,
+        );
+
+        return { workingDirectory, cleanup: jasmine.createSpy('cleanup') };
+      },
+      getManifest: jasmine.createSpy('getManifest').and.resolveTo({
+        name: packageName,
+        version: '1.0.0',
+        'ng-add': { save: false },
+      }),
+    });
+    const command = createCommand(packageManager);
+    const { createSchematic } = mockSchematicWorkflow(command);
+
+    const result = await command.run({
+      collection: `${packageName}@1.0.0`,
+      defaults: false,
+      dryRun: false,
+      force: false,
+      interactive: false,
+      skipConfirmation: true,
+    });
+
+    expect(result).toBe(0);
+    expect(packageManager.add).not.toHaveBeenCalled();
+    expect(packageManager.acquireTempPackage).toHaveBeenCalled();
+    expect(createSchematic).toHaveBeenCalledWith('ng-add', true);
+    expect(command.executeSchematic).toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        collection: join(workingDirectory, 'node_modules', ...packageName.split('/')),
+      }),
+    );
+  });
+
+  function createCommand(packageManager: PackageManager): AddCommandModuleInternals {
+    const context = {
+      args: {
+        positional: [],
+        options: {
+          getYargsCompletions: false,
+          help: false,
+          jsonHelp: false,
+        },
+      },
+      currentDirectory: root,
+      globalConfiguration: {},
+      logger,
+      packageManager,
+      root,
+      yargsInstance: {} as Argv,
+    } as unknown as CommandContext;
+
+    const command = new AddCommandModule(context) as unknown as AddCommandModuleInternals;
+    command.executeSchematic = jasmine.createSpy('executeSchematic').and.resolveTo(0);
+
+    return command;
+  }
+
+  function createPackageManager(options: {
+    acquireTempPackage?: PackageManager['acquireTempPackage'];
+    add?: PackageManager['add'];
+    getManifest: jasmine.Spy;
+  }): PackageManager {
+    const packageManager = {
+      acquireTempPackage: jasmine
+        .createSpy('acquireTempPackage')
+        .and.callFake(options.acquireTempPackage ?? fail),
+      add: jasmine.createSpy('add').and.callFake(options.add ?? fail),
+      getManifest: options.getManifest,
+      name: 'npm',
+    } as unknown as PackageManager;
+
+    return packageManager;
+  }
+
+  function mockSchematicWorkflow(command: AddCommandModuleInternals): {
+    createSchematic: jasmine.Spy;
+  } {
+    const createSchematic = jasmine.createSpy('createSchematic');
+
+    command.getOrCreateWorkflowForBuilder = jasmine
+      .createSpy('getOrCreateWorkflowForBuilder')
+      .and.returnValue({
+        engine: {
+          createCollection: jasmine.createSpy('createCollection').and.returnValue({
+            createSchematic,
+          }),
+        },
+      });
+
+    return { createSchematic };
+  }
+
+  async function writeInstalledPackageManifest(
+    packageName: string,
+    manifest: PackageManifest,
+    basePath = root,
+  ): Promise<void> {
+    const packagePath = join(basePath, 'node_modules', ...packageName.split('/'));
+
+    await mkdir(packagePath, { recursive: true });
+    await writeFile(join(packagePath, 'package.json'), JSON.stringify(manifest));
+  }
+});
+
+type AddCommandModuleInternals = {
+  executeSchematic: jasmine.Spy;
+  getOrCreateWorkflowForBuilder: jasmine.Spy;
+  run: AddCommandModule['run'];
+};


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Fixes #33060.

When `ng add` installs a package from a registry whose package-manager manifest metadata omits the `schematics` field, the CLI sets `hasSchematics` to `false` before installation. That prevents the later post-install `ng-add` schematic verification from running, so the first `ng add` reports that no actions are available even though the installed package's `package.json` contains a valid schematics collection. Running the same command again can work because the already-installed path uses the filesystem instead of registry metadata.

## What is the new behavior?

After installing a package, `ng add` refreshes schematic availability from the installed package manifest. The registry manifest is still used for package resolution, peer dependency checks, `ng-add.save`, and homepage data, but the package that was actually installed becomes authoritative for whether schematics are present.

This refresh is applied to both normal project installs and temporary installs used by packages with `ng-add.save=false`, so both install paths can execute `ng-add` schematics even when registry metadata is incomplete.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Added focused `AddCommandModule` coverage for regular installs and temporary installs where registry metadata omits `schematics` but the installed package manifest provides it.

Validation performed locally:

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec prettier --check packages/angular/cli/src/commands/add/cli.ts packages/angular/cli/src/commands/add/cli_spec.ts`
- `corepack pnpm exec eslint packages/angular/cli/src/commands/add/cli.ts packages/angular/cli/src/commands/add/cli_spec.ts --max-warnings=0`
- `git diff --check`
- Targeted TypeScript diagnostic check confirmed no diagnostics for `packages/angular/cli/src/commands/add/*`.
- Clean Ubuntu WSL validation on commit `87c0004cb46ff7429e6666c01c35910fc4316c15`:
  `corepack pnpm bazel test //packages/angular/cli:test --test_filter=AddCommandModule --test_output=errors --lockfile_mode=off`

Native Windows Bazel execution hit shell/path translation issues, so the focused Bazel target was run in a Linux WSL checkout after installing Ubuntu, Node `v22.22.2`, and pnpm `10.33.0`.