### PR TITLE
build: remove rootDir from root configuration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,6 @@
     "strict": true,
     "target": "es2023",
     "lib": ["es2023"],
-    "rootDir": ".",
     "rootDirs": [".", "./dist-schema/bin/"],
     "paths": {
       "@angular-devkit/build-webpack": ["./packages/angular_devkit/build_webpack"],


### PR DESCRIPTION
Removing the rootDir option from the root tsconfig.json allows the TypeScript compiler to automatically compute the root directory based on the common path of all input files. This provides more flexibility in monorepo setups where files span across multiple top-level directories like packages and modules, avoiding strict location constraints that may not apply to all build targets.
