### PR TITLE
feat(@schematics/angular): set up fake timers in beforeEach instead of beforeAll

### DIFF
--- a/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.integration_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.integration_spec.ts
@@ -576,10 +576,10 @@ describe('Jasmine to Vitest Transformer - Integration Tests', () => {
     `;
     const vitestCode = `
       describe('My fakeAsync suite', () => {
-        beforeAll(() => {
+        beforeEach(() => {
           vi.useFakeTimers({ advanceTimeDelta: 1, shouldAdvanceTime: true });
         });
-        afterAll(() => {
+        afterEach(() => {
           vi.useRealTimers();
         });
         it('works', async () => {

--- a/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer_add-imports_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer_add-imports_spec.ts
@@ -162,13 +162,13 @@ describe('Jasmine to Vitest Transformer - addImports option', () => {
         });
       `;
     const expected = `
-        import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+        import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
         describe('My fakeAsync suite', () => {
-          beforeAll(() => {
+          beforeEach(() => {
             vi.useFakeTimers({ advanceTimeDelta: 1, shouldAdvanceTime: true });
           });
-          afterAll(() => {
+          afterEach(() => {
             vi.useRealTimers();
           });
           it('works', async () => {

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-test.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-test.ts
@@ -119,14 +119,14 @@ function _transformFakeAsyncCall(
 
 function _createFakeTimersHookStatements(ctx: RefactorContext): ts.Statement[] {
   return [
-    // > beforeAll(() => {
+    // > beforeEach(() => {
     // >   vi.useFakeTimers({
     // >     advanceTimeDelta: 1,
     // >     shouldAdvanceTime: true
     // >   });
     // > });
     ts.factory.createExpressionStatement(
-      ts.factory.createCallExpression(ts.factory.createIdentifier('beforeAll'), undefined, [
+      ts.factory.createCallExpression(ts.factory.createIdentifier('beforeEach'), undefined, [
         ts.factory.createArrowFunction(
           undefined,
           undefined,
@@ -156,11 +156,11 @@ function _createFakeTimersHookStatements(ctx: RefactorContext): ts.Statement[] {
       ]),
     ),
 
-    // > afterAll(() => {
+    // > afterEach(() => {
     // >   vi.useRealTimers();
     // > });
     ts.factory.createExpressionStatement(
-      ts.factory.createCallExpression(ts.factory.createIdentifier('afterAll'), undefined, [
+      ts.factory.createCallExpression(ts.factory.createIdentifier('afterEach'), undefined, [
         ts.factory.createArrowFunction(
           undefined,
           undefined,

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-test_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/fake-async-test_spec.ts
@@ -23,10 +23,10 @@ describe('transformFakeAsyncTest', () => {
         `,
       expected: `
           describe('My fakeAsync suite', () => {
-            beforeAll(() => {
+            beforeEach(() => {
               vi.useFakeTimers({ advanceTimeDelta: 1, shouldAdvanceTime: true });
             });
-            afterAll(() => {
+            afterEach(() => {
               vi.useRealTimers();
             });
             it('works', async () => {
@@ -49,10 +49,10 @@ describe('transformFakeAsyncTest', () => {
         `,
       expected: `
           describe('My fakeAsync suite', () => {
-            beforeAll(() => {
+            beforeEach(() => {
               vi.useFakeTimers({ advanceTimeDelta: 1, shouldAdvanceTime: true });
             });
-            afterAll(() => {
+            afterEach(() => {
               vi.useRealTimers();
             });
             it('works', async (strangeArg: Strange = myStrangeDefault) => {
@@ -91,10 +91,10 @@ describe('transformFakeAsyncTest', () => {
           });
 
           describe('My outer fakeAsync suite', () => {
-            beforeAll(() => {
+            beforeEach(() => {
               vi.useFakeTimers({ advanceTimeDelta: 1, shouldAdvanceTime: true });
             });
-            afterAll(() => {
+            afterEach(() => {
               vi.useRealTimers();
             });
 
@@ -137,10 +137,10 @@ describe('transformFakeAsyncTest', () => {
           });
 
           describe.skip('My outer fakeAsync suite', () => {
-            beforeAll(() => {
+            beforeEach(() => {
               vi.useFakeTimers({ advanceTimeDelta: 1, shouldAdvanceTime: true });
             });
-            afterAll(() => {
+            afterEach(() => {
               vi.useRealTimers();
             });
 
@@ -178,10 +178,10 @@ describe('transformFakeAsyncTest', () => {
         `,
       expected: `
           describe('My fakeAsync suite', () => {
-            beforeAll(() => {
+            beforeEach(() => {
               vi.useFakeTimers({ advanceTimeDelta: 1, shouldAdvanceTime: true });
             });
-            afterAll(() => {
+            afterEach(() => {
               vi.useRealTimers();
             });
             beforeAll(async () => {


### PR DESCRIPTION
When migrating `fakeAsync` to Vitest fake timers, fake timers were setup in `beforeAll` to support `fakeAsync` usage in `beforeAll` / `afterAll` hooks.
As brought up by @atscott, this was sacrificing timers isolation between tests.
This change resets fake timers between tests.
Any usage of fake timers APIs in `beforeAll` or `afterAll` hooks will fail.

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [X] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
