### PR TITLE
feat(@angular/cli): add support for Node.js 26.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22, 24]
+        node: [22, 24, 26]
         subset: [esbuild, webpack]
         shard: [0, 1, 2, 3, 4, 5]
     runs-on: ubuntu-latest

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -91,6 +91,21 @@ node_dev.toolchain(
     },
     node_version = "24.13.1",
 )
+
+# Node.js 26
+node_dev.toolchain(
+    name = "node26",
+    node_repositories = {
+        "26.0.0-darwin_arm64": ("node-v26.0.0-darwin-arm64.tar.gz", "node-v26.0.0-darwin-arm64", "dcee8564c1a9342f9594dd5e52d533894dfef6b85aa771bbbb870baa3c403235"),
+        "26.0.0-darwin_amd64": ("node-v26.0.0-darwin-x64.tar.gz", "node-v26.0.0-darwin-x64", "f488ab543fe202d8a2d56e661682117d3c56903a2bf64f2ec1ff7bd421cfd875"),
+        "26.0.0-linux_arm64": ("node-v26.0.0-linux-arm64.tar.xz", "node-v26.0.0-linux-arm64", "f0f94e55142149a4d34634dc3d7e103921d898512dd0cef995ecb62c5ebd3f29"),
+        "26.0.0-linux_ppc64le": ("node-v26.0.0-linux-ppc64le.tar.xz", "node-v26.0.0-linux-ppc64le", "4b7f76967a93fea8cda11554f2a7904744afaef65dc3f48c345e99828f50ef4d"),
+        "26.0.0-linux_s390x": ("node-v26.0.0-linux-s390x.tar.xz", "node-v26.0.0-linux-s390x", "e3bd9df41f777dbb227b1261ea81b1fa9b654901bac8cace50a0b918b5160ab5"),
+        "26.0.0-linux_amd64": ("node-v26.0.0-linux-x64.tar.xz", "node-v26.0.0-linux-x64", "345d558514c62622b5c7d1f7b5f2a19c31ab1405d217df49f010c5ea8decc0f4"),
+        "26.0.0-windows_amd64": ("node-v26.0.0-win-x64.zip", "node-v26.0.0-win-x64", "d0418640a36096e00bddb57761aa0b1b98f91904ec4ed2b9dd75cbad723becd7"),
+    },
+    node_version = "26.0.0",
+)
 use_repo(
     node_dev,
     "node22_darwin_amd64",
@@ -105,6 +120,12 @@ use_repo(
     "node24_linux_arm64",
     "node24_toolchains",
     "node24_windows_amd64",
+    "node26_darwin_amd64",
+    "node26_darwin_arm64",
+    "node26_linux_amd64",
+    "node26_linux_arm64",
+    "node26_toolchains",
+    "node26_windows_amd64",
 )
 
 pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -948,7 +948,7 @@
     "@@rules_nodejs+//nodejs:extensions.bzl%node": {
       "general": {
         "bzlTransitiveDigest": "oZFClfRhTTwsYzpxVPkOpOt/r0+OzEfEV37au0jFZ0s=",
-        "usagesDigest": "fkkDOc1plpzAkO5pn2xJ/0LSXLJElOvwmi3xfrz7cxY=",
+        "usagesDigest": "bqCPXHiIs2yi6xo5XEjRzQJ3R8k+nwCWvizzoGSa3X8=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -2181,6 +2181,416 @@
             "repoRuleId": "@@rules_nodejs+//nodejs/private:nodejs_toolchains_repo.bzl%nodejs_toolchains_repo",
             "attributes": {
               "user_node_repository_name": "node24"
+            }
+          },
+          "node26_linux_amd64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
+            "attributes": {
+              "node_download_auth": {},
+              "node_repositories": {
+                "26.0.0-darwin_arm64": [
+                  "node-v26.0.0-darwin-arm64.tar.gz",
+                  "node-v26.0.0-darwin-arm64",
+                  "dcee8564c1a9342f9594dd5e52d533894dfef6b85aa771bbbb870baa3c403235"
+                ],
+                "26.0.0-darwin_amd64": [
+                  "node-v26.0.0-darwin-x64.tar.gz",
+                  "node-v26.0.0-darwin-x64",
+                  "f488ab543fe202d8a2d56e661682117d3c56903a2bf64f2ec1ff7bd421cfd875"
+                ],
+                "26.0.0-linux_arm64": [
+                  "node-v26.0.0-linux-arm64.tar.xz",
+                  "node-v26.0.0-linux-arm64",
+                  "f0f94e55142149a4d34634dc3d7e103921d898512dd0cef995ecb62c5ebd3f29"
+                ],
+                "26.0.0-linux_ppc64le": [
+                  "node-v26.0.0-linux-ppc64le.tar.xz",
+                  "node-v26.0.0-linux-ppc64le",
+                  "4b7f76967a93fea8cda11554f2a7904744afaef65dc3f48c345e99828f50ef4d"
+                ],
+                "26.0.0-linux_s390x": [
+                  "node-v26.0.0-linux-s390x.tar.xz",
+                  "node-v26.0.0-linux-s390x",
+                  "e3bd9df41f777dbb227b1261ea81b1fa9b654901bac8cace50a0b918b5160ab5"
+                ],
+                "26.0.0-linux_amd64": [
+                  "node-v26.0.0-linux-x64.tar.xz",
+                  "node-v26.0.0-linux-x64",
+                  "345d558514c62622b5c7d1f7b5f2a19c31ab1405d217df49f010c5ea8decc0f4"
+                ],
+                "26.0.0-windows_amd64": [
+                  "node-v26.0.0-win-x64.zip",
+                  "node-v26.0.0-win-x64",
+                  "d0418640a36096e00bddb57761aa0b1b98f91904ec4ed2b9dd75cbad723becd7"
+                ]
+              },
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "26.0.0",
+              "include_headers": false,
+              "platform": "linux_amd64"
+            }
+          },
+          "node26_linux_arm64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
+            "attributes": {
+              "node_download_auth": {},
+              "node_repositories": {
+                "26.0.0-darwin_arm64": [
+                  "node-v26.0.0-darwin-arm64.tar.gz",
+                  "node-v26.0.0-darwin-arm64",
+                  "dcee8564c1a9342f9594dd5e52d533894dfef6b85aa771bbbb870baa3c403235"
+                ],
+                "26.0.0-darwin_amd64": [
+                  "node-v26.0.0-darwin-x64.tar.gz",
+                  "node-v26.0.0-darwin-x64",
+                  "f488ab543fe202d8a2d56e661682117d3c56903a2bf64f2ec1ff7bd421cfd875"
+                ],
+                "26.0.0-linux_arm64": [
+                  "node-v26.0.0-linux-arm64.tar.xz",
+                  "node-v26.0.0-linux-arm64",
+                  "f0f94e55142149a4d34634dc3d7e103921d898512dd0cef995ecb62c5ebd3f29"
+                ],
+                "26.0.0-linux_ppc64le": [
+                  "node-v26.0.0-linux-ppc64le.tar.xz",
+                  "node-v26.0.0-linux-ppc64le",
+                  "4b7f76967a93fea8cda11554f2a7904744afaef65dc3f48c345e99828f50ef4d"
+                ],
+                "26.0.0-linux_s390x": [
+                  "node-v26.0.0-linux-s390x.tar.xz",
+                  "node-v26.0.0-linux-s390x",
+                  "e3bd9df41f777dbb227b1261ea81b1fa9b654901bac8cace50a0b918b5160ab5"
+                ],
+                "26.0.0-linux_amd64": [
+                  "node-v26.0.0-linux-x64.tar.xz",
+                  "node-v26.0.0-linux-x64",
+                  "345d558514c62622b5c7d1f7b5f2a19c31ab1405d217df49f010c5ea8decc0f4"
+                ],
+                "26.0.0-windows_amd64": [
+                  "node-v26.0.0-win-x64.zip",
+                  "node-v26.0.0-win-x64",
+                  "d0418640a36096e00bddb57761aa0b1b98f91904ec4ed2b9dd75cbad723becd7"
+                ]
+              },
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "26.0.0",
+              "include_headers": false,
+              "platform": "linux_arm64"
+            }
+          },
+          "node26_linux_s390x": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
+            "attributes": {
+              "node_download_auth": {},
+              "node_repositories": {
+                "26.0.0-darwin_arm64": [
+                  "node-v26.0.0-darwin-arm64.tar.gz",
+                  "node-v26.0.0-darwin-arm64",
+                  "dcee8564c1a9342f9594dd5e52d533894dfef6b85aa771bbbb870baa3c403235"
+                ],
+                "26.0.0-darwin_amd64": [
+                  "node-v26.0.0-darwin-x64.tar.gz",
+                  "node-v26.0.0-darwin-x64",
+                  "f488ab543fe202d8a2d56e661682117d3c56903a2bf64f2ec1ff7bd421cfd875"
+                ],
+                "26.0.0-linux_arm64": [
+                  "node-v26.0.0-linux-arm64.tar.xz",
+                  "node-v26.0.0-linux-arm64",
+                  "f0f94e55142149a4d34634dc3d7e103921d898512dd0cef995ecb62c5ebd3f29"
+                ],
+                "26.0.0-linux_ppc64le": [
+                  "node-v26.0.0-linux-ppc64le.tar.xz",
+                  "node-v26.0.0-linux-ppc64le",
+                  "4b7f76967a93fea8cda11554f2a7904744afaef65dc3f48c345e99828f50ef4d"
+                ],
+                "26.0.0-linux_s390x": [
+                  "node-v26.0.0-linux-s390x.tar.xz",
+                  "node-v26.0.0-linux-s390x",
+                  "e3bd9df41f777dbb227b1261ea81b1fa9b654901bac8cace50a0b918b5160ab5"
+                ],
+                "26.0.0-linux_amd64": [
+                  "node-v26.0.0-linux-x64.tar.xz",
+                  "node-v26.0.0-linux-x64",
+                  "345d558514c62622b5c7d1f7b5f2a19c31ab1405d217df49f010c5ea8decc0f4"
+                ],
+                "26.0.0-windows_amd64": [
+                  "node-v26.0.0-win-x64.zip",
+                  "node-v26.0.0-win-x64",
+                  "d0418640a36096e00bddb57761aa0b1b98f91904ec4ed2b9dd75cbad723becd7"
+                ]
+              },
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "26.0.0",
+              "include_headers": false,
+              "platform": "linux_s390x"
+            }
+          },
+          "node26_linux_ppc64le": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
+            "attributes": {
+              "node_download_auth": {},
+              "node_repositories": {
+                "26.0.0-darwin_arm64": [
+                  "node-v26.0.0-darwin-arm64.tar.gz",
+                  "node-v26.0.0-darwin-arm64",
+                  "dcee8564c1a9342f9594dd5e52d533894dfef6b85aa771bbbb870baa3c403235"
+                ],
+                "26.0.0-darwin_amd64": [
+                  "node-v26.0.0-darwin-x64.tar.gz",
+                  "node-v26.0.0-darwin-x64",
+                  "f488ab543fe202d8a2d56e661682117d3c56903a2bf64f2ec1ff7bd421cfd875"
+                ],
+                "26.0.0-linux_arm64": [
+                  "node-v26.0.0-linux-arm64.tar.xz",
+                  "node-v26.0.0-linux-arm64",
+                  "f0f94e55142149a4d34634dc3d7e103921d898512dd0cef995ecb62c5ebd3f29"
+                ],
+                "26.0.0-linux_ppc64le": [
+                  "node-v26.0.0-linux-ppc64le.tar.xz",
+                  "node-v26.0.0-linux-ppc64le",
+                  "4b7f76967a93fea8cda11554f2a7904744afaef65dc3f48c345e99828f50ef4d"
+                ],
+                "26.0.0-linux_s390x": [
+                  "node-v26.0.0-linux-s390x.tar.xz",
+                  "node-v26.0.0-linux-s390x",
+                  "e3bd9df41f777dbb227b1261ea81b1fa9b654901bac8cace50a0b918b5160ab5"
+                ],
+                "26.0.0-linux_amd64": [
+                  "node-v26.0.0-linux-x64.tar.xz",
+                  "node-v26.0.0-linux-x64",
+                  "345d558514c62622b5c7d1f7b5f2a19c31ab1405d217df49f010c5ea8decc0f4"
+                ],
+                "26.0.0-windows_amd64": [
+                  "node-v26.0.0-win-x64.zip",
+                  "node-v26.0.0-win-x64",
+                  "d0418640a36096e00bddb57761aa0b1b98f91904ec4ed2b9dd75cbad723becd7"
+                ]
+              },
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "26.0.0",
+              "include_headers": false,
+              "platform": "linux_ppc64le"
+            }
+          },
+          "node26_darwin_amd64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
+            "attributes": {
+              "node_download_auth": {},
+              "node_repositories": {
+                "26.0.0-darwin_arm64": [
+                  "node-v26.0.0-darwin-arm64.tar.gz",
+                  "node-v26.0.0-darwin-arm64",
+                  "dcee8564c1a9342f9594dd5e52d533894dfef6b85aa771bbbb870baa3c403235"
+                ],
+                "26.0.0-darwin_amd64": [
+                  "node-v26.0.0-darwin-x64.tar.gz",
+                  "node-v26.0.0-darwin-x64",
+                  "f488ab543fe202d8a2d56e661682117d3c56903a2bf64f2ec1ff7bd421cfd875"
+                ],
+                "26.0.0-linux_arm64": [
+                  "node-v26.0.0-linux-arm64.tar.xz",
+                  "node-v26.0.0-linux-arm64",
+                  "f0f94e55142149a4d34634dc3d7e103921d898512dd0cef995ecb62c5ebd3f29"
+                ],
+                "26.0.0-linux_ppc64le": [
+                  "node-v26.0.0-linux-ppc64le.tar.xz",
+                  "node-v26.0.0-linux-ppc64le",
+                  "4b7f76967a93fea8cda11554f2a7904744afaef65dc3f48c345e99828f50ef4d"
+                ],
+                "26.0.0-linux_s390x": [
+                  "node-v26.0.0-linux-s390x.tar.xz",
+                  "node-v26.0.0-linux-s390x",
+                  "e3bd9df41f777dbb227b1261ea81b1fa9b654901bac8cace50a0b918b5160ab5"
+                ],
+                "26.0.0-linux_amd64": [
+                  "node-v26.0.0-linux-x64.tar.xz",
+                  "node-v26.0.0-linux-x64",
+                  "345d558514c62622b5c7d1f7b5f2a19c31ab1405d217df49f010c5ea8decc0f4"
+                ],
+                "26.0.0-windows_amd64": [
+                  "node-v26.0.0-win-x64.zip",
+                  "node-v26.0.0-win-x64",
+                  "d0418640a36096e00bddb57761aa0b1b98f91904ec4ed2b9dd75cbad723becd7"
+                ]
+              },
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "26.0.0",
+              "include_headers": false,
+              "platform": "darwin_amd64"
+            }
+          },
+          "node26_darwin_arm64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
+            "attributes": {
+              "node_download_auth": {},
+              "node_repositories": {
+                "26.0.0-darwin_arm64": [
+                  "node-v26.0.0-darwin-arm64.tar.gz",
+                  "node-v26.0.0-darwin-arm64",
+                  "dcee8564c1a9342f9594dd5e52d533894dfef6b85aa771bbbb870baa3c403235"
+                ],
+                "26.0.0-darwin_amd64": [
+                  "node-v26.0.0-darwin-x64.tar.gz",
+                  "node-v26.0.0-darwin-x64",
+                  "f488ab543fe202d8a2d56e661682117d3c56903a2bf64f2ec1ff7bd421cfd875"
+                ],
+                "26.0.0-linux_arm64": [
+                  "node-v26.0.0-linux-arm64.tar.xz",
+                  "node-v26.0.0-linux-arm64",
+                  "f0f94e55142149a4d34634dc3d7e103921d898512dd0cef995ecb62c5ebd3f29"
+                ],
+                "26.0.0-linux_ppc64le": [
+                  "node-v26.0.0-linux-ppc64le.tar.xz",
+                  "node-v26.0.0-linux-ppc64le",
+                  "4b7f76967a93fea8cda11554f2a7904744afaef65dc3f48c345e99828f50ef4d"
+                ],
+                "26.0.0-linux_s390x": [
+                  "node-v26.0.0-linux-s390x.tar.xz",
+                  "node-v26.0.0-linux-s390x",
+                  "e3bd9df41f777dbb227b1261ea81b1fa9b654901bac8cace50a0b918b5160ab5"
+                ],
+                "26.0.0-linux_amd64": [
+                  "node-v26.0.0-linux-x64.tar.xz",
+                  "node-v26.0.0-linux-x64",
+                  "345d558514c62622b5c7d1f7b5f2a19c31ab1405d217df49f010c5ea8decc0f4"
+                ],
+                "26.0.0-windows_amd64": [
+                  "node-v26.0.0-win-x64.zip",
+                  "node-v26.0.0-win-x64",
+                  "d0418640a36096e00bddb57761aa0b1b98f91904ec4ed2b9dd75cbad723becd7"
+                ]
+              },
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "26.0.0",
+              "include_headers": false,
+              "platform": "darwin_arm64"
+            }
+          },
+          "node26_windows_amd64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
+            "attributes": {
+              "node_download_auth": {},
+              "node_repositories": {
+                "26.0.0-darwin_arm64": [
+                  "node-v26.0.0-darwin-arm64.tar.gz",
+                  "node-v26.0.0-darwin-arm64",
+                  "dcee8564c1a9342f9594dd5e52d533894dfef6b85aa771bbbb870baa3c403235"
+                ],
+                "26.0.0-darwin_amd64": [
+                  "node-v26.0.0-darwin-x64.tar.gz",
+                  "node-v26.0.0-darwin-x64",
+                  "f488ab543fe202d8a2d56e661682117d3c56903a2bf64f2ec1ff7bd421cfd875"
+                ],
+                "26.0.0-linux_arm64": [
+                  "node-v26.0.0-linux-arm64.tar.xz",
+                  "node-v26.0.0-linux-arm64",
+                  "f0f94e55142149a4d34634dc3d7e103921d898512dd0cef995ecb62c5ebd3f29"
+                ],
+                "26.0.0-linux_ppc64le": [
+                  "node-v26.0.0-linux-ppc64le.tar.xz",
+                  "node-v26.0.0-linux-ppc64le",
+                  "4b7f76967a93fea8cda11554f2a7904744afaef65dc3f48c345e99828f50ef4d"
+                ],
+                "26.0.0-linux_s390x": [
+                  "node-v26.0.0-linux-s390x.tar.xz",
+                  "node-v26.0.0-linux-s390x",
+                  "e3bd9df41f777dbb227b1261ea81b1fa9b654901bac8cace50a0b918b5160ab5"
+                ],
+                "26.0.0-linux_amd64": [
+                  "node-v26.0.0-linux-x64.tar.xz",
+                  "node-v26.0.0-linux-x64",
+                  "345d558514c62622b5c7d1f7b5f2a19c31ab1405d217df49f010c5ea8decc0f4"
+                ],
+                "26.0.0-windows_amd64": [
+                  "node-v26.0.0-win-x64.zip",
+                  "node-v26.0.0-win-x64",
+                  "d0418640a36096e00bddb57761aa0b1b98f91904ec4ed2b9dd75cbad723becd7"
+                ]
+              },
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "26.0.0",
+              "include_headers": false,
+              "platform": "windows_amd64"
+            }
+          },
+          "node26_windows_arm64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
+            "attributes": {
+              "node_download_auth": {},
+              "node_repositories": {
+                "26.0.0-darwin_arm64": [
+                  "node-v26.0.0-darwin-arm64.tar.gz",
+                  "node-v26.0.0-darwin-arm64",
+                  "dcee8564c1a9342f9594dd5e52d533894dfef6b85aa771bbbb870baa3c403235"
+                ],
+                "26.0.0-darwin_amd64": [
+                  "node-v26.0.0-darwin-x64.tar.gz",
+                  "node-v26.0.0-darwin-x64",
+                  "f488ab543fe202d8a2d56e661682117d3c56903a2bf64f2ec1ff7bd421cfd875"
+                ],
+                "26.0.0-linux_arm64": [
+                  "node-v26.0.0-linux-arm64.tar.xz",
+                  "node-v26.0.0-linux-arm64",
+                  "f0f94e55142149a4d34634dc3d7e103921d898512dd0cef995ecb62c5ebd3f29"
+                ],
+                "26.0.0-linux_ppc64le": [
+                  "node-v26.0.0-linux-ppc64le.tar.xz",
+                  "node-v26.0.0-linux-ppc64le",
+                  "4b7f76967a93fea8cda11554f2a7904744afaef65dc3f48c345e99828f50ef4d"
+                ],
+                "26.0.0-linux_s390x": [
+                  "node-v26.0.0-linux-s390x.tar.xz",
+                  "node-v26.0.0-linux-s390x",
+                  "e3bd9df41f777dbb227b1261ea81b1fa9b654901bac8cace50a0b918b5160ab5"
+                ],
+                "26.0.0-linux_amd64": [
+                  "node-v26.0.0-linux-x64.tar.xz",
+                  "node-v26.0.0-linux-x64",
+                  "345d558514c62622b5c7d1f7b5f2a19c31ab1405d217df49f010c5ea8decc0f4"
+                ],
+                "26.0.0-windows_amd64": [
+                  "node-v26.0.0-win-x64.zip",
+                  "node-v26.0.0-win-x64",
+                  "d0418640a36096e00bddb57761aa0b1b98f91904ec4ed2b9dd75cbad723becd7"
+                ]
+              },
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "26.0.0",
+              "include_headers": false,
+              "platform": "windows_arm64"
+            }
+          },
+          "node26": {
+            "repoRuleId": "@@rules_nodejs+//nodejs/private:nodejs_repo_host_os_alias.bzl%nodejs_repo_host_os_alias",
+            "attributes": {
+              "user_node_repository_name": "node26"
+            }
+          },
+          "node26_host": {
+            "repoRuleId": "@@rules_nodejs+//nodejs/private:nodejs_repo_host_os_alias.bzl%nodejs_repo_host_os_alias",
+            "attributes": {
+              "user_node_repository_name": "node26"
+            }
+          },
+          "node26_toolchains": {
+            "repoRuleId": "@@rules_nodejs+//nodejs/private:nodejs_toolchains_repo.bzl%nodejs_toolchains_repo",
+            "attributes": {
+              "user_node_repository_name": "node26"
             }
           }
         },

--- a/constants.bzl
+++ b/constants.bzl
@@ -1,5 +1,5 @@
 # Engine versions to stamp in a release package.json
-RELEASE_ENGINES_NODE = "^22.22.0 || >=24.13.1"
+RELEASE_ENGINES_NODE = "^22.22.0 || ^24.13.1 || >=26.0.0"
 RELEASE_ENGINES_NPM = "^6.11.0 || ^7.5.6 || >=8.0.0"
 RELEASE_ENGINES_YARN = ">= 1.13.0"
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "packageManager": "pnpm@10.33.2",
   "engines": {
-    "node": "^22.22.0 || >=24.13.1",
+    "node": "^22.22.0 || ^24.13.1 || >=26.0.0",
     "npm": "Please use pnpm instead of NPM to install dependencies",
     "yarn": "Please use pnpm instead of Yarn to install dependencies",
     "pnpm": "10.33.2"

--- a/tools/toolchain_info.bzl
+++ b/tools/toolchain_info.bzl
@@ -5,6 +5,7 @@
 TOOLCHAINS_NAMES = [
     "node22",
     "node24",
+    "node26",
 ]
 
 # this is the list of toolchains that should be used and are registered with nodejs_register_toolchains in the WORKSPACE file
@@ -18,6 +19,11 @@ TOOLCHAINS_VERSIONS = [
         "@bazel_tools//src/conditions:linux_x86_64": "@node24_linux_amd64//:node_toolchain",
         "@bazel_tools//src/conditions:darwin": "@node24_darwin_amd64//:node_toolchain",
         "@bazel_tools//src/conditions:windows": "@node24_windows_amd64//:node_toolchain",
+    }),
+    select({
+        "@bazel_tools//src/conditions:linux_x86_64": "@node26_linux_amd64//:node_toolchain",
+        "@bazel_tools//src/conditions:darwin": "@node26_darwin_amd64//:node_toolchain",
+        "@bazel_tools//src/conditions:windows": "@node26_windows_amd64//:node_toolchain",
     }),
 ]
 


### PR DESCRIPTION
Updates the supported Node.js engine versions to include Node.js 26.

This allows running the CLI on Node.js 26.0.0 and above while continuing to support active LTS versions.
