### PR TITLE
feat(@schematics/angular): add option to migrate `fakeAsync` to Vitest fake timers

### DIFF
--- a/packages/schematics/angular/refactor/jasmine-vitest/index.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/index.ts
@@ -122,6 +122,7 @@ export default function (options: Schema): Rule {
       const newContent = transformJasmineToVitest(file, content, reporter, {
         addImports: !!options.addImports,
         browserMode: !!options.browerMode,
+        fakeAsync: !!options.fakeAsync,
       });
 
       if (content !== newContent) {

--- a/packages/schematics/angular/refactor/jasmine-vitest/schema.json
+++ b/packages/schematics/angular/refactor/jasmine-vitest/schema.json
@@ -36,6 +36,11 @@
       "description": "Whether the tests are intended to run in browser mode. If true, the `toHaveClass` assertions are left as is because Vitest browser mode has such an assertion. Otherwise they're migrated to an equivalent assertion.",
       "default": false
     },
+    "fakeAsync": {
+      "type": "boolean",
+      "description": "Whether to transform `fakeAsync` tests to Vitest fake timers.",
+      "default": false
+    },
     "report": {
       "type": "boolean",
       "description": "Whether to generate a summary report file (jasmine-vitest-<date>.md) in the project root.",

--- a/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.integration_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.integration_spec.ts
@@ -14,7 +14,7 @@ import { RefactorReporter } from './utils/refactor-reporter';
 async function expectTransformation(
   input: string,
   expected: string,
-  options: { addImports: boolean; browserMode: boolean } = {
+  options: { addImports: boolean; browserMode: boolean; fakeAsync?: boolean } = {
     addImports: false,
     browserMode: false,
   },
@@ -533,5 +533,67 @@ describe('Jasmine to Vitest Transformer - Integration Tests', () => {
     `;
 
     await expectTransformation(jasmineCode, vitestCode);
+  });
+
+  it('should not transform `fakeAsync`', async () => {
+    const jasmineCode = `
+      import { fakeAsync, flush, flushMicrotasks, tick } from '@angular/core/testing';
+      
+      describe('My fakeAsync suite', () => {
+        it('works', fakeAsync(() => {
+          flush();
+          flushMicrotasks();
+          tick(100);
+        }));
+      });
+    `;
+    const vitestCode = `
+      import { fakeAsync, flush, flushMicrotasks, tick } from '@angular/core/testing';
+
+      describe('My fakeAsync suite', () => {
+        it('works', fakeAsync(() => {
+          flush();
+          flushMicrotasks();
+          tick(100);
+        }));
+      });
+    `;
+
+    await expectTransformation(jasmineCode, vitestCode);
+  });
+
+  it('should transform `fakeAsync` if `fakeAsync` option is true', async () => {
+    const jasmineCode = `
+      import { fakeAsync, flush, flushMicrotasks, tick } from '@angular/core/testing';
+
+      describe('My fakeAsync suite', () => {
+        it('works', fakeAsync(() => {
+          flush();
+          flushMicrotasks();
+          tick(100);
+        }));
+      });
+    `;
+    const vitestCode = `
+      describe('My fakeAsync suite', () => {
+        beforeAll(() => {
+          vi.useFakeTimers({ advanceTimeDelta: 1, shouldAdvanceTime: true });
+        });
+        afterAll(() => {
+          vi.useRealTimers();
+        });
+        it('works', async () => {
+          await vi.runAllTimersAsync();
+          await vi.advanceTimersByTimeAsync(0);
+          await vi.advanceTimersByTimeAsync(100);
+        });
+      });
+    `;
+
+    await expectTransformation(jasmineCode, vitestCode, {
+      addImports: false,
+      browserMode: false,
+      fakeAsync: true,
+    });
   });
 });

--- a/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.ts
@@ -14,6 +14,10 @@
  */
 
 import ts from 'typescript';
+import { transformFakeAsyncFlush } from './transformers/fake-async-flush';
+import { transformFakeAsyncFlushMicrotasks } from './transformers/fake-async-flush-microtasks';
+import { transformFakeAsyncTest } from './transformers/fake-async-test';
+import { transformFakeAsyncTick } from './transformers/fake-async-tick';
 import {
   transformDoneCallback,
   transformFocusedAndSkippedTests,
@@ -48,7 +52,11 @@ import {
   transformSpyReset,
 } from './transformers/jasmine-spy';
 import { transformJasmineTypes } from './transformers/jasmine-type';
-import { addVitestValueImport, getVitestAutoImports } from './utils/ast-helpers';
+import {
+  addVitestValueImport,
+  getVitestAutoImports,
+  removeImportSpecifiers,
+} from './utils/ast-helpers';
 import { RefactorContext } from './utils/refactor-context';
 import { RefactorReporter } from './utils/refactor-reporter';
 
@@ -129,6 +137,10 @@ const callExpressionTransformers = [
   transformToHaveBeenCalledBefore,
   transformToHaveClass,
   transformToBeNullish,
+  transformFakeAsyncTest,
+  transformFakeAsyncTick,
+  transformFakeAsyncFlush,
+  transformFakeAsyncFlushMicrotasks,
 
   // **Stage 3: Global Functions & Cleanup**
   // These handle global Jasmine functions and catch-alls for unsupported APIs.
@@ -173,8 +185,10 @@ export function transformJasmineToVitest(
   filePath: string,
   content: string,
   reporter: RefactorReporter,
-  options: { addImports: boolean; browserMode: boolean },
+  options: { addImports: boolean; browserMode: boolean; fakeAsync?: boolean },
 ): string {
+  options.fakeAsync ??= false;
+
   const contentWithPlaceholders = preserveBlankLines(content);
 
   const sourceFile = ts.createSourceFile(
@@ -187,6 +201,7 @@ export function transformJasmineToVitest(
 
   const pendingVitestValueImports = new Set<string>();
   const pendingVitestTypeImports = new Set<string>();
+  const pendingImportSpecifierRemovals = new Map<string, Set<string>>();
 
   const transformer: ts.TransformerFactory<ts.SourceFile> = (context) => {
     const refactorCtx: RefactorContext = {
@@ -195,6 +210,7 @@ export function transformJasmineToVitest(
       tsContext: context,
       pendingVitestValueImports,
       pendingVitestTypeImports,
+      pendingImportSpecifierRemovals,
     };
 
     const visitor: ts.Visitor = (node) => {
@@ -211,7 +227,18 @@ export function transformJasmineToVitest(
         }
 
         for (const transformer of callExpressionTransformers) {
-          if (!(options.browserMode && transformer === transformToHaveClass)) {
+          if (
+            !(
+              (options.browserMode && transformer === transformToHaveClass) ||
+              (options.fakeAsync === false &&
+                [
+                  transformFakeAsyncFlush,
+                  transformFakeAsyncFlushMicrotasks,
+                  transformFakeAsyncTick,
+                  transformFakeAsyncTest,
+                ].includes(transformer))
+            )
+          ) {
             transformedNode = transformer(transformedNode, refactorCtx);
           }
         }
@@ -249,14 +276,23 @@ export function transformJasmineToVitest(
 
   const hasPendingValueImports = pendingVitestValueImports.size > 0;
   const hasPendingTypeImports = pendingVitestTypeImports.size > 0;
+  const hasPendingImportSpecifierRemovals = pendingImportSpecifierRemovals.size > 0;
 
   if (
     transformedSourceFile === sourceFile &&
     !reporter.hasTodos &&
     !hasPendingValueImports &&
-    !hasPendingTypeImports
+    !hasPendingTypeImports &&
+    !hasPendingImportSpecifierRemovals
   ) {
     return content;
+  }
+
+  if (hasPendingImportSpecifierRemovals) {
+    transformedSourceFile = removeImportSpecifiers(
+      transformedSourceFile,
+      pendingImportSpecifierRemovals,
+    );
   }
 
   if (hasPendingTypeImports || (options.addImports && hasPendingValueImports)) {

--- a/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer_add-imports_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer_add-imports_spec.ts
@@ -150,4 +150,32 @@ describe('Jasmine to Vitest Transformer - addImports option', () => {
       true,
     );
   });
+
+  it('should add imports for `vi` when addImports is true', async () => {
+    const input = `
+        import { fakeAsync } from '@angular/core/testing';
+
+        describe('My fakeAsync suite', () => {
+          it('works', fakeAsync(() => {
+            expect(1).toBe(1);
+          }));
+        });
+      `;
+    const expected = `
+        import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+        describe('My fakeAsync suite', () => {
+          beforeAll(() => {
+            vi.useFakeTimers({ advanceTimeDelta: 1, shouldAdvanceTime: true });
+          });
+          afterAll(() => {
+            vi.useRealTimers();
+          });
+          it('works', async () => {
+            expect(1).toBe(1);
+          });
+        });
+      `;
+    await expectTransformation(input, expected, true);
+  });
 });

--- a/packages/schematics/angular/refactor/jasmine-vitest/test-helpers.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/test-helpers.ts
@@ -33,6 +33,7 @@ export async function expectTransformation(
   const transformed = transformJasmineToVitest('spec.ts', input, reporter, {
     addImports,
     browserMode: false,
+    fakeAsync: true,
   });
   const formattedTransformed = await format(transformed, { parser: 'typescript' });
   const formattedExpected = await format(expected, { parser: 'typescript' });

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-flush-microtasks.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-flush-microtasks.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import ts from 'typescript';
+import { isNamedImportFrom } from '../utils/ast-helpers';
+import { ANGULAR_CORE_TESTING } from '../utils/constants';
+import { RefactorContext } from '../utils/refactor-context';
+import { addImportSpecifierRemoval, createViCallExpression } from '../utils/refactor-helpers';
+
+export function transformFakeAsyncFlushMicrotasks(node: ts.Node, ctx: RefactorContext): ts.Node {
+  if (
+    !(
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'flushMicrotasks' &&
+      isNamedImportFrom(ctx.sourceFile, 'flushMicrotasks', ANGULAR_CORE_TESTING)
+    )
+  ) {
+    return node;
+  }
+
+  ctx.reporter.reportTransformation(
+    ctx.sourceFile,
+    node,
+    `Transformed \`flushMicrotasks\` to \`await vi.advanceTimersByTimeAsync(0)\`.`,
+  );
+
+  addImportSpecifierRemoval(ctx, 'flushMicrotasks', ANGULAR_CORE_TESTING);
+
+  return ts.factory.createAwaitExpression(
+    createViCallExpression(ctx, 'advanceTimersByTimeAsync', [ts.factory.createNumericLiteral(0)]),
+  );
+}

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-flush-microtasks_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-flush-microtasks_spec.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { expectTransformation } from '../test-helpers';
+
+describe('transformFakeAsyncFlushMicrotasks', () => {
+  const testCases = [
+    {
+      description: 'should replace `flushMicrotasks` with `await vi.advanceTimersByTimeAsync(0)`',
+      input: `
+          import { flushMicrotasks } from '@angular/core/testing';
+          
+          flushMicrotasks();
+        `,
+      expected: `await vi.advanceTimersByTimeAsync(0);`,
+    },
+    {
+      description:
+        'should not replace `flushMicrotasks` if not imported from `@angular/core/testing`',
+      input: `
+          import { flushMicrotasks } from './my-flush-microtasks';
+          
+          flushMicrotasks();
+        `,
+      expected: `
+          import { flushMicrotasks } from './my-flush-microtasks';
+          
+          flushMicrotasks();
+        `,
+    },
+  ];
+
+  testCases.forEach(({ description, input, expected }) => {
+    it(description, async () => {
+      await expectTransformation(input, expected);
+    });
+  });
+});

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-flush.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-flush.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import ts from 'typescript';
+import { isNamedImportFrom } from '../utils/ast-helpers';
+import { addTodoComment } from '../utils/comment-helpers';
+import { ANGULAR_CORE_TESTING } from '../utils/constants';
+import { RefactorContext } from '../utils/refactor-context';
+import { addImportSpecifierRemoval, createViCallExpression } from '../utils/refactor-helpers';
+
+export function transformFakeAsyncFlush(node: ts.Node, ctx: RefactorContext): ts.Node {
+  if (
+    !(
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'flush' &&
+      isNamedImportFrom(ctx.sourceFile, 'flush', ANGULAR_CORE_TESTING)
+    )
+  ) {
+    return node;
+  }
+
+  ctx.reporter.reportTransformation(
+    ctx.sourceFile,
+    node,
+    `Transformed \`flush\` to \`await vi.runAllTimersAsync()\`.`,
+  );
+
+  addImportSpecifierRemoval(ctx, 'flush', ANGULAR_CORE_TESTING);
+
+  if (node.arguments.length > 0) {
+    ctx.reporter.recordTodo('flush-max-turns', ctx.sourceFile, node);
+    addTodoComment(node, 'flush-max-turns');
+  }
+
+  const awaitRunAllTimersAsync = ts.factory.createAwaitExpression(
+    createViCallExpression(ctx, 'runAllTimersAsync'),
+  );
+
+  if (ts.isExpressionStatement(node.parent)) {
+    return awaitRunAllTimersAsync;
+  } else {
+    // If `flush` is not used as its own statement, then the return value is probably used.
+    // Therefore, we replace it with nullish coalescing that returns 0:
+    // > await vi.runAllTimersAsync() ?? 0;
+    ctx.reporter.recordTodo('flush-return-value', ctx.sourceFile, node);
+    addTodoComment(node, 'flush-return-value');
+
+    return ts.factory.createBinaryExpression(
+      awaitRunAllTimersAsync,
+      ts.SyntaxKind.QuestionQuestionToken,
+      ts.factory.createNumericLiteral(0),
+    );
+  }
+}

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-flush_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-flush_spec.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { expectTransformation } from '../test-helpers';
+
+describe('transformFakeAsyncFlush', () => {
+  const testCases = [
+    {
+      description: 'should replace `flush` with `await vi.runAllTimersAsync()`',
+      input: `
+          import { flush } from '@angular/core/testing';
+          
+          flush();
+        `,
+      expected: `await vi.runAllTimersAsync();`,
+    },
+    {
+      description: 'should add TODO comment when flush is called with maxTurns',
+      input: `
+          import { flush } from '@angular/core/testing';
+
+          flush(42);
+        `,
+      expected: `
+          // TODO: vitest-migration: flush(maxTurns) was called but maxTurns parameter is not migrated. Please migrate manually.
+          await vi.runAllTimersAsync();
+        `,
+    },
+    {
+      description: 'should add TODO comment when flush return value is used',
+      input: `
+          import { flush } from '@angular/core/testing';
+          
+          const turns = flush();
+        `,
+      expected: `
+          // TODO: vitest-migration: flush() return value is not migrated. Please migrate manually.
+          const turns = await vi.runAllTimersAsync() ?? 0;
+        `,
+    },
+    {
+      description: 'should add TODO comment when flush return value is used in a return statement',
+      input: `
+          import { flush } from '@angular/core/testing';
+          
+          async function myFlushWrapper() {
+            return flush();
+          }
+        `,
+      expected: `
+         async function myFlushWrapper() {
+            // TODO: vitest-migration: flush() return value is not migrated. Please migrate manually.
+            return await vi.runAllTimersAsync() ?? 0;
+          }
+        `,
+    },
+    {
+      description: 'should not replace `flush` if not imported from `@angular/core/testing`',
+      input: `
+          import { flush } from './my-flush';
+          
+          flush();
+        `,
+      expected: `
+          import { flush } from './my-flush';
+          
+          flush();
+        `,
+    },
+    {
+      description: 'should keep other imported symbols from `@angular/core/testing`',
+      input: `
+          import { TestBed, flush } from '@angular/core/testing';
+          
+          flush();
+        `,
+      expected: `
+          import { TestBed } from '@angular/core/testing';
+          
+          await vi.runAllTimersAsync();
+        `,
+    },
+    {
+      description: 'should keep imported types from `@angular/core/testing`',
+      input: `
+          import { flush, type ComponentFixture } from '@angular/core/testing';
+          
+          flush();
+        `,
+      expected: `
+          import { type ComponentFixture } from '@angular/core/testing';
+          
+          await vi.runAllTimersAsync();
+        `,
+    },
+  ];
+
+  testCases.forEach(({ description, input, expected }) => {
+    it(description, async () => {
+      await expectTransformation(input, expected);
+    });
+  });
+});

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-test.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-test.ts
@@ -1,0 +1,211 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import ts from 'typescript';
+import { isNamedImportFrom } from '../utils/ast-helpers';
+import { ANGULAR_CORE_TESTING } from '../utils/constants';
+import { RefactorContext } from '../utils/refactor-context';
+import { addImportSpecifierRemoval, createViCallExpression } from '../utils/refactor-helpers';
+
+export function transformFakeAsyncTest(
+  node: ts.Node,
+  ctx: RefactorContext,
+  currentOutermostDescribeContext?: CurrentOutermostDescribeContext,
+): ts.Node {
+  // Transform the outermost describe block and skip others.
+  if (currentOutermostDescribeContext == null && _is.describe(node)) {
+    return _transformDescribeCall(node, ctx);
+  }
+
+  // If we encounter a `fakeAsync` call while in a `describe` block, mark it in the context.
+  if (
+    ts.isCallExpression(node) &&
+    ts.isIdentifier(node.expression) &&
+    node.expression.text === 'fakeAsync' &&
+    currentOutermostDescribeContext != null &&
+    node.arguments.length >= 1 &&
+    _is.arrowOrFunction(node.arguments[0]) &&
+    isNamedImportFrom(ctx.sourceFile, 'fakeAsync', ANGULAR_CORE_TESTING)
+  ) {
+    return _transformFakeAsyncCall(node, ctx, currentOutermostDescribeContext);
+  }
+
+  // If we are in a `describe` block, visit the children recursively.
+  if (currentOutermostDescribeContext != null) {
+    return ts.visitEachChild(
+      node,
+      (child) => transformFakeAsyncTest(child, ctx, currentOutermostDescribeContext),
+      ctx.tsContext,
+    );
+  }
+
+  return node;
+}
+
+function _transformDescribeCall(node: ts.CallExpression, ctx: RefactorContext): ts.CallExpression {
+  const currentOutermostDescribeContext: CurrentOutermostDescribeContext = {
+    isUsingFakeAsync: false,
+  };
+
+  // Visit children recursively to collect transform `fakeAsync usages
+  // within the describe block and detect their presence through `isUsingFakeAsync`.
+  node = ts.visitEachChild(
+    node,
+    (child) => transformFakeAsyncTest(child, ctx, currentOutermostDescribeContext),
+    ctx.tsContext,
+  );
+
+  const { isUsingFakeAsync } = currentOutermostDescribeContext;
+
+  const describeBlock = _findDescribeBlock(node);
+  if (!isUsingFakeAsync || describeBlock === undefined) {
+    return node;
+  }
+
+  addImportSpecifierRemoval(ctx, 'fakeAsync', ANGULAR_CORE_TESTING);
+
+  return ts.factory.updateCallExpression(node, node.expression, node.typeArguments, [
+    node.arguments[0],
+    ts.factory.createArrowFunction(
+      undefined,
+      undefined,
+      [],
+      undefined,
+      ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+      ts.factory.createBlock([
+        ..._createFakeTimersHookStatements(ctx),
+        ...describeBlock.statements,
+      ]),
+    ),
+    ...node.arguments.slice(2),
+  ]);
+}
+
+function _transformFakeAsyncCall(
+  node: ts.CallExpression,
+  ctx: RefactorContext,
+  currentOutermostDescribeContext: CurrentOutermostDescribeContext,
+): ts.CallExpression | ts.ArrowFunction {
+  currentOutermostDescribeContext.isUsingFakeAsync = true;
+
+  const fakeAsyncCallback = node.arguments[0];
+  if (!_is.arrowOrFunction(fakeAsyncCallback)) {
+    return node;
+  }
+  const callbackBody = ts.isBlock(fakeAsyncCallback.body)
+    ? fakeAsyncCallback.body
+    : ts.factory.createBlock([ts.factory.createExpressionStatement(fakeAsyncCallback.body)]);
+
+  ctx.reporter.reportTransformation(
+    ctx.sourceFile,
+    node,
+    `Transformed \`fakeAsync\` to \`vi.useFakeTimers\`.`,
+  );
+
+  return ts.factory.createArrowFunction(
+    [ts.factory.createModifier(ts.SyntaxKind.AsyncKeyword)],
+    fakeAsyncCallback.typeParameters,
+    fakeAsyncCallback.parameters,
+    undefined,
+    ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+    ts.factory.createBlock(callbackBody.statements),
+  );
+}
+
+function _createFakeTimersHookStatements(ctx: RefactorContext): ts.Statement[] {
+  return [
+    // > beforeAll(() => {
+    // >   vi.useFakeTimers({
+    // >     advanceTimeDelta: 1,
+    // >     shouldAdvanceTime: true
+    // >   });
+    // > });
+    ts.factory.createExpressionStatement(
+      ts.factory.createCallExpression(ts.factory.createIdentifier('beforeAll'), undefined, [
+        ts.factory.createArrowFunction(
+          undefined,
+          undefined,
+          [],
+          undefined,
+          ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+          ts.factory.createBlock(
+            [
+              ts.factory.createExpressionStatement(
+                createViCallExpression(ctx, 'useFakeTimers', [
+                  ts.factory.createObjectLiteralExpression([
+                    ts.factory.createPropertyAssignment(
+                      'advanceTimeDelta',
+                      ts.factory.createNumericLiteral(1),
+                    ),
+                    ts.factory.createPropertyAssignment(
+                      'shouldAdvanceTime',
+                      ts.factory.createTrue(),
+                    ),
+                  ]),
+                ]),
+              ),
+            ],
+            true,
+          ),
+        ),
+      ]),
+    ),
+
+    // > afterAll(() => {
+    // >   vi.useRealTimers();
+    // > });
+    ts.factory.createExpressionStatement(
+      ts.factory.createCallExpression(ts.factory.createIdentifier('afterAll'), undefined, [
+        ts.factory.createArrowFunction(
+          undefined,
+          undefined,
+          [],
+          undefined,
+          ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+          ts.factory.createBlock(
+            [ts.factory.createExpressionStatement(createViCallExpression(ctx, 'useRealTimers'))],
+            true,
+          ),
+        ),
+      ]),
+    ),
+  ];
+}
+
+interface CurrentOutermostDescribeContext {
+  isUsingFakeAsync: boolean;
+}
+
+function _findDescribeBlock(node: ts.CallExpression): ts.Block | undefined {
+  const args = node.arguments;
+  const describeCallback = args.length >= 2 ? args[1] : undefined;
+  if (describeCallback !== undefined && _is.arrowOrFunction(describeCallback)) {
+    return _getFunctionBlock(describeCallback);
+  }
+
+  return undefined;
+}
+
+function _getFunctionBlock(node: ts.FunctionExpression | ts.ArrowFunction): ts.Block {
+  return ts.isBlock(node.body)
+    ? node.body
+    : ts.factory.createBlock([ts.factory.createExpressionStatement(node.body)]);
+}
+
+const _is = {
+  arrowOrFunction: (node: ts.Node): node is ts.ArrowFunction | ts.FunctionExpression =>
+    ts.isArrowFunction(node) || ts.isFunctionExpression(node),
+  describe: (node: ts.Node): node is ts.CallExpression =>
+    ts.isCallExpression(node) &&
+    // describe
+    ((ts.isIdentifier(node.expression) && node.expression.text === 'describe') ||
+      // describe.only or describe.skip
+      (ts.isPropertyAccessExpression(node.expression) &&
+        ts.isIdentifier(node.expression.expression) &&
+        node.expression.expression.text === 'describe')),
+};

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-test_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-test_spec.ts
@@ -1,0 +1,250 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { expectTransformation } from '../test-helpers';
+
+describe('transformFakeAsyncTest', () => {
+  const testCases = [
+    {
+      description: 'should transform fakeAsync test to `vi.useFakeTimers()`',
+      input: `
+          import { fakeAsync } from '@angular/core/testing';
+
+          describe('My fakeAsync suite', () => {
+            it('works', fakeAsync(() => {
+              expect(1).toBe(1);
+            }));
+          });
+        `,
+      expected: `
+          describe('My fakeAsync suite', () => {
+            beforeAll(() => {
+              vi.useFakeTimers({ advanceTimeDelta: 1, shouldAdvanceTime: true });
+            });
+            afterAll(() => {
+              vi.useRealTimers();
+            });
+            it('works', async () => {
+              expect(1).toBe(1);
+            });
+          });
+        `,
+    },
+    {
+      description:
+        'should transform fakeAsync test to `vi.useFakeTimers()` and keep its arguments but not the return type',
+      input: `
+          import { fakeAsync } from '@angular/core/testing';
+
+          describe('My fakeAsync suite', () => {
+            it('works', fakeAsync((strangeArg: Strange = myStrangeDefault): void => {
+              expect(1).toBe(1);
+            }));
+          });
+        `,
+      expected: `
+          describe('My fakeAsync suite', () => {
+            beforeAll(() => {
+              vi.useFakeTimers({ advanceTimeDelta: 1, shouldAdvanceTime: true });
+            });
+            afterAll(() => {
+              vi.useRealTimers();
+            });
+            it('works', async (strangeArg: Strange = myStrangeDefault) => {
+              expect(1).toBe(1);
+            });
+          });
+        `,
+    },
+    {
+      description: 'should transform fakeAsync test to `vi.useFakeTimers()` in outer describe',
+      input: `
+          import { fakeAsync } from '@angular/core/testing';
+
+          describe('My non-fakeAsync suite', () => {
+            it('works', () => {
+              expect(1).toBe(1);
+            });
+          });
+
+          describe('My outer fakeAsync suite', () => {
+          
+            describe('My inner fakeAsync suite', () => {
+              it('works', fakeAsync(() => {
+                expect(1).toBe(1);
+              }));
+            });
+
+          });
+
+        `,
+      expected: `
+          describe('My non-fakeAsync suite', () => {
+            it('works', () => {
+              expect(1).toBe(1);
+            });
+          });
+
+          describe('My outer fakeAsync suite', () => {
+            beforeAll(() => {
+              vi.useFakeTimers({ advanceTimeDelta: 1, shouldAdvanceTime: true });
+            });
+            afterAll(() => {
+              vi.useRealTimers();
+            });
+
+            describe('My inner fakeAsync suite', () => {
+              it('works', async () => {
+                expect(1).toBe(1);
+              });
+            });
+          });
+        `,
+    },
+    {
+      description:
+        'should transform fakeAsync test to `vi.useFakeTimers()` in outer describe even if it is excluded',
+      input: `
+          import { fakeAsync } from '@angular/core/testing';
+
+          describe('My non-fakeAsync suite', () => {
+            it('works', () => {
+              expect(1).toBe(1);
+            });
+          });
+
+          xdescribe('My outer fakeAsync suite', () => {
+          
+            describe('My inner fakeAsync suite', () => {
+              it('works', fakeAsync(() => {
+                expect(1).toBe(1);
+              }));
+            });
+
+          });
+
+        `,
+      expected: `
+          describe('My non-fakeAsync suite', () => {
+            it('works', () => {
+              expect(1).toBe(1);
+            });
+          });
+
+          describe.skip('My outer fakeAsync suite', () => {
+            beforeAll(() => {
+              vi.useFakeTimers({ advanceTimeDelta: 1, shouldAdvanceTime: true });
+            });
+            afterAll(() => {
+              vi.useRealTimers();
+            });
+
+            describe('My inner fakeAsync suite', () => {
+              it('works', async () => {
+                expect(1).toBe(1);
+              });
+            });
+          });
+        `,
+    },
+    {
+      description:
+        'should transform fakeAsync test to `vi.useFakeTimers()` in `beforeEach`, `afterEach`, `beforeAll`, `afterAll`',
+      input: `
+          import { fakeAsync } from '@angular/core/testing';
+
+          describe('My fakeAsync suite', () => {
+            beforeAll(fakeAsync(() => {
+              console.log('beforeAll');
+            }));
+
+            afterAll(fakeAsync(() => {
+              console.log('afterAll');
+            }));
+
+            beforeEach(fakeAsync(() => {
+              console.log('beforeEach');
+            }));
+
+            afterEach(fakeAsync(() => {
+              console.log('afterEach');
+            }));
+          });
+        `,
+      expected: `
+          describe('My fakeAsync suite', () => {
+            beforeAll(() => {
+              vi.useFakeTimers({ advanceTimeDelta: 1, shouldAdvanceTime: true });
+            });
+            afterAll(() => {
+              vi.useRealTimers();
+            });
+            beforeAll(async () => {
+              console.log('beforeAll');
+            });
+
+            afterAll(async () => {
+              console.log('afterAll');
+            });
+
+            beforeEach(async () => {
+              console.log('beforeEach');
+            });
+
+            afterEach(async () => {
+              console.log('afterEach');
+            });
+          });
+        `,
+    },
+    {
+      description: 'should not replace `fakeAsync` if not used within a describe block',
+      input: `
+          import { fakeAsync } from '@angular/core/testing';
+
+          it('works', fakeAsync(() => {
+            expect(1).toBe(1);
+          }));
+        `,
+      expected: `
+          import { fakeAsync } from '@angular/core/testing';
+
+          it('works', fakeAsync(() => {
+            expect(1).toBe(1);
+          }));
+        `,
+    },
+    {
+      description: 'should not replace `fakeAsync` if not imported from `@angular/core/testing`',
+      input: `
+          import { fakeAsync } from './my-fake-async';
+
+          describe('My fakeAsync suite', () => {
+            it('works', fakeAsync(() => {
+              expect(1).toBe(1);
+            }));
+          });
+        `,
+      expected: `
+          import { fakeAsync } from './my-fake-async';
+
+          describe('My fakeAsync suite', () => {
+            it('works', fakeAsync(() => {
+              expect(1).toBe(1);
+            }));
+          });
+        `,
+    },
+  ];
+
+  testCases.forEach(({ description, input, expected }) => {
+    it(description, async () => {
+      await expectTransformation(input, expected);
+    });
+  });
+});

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-tick.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-tick.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import ts from 'typescript';
+import { isNamedImportFrom } from '../utils/ast-helpers';
+import { ANGULAR_CORE_TESTING } from '../utils/constants';
+import { RefactorContext } from '../utils/refactor-context';
+import { addImportSpecifierRemoval, createViCallExpression } from '../utils/refactor-helpers';
+
+export function transformFakeAsyncTick(node: ts.Node, ctx: RefactorContext): ts.Node {
+  if (
+    !(
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'tick' &&
+      isNamedImportFrom(ctx.sourceFile, 'tick', ANGULAR_CORE_TESTING)
+    )
+  ) {
+    return node;
+  }
+
+  ctx.reporter.reportTransformation(
+    ctx.sourceFile,
+    node,
+    `Transformed \`tick\` to \`await vi.advanceTimersByTimeAsync()\`.`,
+  );
+
+  addImportSpecifierRemoval(ctx, 'tick', ANGULAR_CORE_TESTING);
+
+  const durationNumericLiteral =
+    node.arguments.length > 0 ? node.arguments[0] : ts.factory.createNumericLiteral(0);
+
+  return ts.factory.createAwaitExpression(
+    createViCallExpression(ctx, 'advanceTimersByTimeAsync', [durationNumericLiteral]),
+  );
+}

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-tick_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-tick_spec.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { expectTransformation } from '../test-helpers';
+
+describe('transformFakeAsyncTick', () => {
+  const testCases = [
+    {
+      description: 'should replace `tick` with `vi.advanceTimersByTimeAsync`',
+      input: `
+          import { tick } from '@angular/core/testing';
+          
+          tick(100);
+        `,
+      expected: `await vi.advanceTimersByTimeAsync(100);`,
+    },
+    {
+      description:
+        'should replace `tick` with `vi.advanceTimersByTimeAsync` even if it using a non-literal argument',
+      input: `
+          import { tick } from '@angular/core/testing';
+
+          const duration = 100;
+          tick(duration);
+        `,
+      expected: `
+          const duration = 100;
+          await vi.advanceTimersByTimeAsync(duration);
+      `,
+    },
+    {
+      description: 'should replace `tick()` with `vi.advanceTimersByTimeAsync(0)`',
+      input: `
+          import { tick } from '@angular/core/testing';
+          
+          tick();
+        `,
+      expected: `await vi.advanceTimersByTimeAsync(0);`,
+    },
+    {
+      description: 'should not replace `tick` if not imported from `@angular/core/testing`',
+      input: `
+          import { tick } from './my-tick';
+          
+          tick(100);
+        `,
+      expected: `
+          import { tick } from './my-tick';
+          
+          tick(100);
+        `,
+    },
+  ];
+
+  testCases.forEach(({ description, input, expected }) => {
+    it(description, async () => {
+      await expectTransformation(input, expected);
+    });
+  });
+});

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-misc.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-misc.ts
@@ -14,16 +14,15 @@
  */
 
 import ts from 'typescript';
-import { addVitestValueImport, createViCallExpression } from '../utils/ast-helpers';
+import { addVitestValueImport } from '../utils/ast-helpers';
 import { getJasmineMethodName, isJasmineCallExpression } from '../utils/ast-validation';
 import { addTodoComment } from '../utils/comment-helpers';
 import { RefactorContext } from '../utils/refactor-context';
+import { createViCallExpression } from '../utils/refactor-helpers';
 import { TodoCategory } from '../utils/todo-notes';
 
-export function transformTimerMocks(
-  node: ts.Node,
-  { sourceFile, reporter, pendingVitestValueImports }: RefactorContext,
-): ts.Node {
+export function transformTimerMocks(node: ts.Node, ctx: RefactorContext): ts.Node {
+  const { sourceFile, reporter, pendingVitestValueImports } = ctx;
   if (
     !ts.isCallExpression(node) ||
     !ts.isPropertyAccessExpression(node.expression) ||
@@ -85,7 +84,7 @@ export function transformTimerMocks(
       ];
     }
 
-    return createViCallExpression(newMethodName, newArgs);
+    return createViCallExpression(ctx, newMethodName, newArgs);
   }
 
   return node;
@@ -173,15 +172,16 @@ export function transformJasmineMembers(node: ts.Node, refactorCtx: RefactorCont
 function transformJasmineDefaultTimeoutInterval(
   expression: ts.ExpressionStatement,
   timeoutValue: ts.Expression,
-  { sourceFile, reporter, pendingVitestValueImports }: RefactorContext,
+  ctx: RefactorContext,
 ): ts.Node {
+  const { sourceFile, reporter, pendingVitestValueImports } = ctx;
   addVitestValueImport(pendingVitestValueImports, 'vi');
   reporter.reportTransformation(
     sourceFile,
     expression,
     'Transformed `jasmine.DEFAULT_TIMEOUT_INTERVAL` to `vi.setConfig()`.',
   );
-  const setConfigCall = createViCallExpression('setConfig', [
+  const setConfigCall = createViCallExpression(ctx, 'setConfig', [
     ts.factory.createObjectLiteralExpression(
       [ts.factory.createPropertyAssignment('testTimeout', timeoutValue)],
       false,

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-spy.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-spy.ts
@@ -17,12 +17,12 @@ import ts from 'typescript';
 import {
   addVitestValueImport,
   createPropertyAccess,
-  createViCallExpression,
   getPromiseResolveRejectMethod,
 } from '../utils/ast-helpers';
 import { getJasmineMethodName, isJasmineCallExpression } from '../utils/ast-validation';
 import { addTodoComment } from '../utils/comment-helpers';
 import { RefactorContext } from '../utils/refactor-context';
+import { createViCallExpression } from '../utils/refactor-helpers';
 
 export function transformSpies(node: ts.Node, refactorCtx: RefactorContext): ts.Node {
   const { sourceFile, reporter, pendingVitestValueImports } = refactorCtx;
@@ -219,10 +219,8 @@ export function transformSpies(node: ts.Node, refactorCtx: RefactorContext): ts.
   return node;
 }
 
-export function transformCreateSpy(
-  node: ts.Node,
-  { reporter, sourceFile, pendingVitestValueImports }: RefactorContext,
-): ts.Node {
+export function transformCreateSpy(node: ts.Node, ctx: RefactorContext): ts.Node {
+  const { reporter, sourceFile, pendingVitestValueImports } = ctx;
   if (!isJasmineCallExpression(node, 'createSpy')) {
     return node;
   }
@@ -236,6 +234,7 @@ export function transformCreateSpy(
 
   const spyName = node.arguments[0];
   const viFnCallExpression = createViCallExpression(
+    ctx,
     'fn',
     node.arguments.length > 1 ? [node.arguments[1]] : [],
   );
@@ -251,10 +250,8 @@ export function transformCreateSpy(
       );
 }
 
-export function transformCreateSpyObj(
-  node: ts.Node,
-  { sourceFile, reporter, pendingVitestValueImports }: RefactorContext,
-): ts.Node {
+export function transformCreateSpyObj(node: ts.Node, ctx: RefactorContext): ts.Node {
+  const { reporter, sourceFile, pendingVitestValueImports } = ctx;
   if (!isJasmineCallExpression(node, 'createSpyObj')) {
     return node;
   }
@@ -282,9 +279,9 @@ export function transformCreateSpyObj(
   }
 
   if (ts.isArrayLiteralExpression(methods)) {
-    properties = createSpyObjWithArray(methods, baseName);
+    properties = createSpyObjWithArray(ctx, methods, baseName);
   } else if (ts.isObjectLiteralExpression(methods)) {
-    properties = createSpyObjWithObject(methods, baseName);
+    properties = createSpyObjWithObject(ctx, methods, baseName);
   } else {
     const category = 'createSpyObj-dynamic-variable';
     reporter.recordTodo(category, sourceFile, node);
@@ -307,13 +304,14 @@ export function transformCreateSpyObj(
 }
 
 function createSpyObjWithArray(
+  ctx: RefactorContext,
   methods: ts.ArrayLiteralExpression,
   baseName: string | undefined,
 ): ts.PropertyAssignment[] {
   return methods.elements
     .map((element) => {
       if (ts.isStringLiteral(element)) {
-        const mockFn = createViCallExpression('fn');
+        const mockFn = createViCallExpression(ctx, 'fn');
         const methodName = element.text;
         let finalExpression: ts.Expression = mockFn;
 
@@ -337,6 +335,7 @@ function createSpyObjWithArray(
 }
 
 function createSpyObjWithObject(
+  ctx: RefactorContext,
   methods: ts.ObjectLiteralExpression,
   baseName: string | undefined,
 ): ts.PropertyAssignment[] {
@@ -345,7 +344,7 @@ function createSpyObjWithObject(
       if (ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name)) {
         const methodName = prop.name.text;
         const returnValue = prop.initializer;
-        let mockFn = createViCallExpression('fn');
+        let mockFn = createViCallExpression(ctx, 'fn');
 
         if (baseName) {
           mockFn = ts.factory.createCallExpression(

--- a/packages/schematics/angular/refactor/jasmine-vitest/utils/ast-helpers.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/utils/ast-helpers.ts
@@ -48,30 +48,15 @@ export function getVitestAutoImports(
 
   allSpecifiers.sort((a, b) => a.name.text.localeCompare(b.name.text));
 
-  const importClause = ts.factory.createImportClause(
-    isClauseTypeOnly, // Set isTypeOnly on the clause if only type imports
-    undefined,
-    ts.factory.createNamedImports(allSpecifiers),
-  );
-
   return ts.factory.createImportDeclaration(
     undefined,
-    importClause,
+    ts.factory.createImportClause(
+      isClauseTypeOnly, // Set isTypeOnly on the clause if only type imports
+      undefined,
+      ts.factory.createNamedImports(allSpecifiers),
+    ),
     ts.factory.createStringLiteral('vitest'),
   );
-}
-
-export function createViCallExpression(
-  methodName: string,
-  args: readonly ts.Expression[] = [],
-  typeArgs: ts.TypeNode[] | undefined = undefined,
-): ts.CallExpression {
-  const callee = ts.factory.createPropertyAccessExpression(
-    ts.factory.createIdentifier('vi'),
-    methodName,
-  );
-
-  return ts.factory.createCallExpression(callee, typeArgs, args);
 }
 
 export function createExpectCallExpression(
@@ -120,4 +105,103 @@ export function getPromiseResolveRejectMethod(node: ts.Node): {
     methodName,
     arguments: node.arguments,
   };
+}
+
+/**
+ * Checks if a named binding is imported from the given module in the source file.
+ * @param sourceFile The source file to search for imports.
+ * @param name The import name (e.g. 'flush', 'tick').
+ * @param moduleSpecifier The module path (e.g. '@angular/core/testing').
+ */
+export function isNamedImportFrom(
+  sourceFile: ts.SourceFile,
+  name: string,
+  moduleSpecifier: string,
+): boolean {
+  return sourceFile.statements.some((statement) => {
+    if (!_isImportDeclarationWithNamedBindings(statement)) {
+      return false;
+    }
+
+    const specifier = statement.moduleSpecifier;
+    const modulePath = ts.isStringLiteralLike(specifier) ? specifier.text : null;
+    if (modulePath !== moduleSpecifier) {
+      return false;
+    }
+    for (const element of statement.importClause.namedBindings.elements) {
+      const importedName = element.propertyName ? element.propertyName.text : element.name.text;
+      if (importedName === name) {
+        return true;
+      }
+    }
+  });
+}
+
+/**
+ * Removes specified import specifiers from ImportDeclarations.
+ * If all specifiers are removed from an import, the entire import is dropped.
+ */
+export function removeImportSpecifiers(
+  sourceFile: ts.SourceFile,
+  removals: Map<string, Set<string>>,
+): ts.SourceFile {
+  const newStatements = sourceFile.statements
+    .map((statement) => {
+      if (!_isImportDeclarationWithNamedBindings(statement)) {
+        return statement;
+      }
+
+      const specifier = statement.moduleSpecifier;
+      const modulePath = ts.isStringLiteralLike(specifier) ? specifier.text : null;
+      if (modulePath === null) {
+        return statement;
+      }
+
+      const namesToRemove = removals.get(modulePath);
+      if (namesToRemove === undefined || namesToRemove.size === 0) {
+        return statement;
+      }
+
+      const remaining = statement.importClause.namedBindings.elements.filter((el) => {
+        const name = el.propertyName ? el.propertyName.text : el.name.text;
+
+        return !namesToRemove.has(name);
+      });
+
+      if (remaining.length === 0) {
+        return;
+      }
+
+      if (remaining.length === statement.importClause.namedBindings.elements.length) {
+        return statement;
+      }
+
+      return ts.factory.updateImportDeclaration(
+        statement,
+        statement.modifiers,
+        ts.factory.updateImportClause(
+          statement.importClause,
+          undefined,
+          statement.importClause.name,
+          ts.factory.createNamedImports(remaining),
+        ),
+        statement.moduleSpecifier,
+        statement.attributes,
+      );
+    })
+    .filter((statement) => statement !== undefined);
+
+  return ts.factory.updateSourceFile(sourceFile, newStatements);
+}
+
+function _isImportDeclarationWithNamedBindings(
+  statement: ts.Statement,
+): statement is ts.ImportDeclaration & {
+  importClause: ts.ImportClause & { namedBindings: ts.NamedImports };
+} {
+  return (
+    ts.isImportDeclaration(statement) &&
+    statement.importClause?.namedBindings !== undefined &&
+    ts.isNamedImports(statement.importClause.namedBindings)
+  );
 }

--- a/packages/schematics/angular/refactor/jasmine-vitest/utils/constants.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/utils/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+export const ANGULAR_CORE_TESTING = '@angular/core/testing';

--- a/packages/schematics/angular/refactor/jasmine-vitest/utils/refactor-context.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/utils/refactor-context.ts
@@ -28,6 +28,12 @@ export interface RefactorContext {
 
   /** A set of Vitest type imports to be added to the file. */
   readonly pendingVitestTypeImports: Set<string>;
+
+  /**
+   * Map of module specifier -> names to remove from that import.
+   * Used when transforming identifiers that become inlined (e.g. flush -> vi.runAllTimersAsync).
+   */
+  readonly pendingImportSpecifierRemovals: Map<string, Set<string>>;
 }
 
 /**

--- a/packages/schematics/angular/refactor/jasmine-vitest/utils/refactor-helpers.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/utils/refactor-helpers.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import ts from 'typescript';
+import { RefactorContext } from './refactor-context';
+
+/**
+ * Marks an identifier to be removed from an import specifier.
+ *
+ * @param ctx The refactor context object.
+ * @param name The name of the identifier to remove from the import specifier.
+ * @param moduleSpecifier The module specifier to remove the identifier from.
+ */
+export function addImportSpecifierRemoval(
+  ctx: RefactorContext,
+  name: string,
+  moduleSpecifier: string,
+): void {
+  const removals = ctx.pendingImportSpecifierRemovals.get(moduleSpecifier) ?? new Set<string>();
+  removals.add(name);
+  ctx.pendingImportSpecifierRemovals.set(moduleSpecifier, removals);
+}
+
+/**
+ * Creates a call expression to a vitest method.
+ * This also adds the `vi` identifier to the context object,
+ * to import it later if addImports option is enabled.
+ *
+ * @param ctx The refactor context object.
+ * @param args The arguments to pass to the method.
+ * @param typeArgs The type arguments to pass to the method.
+ * @param methodeName The name of the vitest method to call.
+ * @returns The created identifier node.
+ */
+export function createViCallExpression(
+  ctx: RefactorContext,
+  methodName: string,
+  args: readonly ts.Expression[] = [],
+  typeArgs: ts.TypeNode[] | undefined = undefined,
+): ts.CallExpression {
+  const vi = requireVitestIdentifier(ctx, 'vi');
+  const callee = ts.factory.createPropertyAccessExpression(vi, methodName);
+
+  return ts.factory.createCallExpression(callee, typeArgs, args);
+}
+
+/**
+ * Creates an identifier for a vitest value import.
+ * This also adds the identifier to the context object,
+ * to import it later if addImports option is enabled.
+ *
+ * @param ctx The refactor context object.
+ * @param name The name of the vitest identifier to require.
+ * @returns The created identifier node.
+ */
+export function requireVitestIdentifier(ctx: RefactorContext, name: string): ts.Identifier {
+  ctx.pendingVitestValueImports.add(name);
+
+  return ts.factory.createIdentifier(name);
+}

--- a/packages/schematics/angular/refactor/jasmine-vitest/utils/todo-notes.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/utils/todo-notes.ts
@@ -178,6 +178,13 @@ export const TODO_NOTES = {
   'unhandled-done-usage': {
     message: "The 'done' callback was used in an unhandled way. Please migrate manually.",
   },
+  'flush-max-turns': {
+    message:
+      'flush(maxTurns) was called but maxTurns parameter is not migrated. Please migrate manually.',
+  },
+  'flush-return-value': {
+    message: 'flush() return value is not migrated. Please migrate manually.',
+  },
 } as const;
 
 /**


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [X] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There is no migration from `fakeAsync` to Vitest fake timer APIs.

Issue Number: N/A

## What is the new behavior?

The current migration transforms the following test:

```ts
describe('suite', () => {
  it("should work", fakeAsync(() => {
    let value = 0;

    setTimeout(() => value = 42, 100);

    tick(100);
    flushMicrotasks();
    flush();

    expect(value).toBe(42);
  });
);
```

into:

```ts
import { beforeAll, afterAll, vi } from 'vitest';


describe('suite', () => {

  beforeAll(() => {
    vi.useFakeTimers({ advanceTimeDelta: 1, shouldAdvanceTime: true });
  });
  afterAll(() => {
    vi.useRealTimers();
  });

  it("should work", fakeAsync(() => {
    let value = 0;

    setTimeout(() => value = 42, 100);

    await vi.advanceTimersByTimeAsync(100);
    await vi.advanceTimersByTimeAsync(0);
    await vi.runAllTimersAsync();

    expect(value).toBe(42);
  });
});
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Open Questions
- [X] This migration could be part of the jasmine-vitest migration. Should I moved it there and add an opt-out?
Moved to jasmine-vitest migration under `fakeAsync` option which is false by default

- [X] `flushMicrotasks` can only be partially reproduced (i.e. explicit `queueMicrotask` calls), transforming it have high chances of producing a broken test. Should we just skip transforming tests that use it?
Migrated to `await vi.advanceTimersByTimeAsync(0);`.

- [X] Should we generate code that measures time "manually" when the return value of `flush` is used?
Generates a TODO.

- [X] Should we generate an "ad-hoc" function in the test file that reproduces `flush`'s `maxTurns` option?
Generates a TODO.

- [X] What should we do about `processNewMacroTasksSynchronously` option?
Ignored.

- [X] This only migrates `flush` and `tick` if used inside `fakeAsync` but it's probably better to just replace in the whole file as users might create some wrappers. What do you think?
Replaced everywhere.