### PR TITLE
refactor(schematics): remove unnecessary `compileComponents`

### DIFF
--- a/packages/angular/build/src/builders/unit-test/tests/behavior/coverage-ignore-comments_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/behavior/coverage-ignore-comments_spec.ts
@@ -26,10 +26,10 @@ import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [AppComponent],
-    }).compileComponents();
+    });
   });
 
   it('should create the app', () => {

--- a/packages/schematics/angular/application/files/module-files/src/app/app__suffix__.spec.ts.template
+++ b/packages/schematics/angular/application/files/module-files/src/app/app__suffix__.spec.ts.template
@@ -3,15 +3,15 @@ import { RouterModule } from '@angular/router';<% } %>
 import { App } from './app<%= suffix %>';
 
 describe('App', () => {
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({<% if (routing) { %>
+  beforeEach(() => {
+    TestBed.configureTestingModule({<% if (routing) { %>
       imports: [
         RouterModule.forRoot([])
       ],<% } %>
       declarations: [
         App
       ],
-    }).compileComponents();
+    });
   });
 
   it('should create the app', () => {

--- a/packages/schematics/angular/application/files/standalone-files/src/app/app__suffix__.spec.ts.template
+++ b/packages/schematics/angular/application/files/standalone-files/src/app/app__suffix__.spec.ts.template
@@ -2,12 +2,6 @@ import { TestBed } from '@angular/core/testing';
 import { App } from './app<%= suffix %>';
 
 describe('App', () => {
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [App],
-    }).compileComponents();
-  });
-
   it('should create the app', () => {
     const fixture = TestBed.createComponent(App);
     const app = fixture.componentInstance;

--- a/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.spec.ts.template
+++ b/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.spec.ts.template
@@ -7,10 +7,9 @@ describe('<%= classifiedName %>', () => {
   let fixture: ComponentFixture<<%= classifiedName %>>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
+    TestBed.configureTestingModule({
       <%= standalone ? 'imports' : 'declarations' %>: [<%= classifiedName %>]
-    })
-    .compileComponents();
+    });
 
     fixture = TestBed.createComponent(<%= classifiedName %>);
     component = fixture.componentInstance;

--- a/packages/schematics/angular/component/index_spec.ts
+++ b/packages/schematics/angular/component/index_spec.ts
@@ -56,14 +56,6 @@ describe('Component Schematic', () => {
     appTree = await schematicRunner.runSchematic('application', appOptions, appTree);
   });
 
-  it('should contain a TestBed compileComponents call', async () => {
-    const options = { ...defaultOptions };
-
-    const tree = await schematicRunner.runSchematic('component', options, appTree);
-    const tsContent = tree.readContent('/projects/bar/src/app/foo/foo.component.spec.ts');
-    expect(tsContent).toContain('compileComponents()');
-  });
-
   it('should not set change detection when default is OnPush', async () => {
     const options = { ...defaultOptions };
 


### PR DESCRIPTION
angular/angular/pull/61230 updated `TestBed`'s behavior of components with async metadata. `TestBed` will now only throw when `overrideComponent()` is used on a component with a `@defer` block
