### PR TITLE
fix(@schematics/angular): use service decorator in ng generate

### DIFF
--- a/packages/schematics/angular/service/files/__name@dasherize__.__type@dasherize__.ts.template
+++ b/packages/schematics/angular/service/files/__name@dasherize__.__type@dasherize__.ts.template
@@ -1,8 +1,8 @@
-import { Injectable } from '@angular/core';
+import { <%= injectable ? 'Injectable' : 'Service' %> } from '@angular/core';
 
-@Injectable({
+<% if (injectable) { %>@Injectable({
   providedIn: 'root',
-})
+})<% } else { %>@Service()<% } %>
 export class <%= classifiedName %> {
   
 }

--- a/packages/schematics/angular/service/index_spec.ts
+++ b/packages/schematics/angular/service/index_spec.ts
@@ -36,6 +36,7 @@ describe('Service Schematic', () => {
     skipPackageJson: false,
   };
   let appTree: UnitTestTree;
+
   beforeEach(async () => {
     appTree = await schematicRunner.runSchematic('workspace', workspaceOptions);
     appTree = await schematicRunner.runSchematic('application', appOptions, appTree);
@@ -50,12 +51,23 @@ describe('Service Schematic', () => {
     expect(files).toContain('/projects/bar/src/app/foo/foo.ts');
   });
 
-  it('service should be tree-shakeable', async () => {
+  it('should use @Service decorator', async () => {
     const options = { ...defaultOptions };
 
     const tree = await schematicRunner.runSchematic('service', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/foo/foo.ts');
+    expect(content).toMatch(/@Service\(\)/);
+    expect(content).toMatch(/import \{ Service \} from '@angular\/core'/);
+  });
+
+  it('should use @Injectable decorator when injectable flag is true', async () => {
+    const options = { ...defaultOptions, injectable: true };
+
+    const tree = await schematicRunner.runSchematic('service', options, appTree);
+    const content = tree.readContent('/projects/bar/src/app/foo/foo.ts');
+    expect(content).toMatch(/@Injectable\(/);
     expect(content).toMatch(/providedIn: 'root',/);
+    expect(content).toMatch(/import \{ Injectable \} from '@angular\/core'/);
   });
 
   it('should respect the skipTests flag', async () => {

--- a/packages/schematics/angular/service/schema.json
+++ b/packages/schematics/angular/service/schema.json
@@ -48,6 +48,11 @@
       "type": "boolean",
       "default": true,
       "description": "When true, the 'type' option will be appended to the generated class name. When false, only the file name will include the type."
+    },
+    "injectable": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, generates an `@Injectable` instead of `@Service`."
     }
   },
   "required": ["name", "project"]


### PR DESCRIPTION
Updates the `service` schematic in `ng generate` to use the `@Service` decorator instead of `@Injectable`. There's also a new `--injectable` flag to get back the old behavior.