### PR TITLE
build: temporarily disable @typescript-eslint/no-unnecessary-type-assertion

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -213,6 +213,7 @@ export default [
       '@typescript-eslint/prefer-promise-reject-errors': 'off',
       '@typescript-eslint/only-throw-error': 'off',
       '@typescript-eslint/no-unsafe-function-type': 'off',
+      '@typescript-eslint/no-unnecessary-type-assertion': 'off',
     },
   },
   {


### PR DESCRIPTION
Disables the unnecessary type assertion lint rule across the repository to accommodate an upcoming typescript-eslint upgrade. The updated version introduces rule modifications that generate a significant volume of validation failures, which would block the upgrade process. Temporarily disabling the rule provides a path forward for the version bump, after which the codebase can be audited and the rule can be re-enabled incrementally.