### PR TITLE
refactor: configure Gemini reviewer to ignore lockfile and changelog

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -8,4 +8,6 @@ code_review:
     summary: false
     code_review: true
     include_drafts: false
-ignore_patterns: []
+ignore_patterns:
+  - pnpm-lock.yaml
+  - CHANGELOG.md


### PR DESCRIPTION
The bot doesn't provide much useful feedback on these files and pollutes release PRs, so we can just skip them.