### PR TITLE
fix(@angular/ssr): normalize patched host headers

### DIFF
--- a/packages/angular/ssr/src/utils/validation.ts
+++ b/packages/angular/ssr/src/utils/validation.ts
@@ -98,8 +98,16 @@ export function cloneRequestAndPatchHeaders(
   });
 
   const headers = clonedReq.headers;
-
   const originalGet = headers.get;
+
+  for (const name of HOST_HEADERS_TO_VALIDATE) {
+    const value = originalGet.call(headers, name);
+    const normalizedValue = getFirstHeaderValue(value);
+    if (normalizedValue !== undefined && normalizedValue !== value) {
+      headers.set(name, normalizedValue);
+    }
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
   (headers.get as typeof originalGet) = function (name) {
     const value = originalGet.call(headers, name);

--- a/packages/angular/ssr/test/utils/validation_spec.ts
+++ b/packages/angular/ssr/test/utils/validation_spec.ts
@@ -240,11 +240,49 @@ describe('Validation Utils', () => {
 
     it('should allow accessing other headers without validation', () => {
       const req = new Request('http://example.com', {
-        headers: { 'accept': 'application/json' },
+        headers: { 'accept': 'text/html, application/json' },
       });
       const { request: secured } = cloneRequestAndPatchHeaders(req, allowedHosts);
 
-      expect(secured.headers.get('accept')).toBe('application/json');
+      expect(secured.headers.get('accept')).toBe('text/html, application/json');
+    });
+
+    it('should return the validated host header token when accessed via get()', () => {
+      const req = new Request('http://example.com', {
+        headers: {
+          host: 'example.com,@127.0.0.1:8765',
+          'x-forwarded-host': 'sub.valid.com,@127.0.0.1:8765',
+        },
+      });
+      const { request: secured } = cloneRequestAndPatchHeaders(req, allowedHosts);
+
+      expect(secured.headers.get('host')).toBe('example.com');
+      expect(secured.headers.get('x-forwarded-host')).toBe('sub.valid.com');
+    });
+
+    it('should return validated host header tokens when iterating headers', () => {
+      const req = new Request('http://example.com', {
+        headers: {
+          accept: 'text/html, application/json',
+          host: 'example.com,@127.0.0.1:8765',
+          'x-forwarded-host': 'sub.valid.com,@127.0.0.1:8765',
+        },
+      });
+      const { request: secured } = cloneRequestAndPatchHeaders(req, allowedHosts);
+
+      expect([...secured.headers.entries()]).toContain(['host', 'example.com']);
+      expect([...secured.headers.entries()]).toContain(['x-forwarded-host', 'sub.valid.com']);
+      expect([...secured.headers.values()]).toContain('example.com');
+      expect([...secured.headers.values()]).toContain('sub.valid.com');
+      expect([...secured.headers]).toContain(['host', 'example.com']);
+      expect([...secured.headers]).toContain(['x-forwarded-host', 'sub.valid.com']);
+
+      const forEachValues = new Map<string, string>();
+      secured.headers.forEach((value, key) => forEachValues.set(key, value));
+
+      expect(forEachValues.get('accept')).toBe('text/html, application/json');
+      expect(forEachValues.get('host')).toBe('example.com');
+      expect(forEachValues.get('x-forwarded-host')).toBe('sub.valid.com');
     });
 
     it('should validate headers when iterating with entries()', async () => {


### PR DESCRIPTION
This fix addresses an SSRF / host-confusion hardening issue in the `@angular/ssr`
`cloneRequestAndPatchHeaders()` code path on the 21.1.x release branch. The same
code path was present in earlier 21.2.x builds before it was replaced by the newer
trusted proxy header flow.

The affected code `cloneRequestAndPatchHeaders()` validated only the first comma-separated token
of `Host` / `X-Forwarded-Host`, but returned the original raw header value to
application code through the patched `Headers` accessors.

This PR follows Google OSS VRP guidance to work with the Angular maintainers via
a public GitHub PR for this issue.

Changes:
- Normalize cloned `Host` and `X-Forwarded-Host` header values to the first
  comma-separated token before application code can read them
- Preserve existing validation behavior for the normalized token
- Add regression tests for `get()`, `entries()`, `values()`, `forEach()`, and
  `for...of` reads

This aligns the values returned to application code with the value Angular already
uses for validation and internal URL construction.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: N/A

`cloneRequestAndPatchHeaders()` patches `Headers.get()`, `Headers.entries()`,
`Headers.values()`, `Headers.forEach()`, and `[Symbol.iterator]` so host headers
are validated when application code reads them. The validation path uses the first
comma-separated header token. However, the patched accessors return the raw header
string.

For example, with `allowedHosts = new Set(['example.com'])`,
`X-Forwarded-Host: example.com,@127.0.0.1:8765` validates as `example.com`, but
application code reading `request.headers.get('x-forwarded-host')` receives the
raw value `example.com,@127.0.0.1:8765`.

## What is the new behavior?

The cloned request normalizes `Host` and `X-Forwarded-Host` to the same first
comma-separated token that Angular validates. Application code therefore receives
`example.com` in the example above, rather than the unvalidated suffix.

Other headers are unchanged; e.g. `Accept: text/html, application/json` still
returns the full value.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Validated locally with:

```bash
bazelisk test //packages/angular/ssr/test:test
```

Bazel reported the target as flaky because the first attempt hit unrelated existing
`app_spec.ts` failures, then retried and completed with the test target passing.
