### PR TITLE
fix(@angular/build): use dynamic TestComponentRenderer for Vitest

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
@@ -54,11 +54,15 @@ function createTestBedInitVirtualFile(
     }`;
   }
 
+  // The DynamicDOMTestComponentRenderer is used to avoid stale document references
+  // when running Vitest in non-isolated mode with JSDOM. It looks up the
+  // document dynamically on every operation instead of caching it.
   return `
     // Initialize the Angular testing environment
     import { NgModule, provideZoneChangeDetection } from '@angular/core';
-    import { getTestBed, ɵgetCleanupHook as getCleanupHook } from '@angular/core/testing';
+    import { getTestBed, ɵgetCleanupHook as getCleanupHook, TestComponentRenderer } from '@angular/core/testing';
     import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';
+    import { ɵgetDOM } from '@angular/common';
     import { afterEach, beforeEach } from 'vitest';
     ${providersImport}
 
@@ -69,6 +73,31 @@ function createTestBedInitVirtualFile(
     // Same as https://github.com/angular/angular/blob/05a03d3f975771bb59c7eefd37c01fa127ee2229/packages/core/testing/srcs/test_hooks.ts#L21-L29
     beforeEach(getCleanupHook(false));
     afterEach(getCleanupHook(true));
+
+    class DynamicDOMTestComponentRenderer extends TestComponentRenderer {
+      insertRootElement(rootElId, tagName = 'div') {
+        this.removeAllRootElements();
+
+        const dom = ɵgetDOM();
+        const doc = dom.getDefaultDocument();
+        if (doc && doc.body) {
+          const rootElement = doc.createElement(tagName);
+          rootElement.setAttribute('id', rootElId);
+          doc.body.appendChild(rootElement);
+        }
+      }
+
+      removeAllRootElements() {
+        const dom = ɵgetDOM();
+        const doc = dom.getDefaultDocument();
+        if (doc && typeof doc.querySelectorAll === 'function') {
+          const oldRoots = doc.querySelectorAll('[id^=root]');
+          for (let i = 0; i < oldRoots.length; i++) {
+            dom.remove(oldRoots[i]);
+          }
+        }
+      }
+    }
 
     const ANGULAR_TESTBED_SETUP = Symbol.for('@angular/cli/testbed-setup');
     if (!globalThis[ANGULAR_TESTBED_SETUP]) {
@@ -82,6 +111,7 @@ function createTestBedInitVirtualFile(
         providers: [
           ...(typeof Zone !== 'undefined' ? [provideZoneChangeDetection()] : []),
           ...providers,
+          { provide: TestComponentRenderer, useClass: DynamicDOMTestComponentRenderer },
         ],
       })
       class TestModule {}

--- a/tests/e2e/tests/vitest/larger-project.ts
+++ b/tests/e2e/tests/vitest/larger-project.ts
@@ -2,12 +2,11 @@ import { ng } from '../../utils/process';
 import { applyVitestBuilder } from '../../utils/vitest';
 import assert from 'node:assert';
 import { installPackage } from '../../utils/packages';
-import { exec } from '../../utils/process';
 
 export default async function () {
   await applyVitestBuilder();
 
-  const artifactCount = 100;
+  const artifactCount = 500;
   // A new project starts with 1 test file (app.spec.ts)
   // Each generated artifact will add one more test file.
   const initialTestCount = 1;


### PR DESCRIPTION
This commit implements a custom TestComponentRenderer in the virtual init-testbed.js file generated for Vitest. In Vitests non-isolated mode (isolate: false) with JSDOM, Vitest creates a fresh document for each spec file but reuses the module cache. The default Angular DOMTestComponentRenderer caches the document during initialization, leading to stale references and errors like setAttribute is not a function in subsequent tests. The new DynamicDOMTestComponentRenderer looks up the document dynamically on every operation, resolving the issue without requiring a breaking change to defaults or affecting browser-based testing.