### PR TITLE
refactor(@angular-devkit/core): deprecate stringToFileBuffer and fileBufferToString

### DIFF
--- a/goldens/public-api/angular_devkit/core/index.api.md
+++ b/goldens/public-api/angular_devkit/core/index.api.md
@@ -243,7 +243,7 @@ type FileBuffer = ArrayBuffer;
 // @public (undocumented)
 type FileBufferLike = ArrayBufferLike;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 function fileBufferToString(fileBuffer: FileBuffer): string;
 
 // @public (undocumented)
@@ -1012,7 +1012,7 @@ declare namespace strings {
 }
 export { strings }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 function stringToFileBuffer(str: string): FileBuffer;
 
 // @public (undocumented)

--- a/packages/angular_devkit/architect/testing/test-project-host.ts
+++ b/packages/angular_devkit/architect/testing/test-project-host.ts
@@ -117,7 +117,7 @@ export class TestProjectHost extends NodeJsSyncHost {
     Object.keys(files).forEach((fileName) => {
       let content = files[fileName];
       if (typeof content == 'string') {
-        content = virtualFs.stringToFileBuffer(content);
+        content = new TextEncoder().encode(content).buffer;
       } else if (content instanceof Buffer) {
         content = content.buffer.slice(content.byteOffset, content.byteOffset + content.byteLength);
       }
@@ -127,16 +127,16 @@ export class TestProjectHost extends NodeJsSyncHost {
   }
 
   replaceInFile(path: string, match: RegExp | string, replacement: string): void {
-    const content = virtualFs.fileBufferToString(this.scopedSync().read(normalize(path)));
+    const content = new TextDecoder().decode(this.scopedSync().read(normalize(path)));
     this.scopedSync().write(
       normalize(path),
-      virtualFs.stringToFileBuffer(content.replace(match, replacement)),
+      new TextEncoder().encode(content.replace(match, replacement)).buffer,
     );
   }
 
   appendToFile(path: string, str: string): void {
-    const content = virtualFs.fileBufferToString(this.scopedSync().read(normalize(path)));
-    this.scopedSync().write(normalize(path), virtualFs.stringToFileBuffer(content.concat(str)));
+    const content = new TextDecoder().decode(this.scopedSync().read(normalize(path)));
+    this.scopedSync().write(normalize(path), new TextEncoder().encode(content.concat(str)).buffer);
   }
 
   fileMatchExists(dir: string, regex: RegExp): PathFragment | undefined {

--- a/packages/angular_devkit/build_angular/src/builders/app-shell/app-shell_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/app-shell/app-shell_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { Architect } from '@angular-devkit/architect';
-import { normalize, virtualFs } from '@angular-devkit/core';
+import { normalize } from '@angular-devkit/core';
 import { createArchitect, host } from '../../testing/test-utils';
 
 describe('AppShell Builder', () => {
@@ -133,7 +133,7 @@ describe('AppShell Builder', () => {
     expect(output.success).toBe(true);
 
     const fileName = 'dist/index.html';
-    const content = virtualFs.fileBufferToString(host.scopedSync().read(normalize(fileName)));
+    const content = new TextDecoder().decode(host.scopedSync().read(normalize(fileName)));
     expect(content).toMatch('Welcome to app');
   });
 
@@ -147,7 +147,7 @@ describe('AppShell Builder', () => {
 
     expect(output.success).toBe(true);
     const fileName = 'dist/index.html';
-    const content = virtualFs.fileBufferToString(host.scopedSync().read(normalize(fileName)));
+    const content = new TextDecoder().decode(host.scopedSync().read(normalize(fileName)));
     expect(content).toContain('app-shell works!');
   });
 
@@ -164,7 +164,7 @@ describe('AppShell Builder', () => {
 
     expect(output.success).toBe(true);
     const fileName = 'dist/index.html';
-    const content = virtualFs.fileBufferToString(host.scopedSync().read(normalize(fileName)));
+    const content = new TextDecoder().decode(host.scopedSync().read(normalize(fileName)));
 
     expect(content).toContain('app-shell works!');
     expect(content).toContain('p{color:#000}');
@@ -187,7 +187,7 @@ describe('AppShell Builder', () => {
 
     expect(output.success).toBe(true);
     const fileName = 'dist/index.html';
-    const content = virtualFs.fileBufferToString(host.scopedSync().read(normalize(fileName)));
+    const content = new TextDecoder().decode(host.scopedSync().read(normalize(fileName)));
 
     expect(content).toContain('app-shell works!');
     expect(content).toContain('<style nonce="{% nonce %}">p{color:#000}</style>');

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/allow-js_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/allow-js_spec.ts
@@ -8,7 +8,7 @@
 
 import { Architect } from '@angular-devkit/architect';
 
-import { join, normalize, relative, virtualFs } from '@angular-devkit/core';
+import { join, normalize, relative } from '@angular-devkit/core';
 import { Observable, lastValueFrom, take, tap } from 'rxjs';
 import { createArchitect, host } from '../../../testing/test-utils';
 import { BrowserBuilderOutput } from '../index';
@@ -39,7 +39,7 @@ describe('Browser Builder allow js', () => {
     const output = await run.result;
     expect(output.success).toBe(true);
 
-    const content = virtualFs.fileBufferToString(
+    const content = new TextDecoder().decode(
       await lastValueFrom(host.read(join(normalize(output.outputs[0].path), 'main.js'))),
     );
 
@@ -66,7 +66,7 @@ describe('Browser Builder allow js', () => {
     const output = await run.result;
     expect(output.success).toBe(true);
 
-    const content = virtualFs.fileBufferToString(
+    const content = new TextDecoder().decode(
       await lastValueFrom(host.read(join(normalize(output.outputs[0].path), 'main.js'))),
     );
 
@@ -96,7 +96,7 @@ describe('Browser Builder allow js', () => {
       run.output.pipe(
         tap((output) => {
           const path = relative(host.root(), join(normalize(output.outputs[0].path), 'main.js'));
-          const content = virtualFs.fileBufferToString(host.scopedSync().read(path));
+          const content = new TextDecoder().decode(host.scopedSync().read(path));
 
           switch (buildCount) {
             case 1:

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/base-href_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/base-href_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { Architect } from '@angular-devkit/architect';
-import { join, normalize, tags, virtualFs } from '@angular-devkit/core';
+import { join, normalize, tags } from '@angular-devkit/core';
 import { lastValueFrom } from 'rxjs';
 import { createArchitect, host } from '../../../testing/test-utils';
 
@@ -39,7 +39,7 @@ describe('Browser Builder base href', () => {
 
     expect(output.success).toBe(true);
     const fileName = join(normalize(output.outputs[0].path), 'index.html');
-    const content = virtualFs.fileBufferToString(await lastValueFrom(host.read(fileName)));
+    const content = new TextDecoder().decode(await lastValueFrom(host.read(fileName)));
     expect(content).toMatch(/<base href="\/myUrl">/);
 
     await run.stop();
@@ -60,7 +60,7 @@ describe('Browser Builder base href', () => {
 
     expect(output.success).toBeTrue();
     const fileName = join(normalize(output.outputs[0].path), 'index.html');
-    const content = virtualFs.fileBufferToString(await lastValueFrom(host.read(fileName)));
+    const content = new TextDecoder().decode(await lastValueFrom(host.read(fileName)));
     expect(content).toContain(`<base href=".">`);
 
     await run.stop();
@@ -79,9 +79,7 @@ describe('Browser Builder base href', () => {
     const output = await run.result;
     expect(output.success).toBe(true);
     const fileName = join(normalize(output.outputs[0].path), 'index.html');
-    const content = virtualFs.fileBufferToString(
-      await lastValueFrom(host.read(normalize(fileName))),
-    );
+    const content = new TextDecoder().decode(await lastValueFrom(host.read(normalize(fileName))));
     expect(content).toContain('<head><base href="/myUrl"><meta charset="UTF-8">');
     await run.stop();
   });

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/cross-origin_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/cross-origin_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { Architect } from '@angular-devkit/architect';
-import { join, normalize, virtualFs } from '@angular-devkit/core';
+import { join, normalize } from '@angular-devkit/core';
 import { lastValueFrom } from 'rxjs';
 import { createArchitect, host } from '../../../testing/test-utils';
 import { BrowserBuilderOutput } from '../index';
@@ -37,9 +37,7 @@ describe('Browser Builder crossOrigin', () => {
     const output = await run.result;
     expect(output.success).toBe(true);
     const fileName = join(normalize(output.outputs[0].path), 'index.html');
-    const content = virtualFs.fileBufferToString(
-      await lastValueFrom(host.read(normalize(fileName))),
-    );
+    const content = new TextDecoder().decode(await lastValueFrom(host.read(normalize(fileName))));
     expect(content).toBe(
       `<html><head><base href="/"><link rel="stylesheet" href="styles.css" crossorigin="use-credentials"></head>` +
         `<body><app-root></app-root>` +
@@ -57,9 +55,7 @@ describe('Browser Builder crossOrigin', () => {
     const output = await run.result;
     expect(output.success).toBe(true);
     const fileName = join(normalize(output.outputs[0].path), 'index.html');
-    const content = virtualFs.fileBufferToString(
-      await lastValueFrom(host.read(normalize(fileName))),
-    );
+    const content = new TextDecoder().decode(await lastValueFrom(host.read(normalize(fileName))));
     expect(content).toBe(
       `<html><head><base href="/">` +
         `<link rel="stylesheet" href="styles.css" crossorigin="anonymous"></head>` +
@@ -78,9 +74,7 @@ describe('Browser Builder crossOrigin', () => {
     const output = await run.result;
     expect(output.success).toBe(true);
     const fileName = join(normalize(output.outputs[0].path), 'index.html');
-    const content = virtualFs.fileBufferToString(
-      await lastValueFrom(host.read(normalize(fileName))),
-    );
+    const content = new TextDecoder().decode(await lastValueFrom(host.read(normalize(fileName))));
     expect(content).toBe(
       `<html><head><base href="/">` +
         `<link rel="stylesheet" href="styles.css"></head>` +
@@ -105,9 +99,7 @@ describe('Browser Builder crossOrigin', () => {
     expect(output.success).toBe(true);
 
     const fileName = join(normalize(output.outputs[0].path), 'runtime.js');
-    const content = virtualFs.fileBufferToString(
-      await lastValueFrom(host.read(normalize(fileName))),
-    );
+    const content = new TextDecoder().decode(await lastValueFrom(host.read(normalize(fileName))));
     expect(content).toContain('script.crossOrigin = "use-credentials"');
     await run.stop();
   });

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/deploy-url_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/deploy-url_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { Architect } from '@angular-devkit/architect';
-import { join, normalize, virtualFs } from '@angular-devkit/core';
+import { join, normalize } from '@angular-devkit/core';
 import { lastValueFrom } from 'rxjs';
 import { createArchitect, host } from '../../../testing/test-utils';
 import { BrowserBuilderOutput } from '../index';
@@ -41,11 +41,9 @@ describe('Browser Builder deploy url', () => {
 
     const fileName = join(outputPath, 'index.html');
     const runtimeFileName = join(outputPath, 'runtime.js');
-    const content = virtualFs.fileBufferToString(
-      await lastValueFrom(host.read(normalize(fileName))),
-    );
+    const content = new TextDecoder().decode(await lastValueFrom(host.read(normalize(fileName))));
     expect(content).toContain('deployUrl/main.js');
-    const runtimeContent = virtualFs.fileBufferToString(
+    const runtimeContent = new TextDecoder().decode(
       await lastValueFrom(host.read(normalize(runtimeFileName))),
     );
     expect(runtimeContent).toContain('deployUrl/');
@@ -54,9 +52,7 @@ describe('Browser Builder deploy url', () => {
     const output2 = await run2.result;
     expect(output2.outputs[0].path).toEqual(outputPath); // These should be the same.
 
-    const content2 = virtualFs.fileBufferToString(
-      await lastValueFrom(host.read(normalize(fileName))),
-    );
+    const content2 = new TextDecoder().decode(await lastValueFrom(host.read(normalize(fileName))));
     expect(content2).toContain('http://example.com/some/path/main.js');
 
     await run.stop();

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/index_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/index_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { Architect } from '@angular-devkit/architect';
-import { join, normalize, tags, virtualFs, workspaces } from '@angular-devkit/core';
+import { join, normalize, tags, workspaces } from '@angular-devkit/core';
 import { lastValueFrom } from 'rxjs';
 import { createArchitect, host } from '../../../testing/test-utils';
 import { BrowserBuilderOutput } from '../index';
@@ -34,9 +34,7 @@ describe('Browser Builder index HTML processing', () => {
     const output = await run.result;
     expect(output.success).toBe(true);
     const fileName = join(normalize(output.outputs[0].path), 'index.html');
-    const content = virtualFs.fileBufferToString(
-      await lastValueFrom(host.read(normalize(fileName))),
-    );
+    const content = new TextDecoder().decode(await lastValueFrom(host.read(normalize(fileName))));
     expect(content).toBe(
       `<html><head><base href="/"><link rel="stylesheet" href="styles.css"></head>` +
         `<body><app-root></app-root><script src="runtime.js" type="module"></script>` +
@@ -59,9 +57,7 @@ describe('Browser Builder index HTML processing', () => {
     const output = await run.result;
     expect(output.success).toBe(true);
     const fileName = join(normalize(output.outputs[0].path), 'index.html');
-    const content = virtualFs.fileBufferToString(
-      await lastValueFrom(host.read(normalize(fileName))),
-    );
+    const content = new TextDecoder().decode(await lastValueFrom(host.read(normalize(fileName))));
     expect(content).toBe(
       `<html><head><base href="/"><link rel="stylesheet" href="styles.css"></head>` +
         `<body><app-root></app-root>` +
@@ -84,9 +80,7 @@ describe('Browser Builder index HTML processing', () => {
     const output = await run.result;
     expect(output.success).toBe(true);
     const fileName = join(normalize(output.outputs[0].path), 'index.html');
-    const content = virtualFs.fileBufferToString(
-      await lastValueFrom(host.read(normalize(fileName))),
-    );
+    const content = new TextDecoder().decode(await lastValueFrom(host.read(normalize(fileName))));
     expect(content).toBe(
       `<html><head><title>&iacute;</title><base href="/"><link rel="stylesheet" href="styles.css"></head> ` +
         `<body><app-root></app-root><script src="runtime.js" type="module"></script>` +
@@ -108,9 +102,7 @@ describe('Browser Builder index HTML processing', () => {
     const output = await run.result;
     expect(output.success).toBe(true);
     const fileName = join(normalize(output.outputs[0].path), 'index.html');
-    const content = virtualFs.fileBufferToString(
-      await lastValueFrom(host.read(normalize(fileName))),
-    );
+    const content = new TextDecoder().decode(await lastValueFrom(host.read(normalize(fileName))));
     expect(content).toBe(
       `<html><head><base href="/"><%= csrf_meta_tags %><link rel="stylesheet" href="styles.css"></head> ` +
         `<body><app-root></app-root><script src="runtime.js" type="module"></script>` +
@@ -159,7 +151,7 @@ describe('Browser Builder index HTML processing', () => {
 
     const outputIndexPath = join(host.root(), 'dist', 'index.html');
     const content = await lastValueFrom(host.read(normalize(outputIndexPath)));
-    expect(virtualFs.fileBufferToString(content)).toBe(
+    expect(new TextDecoder().decode(content)).toBe(
       `<html><head><base href="/"><%= csrf_meta_tags %><link rel="stylesheet" href="styles.css"></head> ` +
         `<body><app-root></app-root><script src="runtime.js" type="module"></script>` +
         `<script src="polyfills.js" type="module"></script>` +
@@ -206,7 +198,7 @@ describe('Browser Builder index HTML processing', () => {
 
     const outputIndexPath = join(host.root(), 'dist', 'main.html');
     const content = await lastValueFrom(host.read(normalize(outputIndexPath)));
-    expect(virtualFs.fileBufferToString(content)).toBe(
+    expect(new TextDecoder().decode(content)).toBe(
       `<html><head><base href="/"><link rel="stylesheet" href="styles.css"></head> ` +
         `<body><app-root></app-root><script src="runtime.js" type="module"></script>` +
         `<script src="polyfills.js" type="module"></script>` +
@@ -253,7 +245,7 @@ describe('Browser Builder index HTML processing', () => {
 
     const outputIndexPath = join(host.root(), 'dist', 'extra', 'main.html');
     const content = await lastValueFrom(host.read(normalize(outputIndexPath)));
-    expect(virtualFs.fileBufferToString(content)).toBe(
+    expect(new TextDecoder().decode(content)).toBe(
       `<html><head><base href="/"><link rel="stylesheet" href="styles.css"></head> ` +
         `<body><app-root></app-root><script src="runtime.js" type="module"></script>` +
         `<script src="polyfills.js" type="module"></script>` +

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/output-path_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/output-path_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { Architect } from '@angular-devkit/architect';
-import { getSystemPath, join, virtualFs } from '@angular-devkit/core';
+import { getSystemPath, join } from '@angular-devkit/core';
 import * as fs from 'node:fs';
 import { browserBuild, createArchitect, host } from '../../../testing/test-utils';
 
@@ -24,7 +24,7 @@ describe('Browser Builder output path', () => {
   it('deletes output path content', async () => {
     // Write a file to the output path to later verify it was deleted.
     await host
-      .write(join(host.root(), 'dist/file.txt'), virtualFs.stringToFileBuffer('file'))
+      .write(join(host.root(), 'dist/file.txt'), new TextEncoder().encode('file').buffer)
       .toPromise();
 
     // Delete an app file to force a failed compilation.
@@ -42,7 +42,7 @@ describe('Browser Builder output path', () => {
     // Write a file to the output path to later verify it was deleted.
     host.writeMultipleFiles({
       'src-link/a.txt': '',
-      'dist/file.txt': virtualFs.stringToFileBuffer('file'),
+      'dist/file.txt': new TextEncoder().encode('file').buffer,
     });
 
     const distLinked = join(host.root(), 'dist', 'linked');

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/rebuild_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/rebuild_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { Architect } from '@angular-devkit/architect';
-import { join, logging, normalize, virtualFs } from '@angular-devkit/core';
+import { join, logging, normalize } from '@angular-devkit/core';
 import { debounceTime, take, takeWhile, tap, timeout } from 'rxjs';
 import {
   createArchitect,
@@ -104,9 +104,7 @@ describe('Browser Builder rebuilds', () => {
                   /\$\$_E2E_GOLDEN_VALUE_3/.source,
               );
               const fileName = './dist/main.js';
-              const content = virtualFs.fileBufferToString(
-                host.scopedSync().read(normalize(fileName)),
-              );
+              const content = new TextDecoder().decode(host.scopedSync().read(normalize(fileName)));
 
               if (re.test(content)) {
                 phase = 4;
@@ -311,7 +309,7 @@ describe('Browser Builder rebuilds', () => {
   });
 
   it('rebuilds after errors in JIT', async () => {
-    const origContent = virtualFs.fileBufferToString(
+    const origContent = new TextDecoder().decode(
       host.scopedSync().read(normalize('src/app/app.component.ts')),
     );
     host.appendToFile('./src/app/app.component.ts', `]]]]`);
@@ -348,7 +346,7 @@ describe('Browser Builder rebuilds', () => {
 
   it('rebuilds after errors in AOT', async () => {
     // Save the original contents of `./src/app/app.component.ts`.
-    const origContent = virtualFs.fileBufferToString(
+    const origContent = new TextDecoder().decode(
       host.scopedSync().read(normalize('src/app/app.component.ts')),
     );
     // Add a major static analysis error on a non-main file to the initial build.
@@ -495,7 +493,7 @@ describe('Browser Builder rebuilds', () => {
             case 4:
               // Check if html changes are added to factories.
               expect(buildEvent.success).toBe(true);
-              content = virtualFs.fileBufferToString(host.scopedSync().read(normalize(fileName)));
+              content = new TextDecoder().decode(host.scopedSync().read(normalize(fileName)));
               expect(content).toContain('HTML_REBUILD_STRING');
               // Change the component css.
               host.appendToFile('src/app/app.component.css', 'CSS_REBUILD_STRING {color: #f00;}');
@@ -504,7 +502,7 @@ describe('Browser Builder rebuilds', () => {
             case 5:
               // Check if css changes are added to factories.
               expect(buildEvent.success).toBe(true);
-              content = virtualFs.fileBufferToString(host.scopedSync().read(normalize(fileName)));
+              content = new TextDecoder().decode(host.scopedSync().read(normalize(fileName)));
               expect(content).toContain('CSS_REBUILD_STRING');
               // Change the component css import.
               host.appendToFile(
@@ -516,7 +514,7 @@ describe('Browser Builder rebuilds', () => {
             case 6:
               // Check if css import changes are added to factories.
               expect(buildEvent.success).toBe(true);
-              content = virtualFs.fileBufferToString(host.scopedSync().read(normalize(fileName)));
+              content = new TextDecoder().decode(host.scopedSync().read(normalize(fileName)));
               expect(content).toContain('CSS_DEP_REBUILD_STRING');
               // Change the component itself.
               host.replaceInFile(
@@ -529,7 +527,7 @@ describe('Browser Builder rebuilds', () => {
             case 7:
               // Check if component changes are added to factories.
               expect(buildEvent.success).toBe(true);
-              content = virtualFs.fileBufferToString(host.scopedSync().read(normalize(fileName)));
+              content = new TextDecoder().decode(host.scopedSync().read(normalize(fileName)));
               expect(content).toContain('FACTORY_REBUILD_STRING');
               break;
           }
@@ -593,7 +591,7 @@ describe('Browser Builder rebuilds', () => {
       .pipe(
         debounceTime(rebuildDebounceTime),
         tap(() => {
-          const content = virtualFs.fileBufferToString(
+          const content = new TextDecoder().decode(
             host.scopedSync().read(join(outputPath, 'main.js')),
           );
 
@@ -626,7 +624,7 @@ describe('Browser Builder rebuilds', () => {
         timeout(BUILD_TIMEOUT),
         debounceTime(rebuildDebounceTime),
         tap(() => {
-          const content = virtualFs.fileBufferToString(
+          const content = new TextDecoder().decode(
             host.scopedSync().read(join(outputPath, 'main.js')),
           );
 

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/replacements_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/replacements_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { Architect } from '@angular-devkit/architect';
-import { logging, normalize, virtualFs } from '@angular-devkit/core';
+import { logging, normalize } from '@angular-devkit/core';
 import { delay, filter, map, of, race, take, takeUntil, takeWhile, tap, timeout } from 'rxjs';
 import { browserBuild, createArchitect, host } from '../../../testing/test-utils';
 
@@ -116,7 +116,7 @@ describe('Browser Builder file replacements', () => {
           expect(result.success).toBe(true, 'build should succeed');
 
           const fileName = normalize('dist/main.js');
-          const content = virtualFs.fileBufferToString(host.scopedSync().read(fileName));
+          const content = new TextDecoder().decode(host.scopedSync().read(fileName));
           const has42 = /meaning\s*=\s*42/.test(content);
           buildCount++;
           switch (phase) {

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/resolve-json-module_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/resolve-json-module_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { Architect } from '@angular-devkit/architect';
-import { join, virtualFs } from '@angular-devkit/core';
+import { join } from '@angular-devkit/core';
 import { take, tap } from 'rxjs';
 import { createArchitect, host, outputPath } from '../../../testing/test-utils';
 
@@ -40,7 +40,7 @@ describe('Browser Builder resolve json module', () => {
     await run.output
       .pipe(
         tap(() => {
-          const content = virtualFs.fileBufferToString(
+          const content = new TextDecoder().decode(
             host.scopedSync().read(join(outputPath, 'main.js')),
           );
 

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/service-worker_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/service-worker_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { Architect } from '@angular-devkit/architect';
-import { join, normalize, virtualFs } from '@angular-devkit/core';
+import { join, normalize } from '@angular-devkit/core';
 import { debounceTime, take, tap } from 'rxjs';
 import { createArchitect, host } from '../../../testing/test-utils';
 
@@ -86,7 +86,7 @@ describe('Browser Builder service worker', () => {
 
     expect(host.scopedSync().exists(normalize('dist/ngsw.json'))).toBeTrue();
     const ngswJson = JSON.parse(
-      virtualFs.fileBufferToString(host.scopedSync().read(normalize('dist/ngsw.json'))),
+      new TextDecoder().decode(host.scopedSync().read(normalize('dist/ngsw.json'))),
     );
     // Verify index and assets are there.
     expect(ngswJson).toEqual(
@@ -154,7 +154,7 @@ describe('Browser Builder service worker', () => {
           const ngswJsonPath = normalize('dist/ngsw.json');
           expect(host.scopedSync().exists(ngswJsonPath)).toBeTrue();
           const ngswJson = JSON.parse(
-            virtualFs.fileBufferToString(host.scopedSync().read(ngswJsonPath)),
+            new TextDecoder().decode(host.scopedSync().read(ngswJsonPath)),
           );
 
           const hashTableEntries = Object.keys(ngswJson.hashTable);
@@ -203,7 +203,7 @@ describe('Browser Builder service worker', () => {
 
     expect(host.scopedSync().exists(normalize('dist/ngsw.json'))).toBeTrue();
     const ngswJson = JSON.parse(
-      virtualFs.fileBufferToString(host.scopedSync().read(normalize('dist/ngsw.json'))),
+      new TextDecoder().decode(host.scopedSync().read(normalize('dist/ngsw.json'))),
     );
     // Verify index and assets include the base href.
     expect(ngswJson).toEqual(

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/svg_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/svg_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { Architect } from '@angular-devkit/architect';
-import { join, normalize, virtualFs } from '@angular-devkit/core';
+import { join, normalize } from '@angular-devkit/core';
 import { createArchitect, host, outputPath } from '../../../testing/test-utils';
 
 describe('Browser Builder allow svg', () => {
@@ -53,9 +53,7 @@ describe('Browser Builder allow svg', () => {
     expect(exists).toBe(true, '"main.js" should exist');
 
     if (exists) {
-      const content = virtualFs.fileBufferToString(
-        host.scopedSync().read(join(outputPath, 'main.js')),
-      );
+      const content = new TextDecoder().decode(host.scopedSync().read(join(outputPath, 'main.js')));
 
       // Verify that the svg contents are present in the main bundle,
       // e.g. as template instructions.

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/tsconfig-paths_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/tsconfig-paths_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { Architect } from '@angular-devkit/architect';
-import { normalize, virtualFs } from '@angular-devkit/core';
+import { normalize } from '@angular-devkit/core';
 import { browserBuild, createArchitect, host } from '../../../testing/test-utils';
 
 describe('Browser Builder tsconfig paths', () => {
@@ -24,14 +24,14 @@ describe('Browser Builder tsconfig paths', () => {
     host.replaceInFile('src/app/app.module.ts', './app.component', '@root/app/app.component');
 
     const tsconfigPath = normalize('tsconfig.json');
-    const tsconfig = JSON.parse(virtualFs.fileBufferToString(host.scopedSync().read(tsconfigPath)));
+    const tsconfig = JSON.parse(new TextDecoder().decode(host.scopedSync().read(tsconfigPath)));
     tsconfig.compilerOptions ??= {};
     tsconfig.compilerOptions.paths = {
       '@root/*': ['./src/*'],
     };
     host
       .scopedSync()
-      .write(tsconfigPath, virtualFs.stringToFileBuffer(JSON.stringify(tsconfig, null, 2)));
+      .write(tsconfigPath, new TextEncoder().encode(JSON.stringify(tsconfig, null, 2)).buffer);
 
     await browserBuild(architect, host, target);
   });
@@ -43,7 +43,7 @@ describe('Browser Builder tsconfig paths', () => {
       'src/app/shared/index.ts': `export * from './meaning'`,
     });
     const tsconfigPath = normalize('tsconfig.json');
-    const tsconfig = JSON.parse(virtualFs.fileBufferToString(host.scopedSync().read(tsconfigPath)));
+    const tsconfig = JSON.parse(new TextDecoder().decode(host.scopedSync().read(tsconfigPath)));
     tsconfig.compilerOptions ??= {};
     tsconfig.compilerOptions.paths = {
       '@shared': ['./src/app/shared'],
@@ -52,7 +52,7 @@ describe('Browser Builder tsconfig paths', () => {
     };
     host
       .scopedSync()
-      .write(tsconfigPath, virtualFs.stringToFileBuffer(JSON.stringify(tsconfig, null, 2)));
+      .write(tsconfigPath, new TextEncoder().encode(JSON.stringify(tsconfig, null, 2)).buffer);
 
     host.appendToFile(
       'src/app/app.component.ts',

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/web-worker_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/web-worker_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { Architect } from '@angular-devkit/architect';
-import { join, logging, virtualFs } from '@angular-devkit/core';
+import { join, logging } from '@angular-devkit/core';
 import { debounceTime, lastValueFrom, map, switchMap, takeWhile, tap, timer } from 'rxjs';
 import { browserBuild, createArchitect, host, outputPath } from '../../../testing/test-utils';
 
@@ -90,14 +90,14 @@ describe('Browser Builder Web Worker support', () => {
     await browserBuild(architect, host, target, overrides, { logger });
 
     // Worker bundle contains worker code.
-    const workerContent = virtualFs.fileBufferToString(
+    const workerContent = new TextDecoder().decode(
       host.scopedSync().read(join(outputPath, 'src_app_app_worker_ts.js')),
     );
     expect(workerContent).toContain('hello from worker');
     expect(workerContent).toContain('bar');
 
     // Main bundle references worker.
-    const mainContent = virtualFs.fileBufferToString(
+    const mainContent = new TextDecoder().decode(
       host.scopedSync().read(join(outputPath, 'main.js')),
     );
     expect(mainContent).toContain('src_app_app_worker_ts');
@@ -119,7 +119,7 @@ describe('Browser Builder Web Worker support', () => {
       /src_app_app_worker_ts\.[0-9a-f]{16}\.js/,
     ) as string;
     expect(workerBundle).toBeTruthy('workerBundle should exist');
-    const workerContent = virtualFs.fileBufferToString(
+    const workerContent = new TextDecoder().decode(
       host.scopedSync().read(join(outputPath, workerBundle)),
     );
     expect(workerContent).toContain('hello from worker');
@@ -129,7 +129,7 @@ describe('Browser Builder Web Worker support', () => {
     // Main bundle should reference hashed worker bundle.
     const mainBundle = host.fileMatchExists(outputPath, /main\.[0-9a-f]{16}\.js/) as string;
     expect(mainBundle).toBeTruthy('mainBundle should exist');
-    const mainContent = virtualFs.fileBufferToString(
+    const mainContent = new TextDecoder().decode(
       host.scopedSync().read(join(outputPath, mainBundle)),
     );
     expect(mainContent).toContain('src_app_app_worker_ts');
@@ -159,7 +159,7 @@ describe('Browser Builder Web Worker support', () => {
           switch (phase) {
             case 1:
               // Original worker content should be there.
-              workerContent = virtualFs.fileBufferToString(host.scopedSync().read(workerPath));
+              workerContent = new TextDecoder().decode(host.scopedSync().read(workerPath));
               expect(workerContent).toContain('bar');
               // Change content of worker dependency.
               host.writeMultipleFiles({ 'src/app/dep.ts': `export const foo = 'baz';` });
@@ -167,7 +167,7 @@ describe('Browser Builder Web Worker support', () => {
               break;
 
             case 2:
-              workerContent = virtualFs.fileBufferToString(host.scopedSync().read(workerPath));
+              workerContent = new TextDecoder().decode(host.scopedSync().read(workerPath));
               // Worker content should have changed.
               expect(workerContent).toContain('baz');
               phase = 3;

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/specs/works_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/specs/works_spec.ts
@@ -8,7 +8,7 @@
 
 import { Architect, BuilderRun } from '@angular-devkit/architect';
 import { EmittedFiles } from '@angular-devkit/build-webpack';
-import { normalize, virtualFs } from '@angular-devkit/core';
+import { normalize } from '@angular-devkit/core';
 import { createArchitect, host } from '../../../testing/test-utils';
 import { DevServerBuilderOutput } from '../index';
 
@@ -73,7 +73,7 @@ describe('Dev Server Builder', () => {
 
   it('uses source locale when not localizing', async () => {
     const config = host.scopedSync().read(normalize('angular.json'));
-    const jsonConfig = JSON.parse(virtualFs.fileBufferToString(config));
+    const jsonConfig = JSON.parse(new TextDecoder().decode(config));
     const applicationProject = jsonConfig.projects.app;
 
     applicationProject.i18n = { sourceLocale: 'fr' };

--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/works_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/works_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { Architect } from '@angular-devkit/architect';
-import { join, logging, normalize, virtualFs } from '@angular-devkit/core';
+import { join, logging, normalize } from '@angular-devkit/core';
 import { createArchitect, extractI18nTargetSpec, host } from '../../testing/test-utils';
 
 describe('Extract i18n Target', () => {
@@ -34,7 +34,7 @@ describe('Extract i18n Target', () => {
     expect(exists).toBe(true);
 
     if (exists) {
-      const content = virtualFs.fileBufferToString(host.scopedSync().read(extractionFile));
+      const content = new TextDecoder().decode(host.scopedSync().read(extractionFile));
       expect(content).toContain('i18n test');
     }
   });
@@ -85,9 +85,7 @@ describe('Extract i18n Target', () => {
     await run.stop();
 
     expect(host.scopedSync().exists(extractionFile)).toBe(true);
-    expect(virtualFs.fileBufferToString(host.scopedSync().read(extractionFile))).toMatch(
-      /i18n test/,
-    );
+    expect(new TextDecoder().decode(host.scopedSync().read(extractionFile))).toMatch(/i18n test/);
   });
 
   it('supports output path', async () => {
@@ -104,9 +102,7 @@ describe('Extract i18n Target', () => {
     await run.stop();
 
     expect(host.scopedSync().exists(extractionFile)).toBe(true);
-    expect(virtualFs.fileBufferToString(host.scopedSync().read(extractionFile))).toMatch(
-      /i18n test/,
-    );
+    expect(new TextDecoder().decode(host.scopedSync().read(extractionFile))).toMatch(/i18n test/);
   });
 
   it('supports i18n format', async () => {
@@ -121,9 +117,7 @@ describe('Extract i18n Target', () => {
     await run.stop();
 
     expect(host.scopedSync().exists(extractionFile)).toBe(true);
-    expect(virtualFs.fileBufferToString(host.scopedSync().read(extractionFile))).toMatch(
-      /i18n test/,
-    );
+    expect(new TextDecoder().decode(host.scopedSync().read(extractionFile))).toMatch(/i18n test/);
   });
 
   it('issues warnings for duplicate message identifiers', async () => {

--- a/packages/angular_devkit/build_angular/src/builders/ng-packagr/works_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/ng-packagr/works_spec.ts
@@ -9,14 +9,7 @@
 import { Architect } from '@angular-devkit/architect';
 import { WorkspaceNodeModulesArchitectHost } from '@angular-devkit/architect/node';
 import { TestProjectHost, TestingArchitectHost } from '@angular-devkit/architect/testing';
-import {
-  getSystemPath,
-  join,
-  normalize,
-  schema,
-  virtualFs,
-  workspaces,
-} from '@angular-devkit/core';
+import { getSystemPath, join, normalize, schema, workspaces } from '@angular-devkit/core';
 import { debounceTime, map, take, tap } from 'rxjs';
 
 describe('NgPackagr Builder', () => {
@@ -67,7 +60,7 @@ describe('NgPackagr Builder', () => {
     await run.stop();
 
     expect(host.scopedSync().exists(normalize('./dist/lib/fesm2022/lib.mjs'))).toBe(true);
-    const content = virtualFs.fileBufferToString(
+    const content = new TextDecoder().decode(
       host.scopedSync().read(normalize('./dist/lib/fesm2022/lib.mjs')),
     );
     expect(content).toContain('lib works');
@@ -101,7 +94,7 @@ describe('NgPackagr Builder', () => {
         debounceTime(1000),
         map(() => {
           const fileName = './dist/lib/fesm2022/lib.mjs';
-          const content = virtualFs.fileBufferToString(host.scopedSync().read(normalize(fileName)));
+          const content = new TextDecoder().decode(host.scopedSync().read(normalize(fileName)));
 
           return content;
         }),

--- a/packages/angular_devkit/build_angular/src/builders/prerender/works_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/prerender/works_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { Architect } from '@angular-devkit/architect';
-import { join, normalize, virtualFs } from '@angular-devkit/core';
+import { join, normalize } from '@angular-devkit/core';
 import { createArchitect, host } from '../../testing/test-utils';
 
 describe('Prerender Builder', () => {
@@ -94,7 +94,7 @@ describe('Prerender Builder', () => {
 
     expect(output.success).toBe(true);
 
-    const content = virtualFs.fileBufferToString(
+    const content = new TextDecoder().decode(
       host.scopedSync().read(normalize('dist/foo/index.html')),
     );
 
@@ -109,17 +109,17 @@ describe('Prerender Builder', () => {
 
     expect(output.success).toBe(true);
 
-    let content = virtualFs.fileBufferToString(
+    let content = new TextDecoder().decode(
       host.scopedSync().read(normalize('dist/foo/index.html')),
     );
     expect(content).toContain('foo works!');
 
-    content = virtualFs.fileBufferToString(
+    content = new TextDecoder().decode(
       host.scopedSync().read(normalize('dist/index.original.html')),
     );
     expect(content).not.toContain('<router-outlet');
 
-    content = virtualFs.fileBufferToString(host.scopedSync().read(normalize('dist/index.html')));
+    content = new TextDecoder().decode(host.scopedSync().read(normalize('dist/index.html')));
 
     expect(content).toContain('<router-outlet');
   });
@@ -128,7 +128,7 @@ describe('Prerender Builder', () => {
     await host
       .write(
         join(host.root(), 'routes-file.txt'),
-        virtualFs.stringToFileBuffer(['/foo', '/'].join('\n')),
+        new TextEncoder().encode(['/foo', '/'].join('\n')).buffer,
       )
       .toPromise();
     const run = await architect.scheduleTarget(target, {
@@ -140,10 +140,10 @@ describe('Prerender Builder', () => {
 
     expect(output.success).toBe(true);
 
-    const fooContent = virtualFs.fileBufferToString(
+    const fooContent = new TextDecoder().decode(
       host.scopedSync().read(normalize('dist/foo/index.html')),
     );
-    const appContent = virtualFs.fileBufferToString(
+    const appContent = new TextDecoder().decode(
       host.scopedSync().read(normalize('dist/index.html')),
     );
 
@@ -173,10 +173,10 @@ describe('Prerender Builder', () => {
     });
 
     const output = await run.result;
-    const fooContent = virtualFs.fileBufferToString(
+    const fooContent = new TextDecoder().decode(
       host.scopedSync().read(normalize('dist/foo/index.html')),
     );
-    const appContent = virtualFs.fileBufferToString(
+    const appContent = new TextDecoder().decode(
       host.scopedSync().read(normalize('dist/index.html')),
     );
 
@@ -214,7 +214,7 @@ describe('Prerender Builder', () => {
 
     expect(output.success).toBe(true);
 
-    const content = virtualFs.fileBufferToString(
+    const content = new TextDecoder().decode(
       host.scopedSync().read(normalize('dist/foo/index.html')),
     );
 

--- a/packages/angular_devkit/core/node/host_spec.ts
+++ b/packages/angular_devkit/core/node/host_spec.ts
@@ -33,15 +33,15 @@ describe('NodeJsAsyncHost', () => {
   it('should get correct result for exists', async () => {
     const filePath = normalize('not-found');
     expect(await host.exists(filePath).toPromise()).toBeFalse();
-    await host.write(filePath, virtualFs.stringToFileBuffer('content')).toPromise();
+    await host.write(filePath, new TextEncoder().encode('content').buffer).toPromise();
     expect(await host.exists(filePath).toPromise()).toBeTrue();
   });
 
   linuxOnlyIt(
     'can watch',
     async () => {
-      const content = virtualFs.stringToFileBuffer('hello world');
-      const content2 = virtualFs.stringToFileBuffer('hello world 2');
+      const content = new TextEncoder().encode('hello world').buffer;
+      const content2 = new TextEncoder().encode('hello world 2').buffer;
       const allEvents: virtualFs.HostWatchEvent[] = [];
 
       fs.mkdirSync(root + '/sub1');
@@ -85,8 +85,8 @@ describe('NodeJsSyncHost', () => {
   linuxOnlyIt(
     'can watch',
     async () => {
-      const content = virtualFs.stringToFileBuffer('hello world');
-      const content2 = virtualFs.stringToFileBuffer('hello world 2');
+      const content = new TextEncoder().encode('hello world').buffer;
+      const content2 = new TextEncoder().encode('hello world 2').buffer;
       const allEvents: virtualFs.HostWatchEvent[] = [];
 
       fs.mkdirSync(root + '/sub1');
@@ -122,7 +122,7 @@ describe('NodeJsSyncHost', () => {
       host.rename(normalize('/rename/a.txt'), normalize('/rename/b/c/d/a.txt'));
       if (fs.existsSync(root + '/rename/b/c/d/a.txt')) {
         const resContent = host.read(normalize('/rename/b/c/d/a.txt'));
-        const content = virtualFs.fileBufferToString(resContent);
+        const content = new TextDecoder().decode(resContent);
         expect(content).toEqual('hello world');
       }
     },

--- a/packages/angular_devkit/core/src/virtual-fs/host/alias_spec.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/alias_spec.ts
@@ -8,12 +8,11 @@
 
 import { normalize } from '..';
 import { AliasHost } from './alias';
-import { stringToFileBuffer } from './buffer';
 import { SimpleMemoryHost } from './memory';
 
 describe('AliasHost', () => {
   it('works as in the example', () => {
-    const content = stringToFileBuffer('hello world');
+    const content = new TextEncoder().encode('hello world').buffer;
 
     const host = new SimpleMemoryHost();
     host.write(normalize('/some/file'), content).subscribe();
@@ -33,8 +32,8 @@ describe('AliasHost', () => {
   });
 
   it('works as in the example (2)', () => {
-    const content = stringToFileBuffer('hello world');
-    const content2 = stringToFileBuffer('hello world 2');
+    const content = new TextEncoder().encode('hello world').buffer;
+    const content2 = new TextEncoder().encode('hello world 2').buffer;
 
     const host = new SimpleMemoryHost();
     host.write(normalize('/some/folder/file'), content).subscribe();

--- a/packages/angular_devkit/core/src/virtual-fs/host/buffer.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/buffer.ts
@@ -6,13 +6,18 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { TextDecoder, TextEncoder } from 'node:util';
 import { FileBuffer } from './interface';
 
+/**
+ * @deprecated Use `new TextEncoder().encode(str).buffer` instead.
+ */
 export function stringToFileBuffer(str: string): FileBuffer {
   return new TextEncoder().encode(str).buffer;
 }
 
+/**
+ * @deprecated Use `new TextDecoder().decode(fileBuffer)` instead.
+ */
 export function fileBufferToString(fileBuffer: FileBuffer): string {
   if (fileBuffer.toString.length === 1) {
     return (fileBuffer.toString as (enc: string) => string)('utf-8');

--- a/packages/angular_devkit/core/src/virtual-fs/host/memory_spec.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/memory_spec.ts
@@ -8,7 +8,6 @@
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { fragment, normalize } from '../path';
-import { stringToFileBuffer } from './buffer';
 import { SimpleMemoryHost } from './memory';
 import { SyncDelegateHost } from './sync';
 
@@ -16,7 +15,7 @@ describe('SimpleMemoryHost', () => {
   it('can watch', () => {
     const host = new SyncDelegateHost(new SimpleMemoryHost());
 
-    host.write(normalize('/sub/file1'), stringToFileBuffer(''));
+    host.write(normalize('/sub/file1'), new TextEncoder().encode('').buffer);
 
     let recursiveCalled = 0;
     let noRecursiveCalled = 0;
@@ -28,14 +27,14 @@ describe('SimpleMemoryHost', () => {
     host.watch(normalize('/sub/file2'))!.subscribe(() => noRecursiveFileCalled++);
     host.watch(normalize('/sub/file3'))!.subscribe(() => diffFile++);
 
-    host.write(normalize('/sub/file2'), stringToFileBuffer(''));
+    host.write(normalize('/sub/file2'), new TextEncoder().encode('').buffer);
 
     expect(recursiveCalled).toBe(1);
     expect(noRecursiveCalled).toBe(0);
     expect(noRecursiveFileCalled).toBe(1);
     expect(diffFile).toBe(0);
 
-    host.write(normalize('/sub/file3'), stringToFileBuffer(''));
+    host.write(normalize('/sub/file3'), new TextEncoder().encode('').buffer);
 
     expect(recursiveCalled).toBe(2);
     expect(noRecursiveCalled).toBe(0);
@@ -46,7 +45,7 @@ describe('SimpleMemoryHost', () => {
   it('can read', () => {
     const host = new SyncDelegateHost(new SimpleMemoryHost());
 
-    const buffer = stringToFileBuffer('hello');
+    const buffer = new TextEncoder().encode('hello').buffer;
 
     host.write(normalize('/hello'), buffer);
     expect(host.read(normalize('/hello'))).toBe(buffer);
@@ -55,7 +54,7 @@ describe('SimpleMemoryHost', () => {
   it('can delete', () => {
     const host = new SyncDelegateHost(new SimpleMemoryHost());
 
-    const buffer = stringToFileBuffer('hello');
+    const buffer = new TextEncoder().encode('hello').buffer;
 
     expect(host.exists(normalize('/sub/file1'))).toBe(false);
     host.write(normalize('/sub/file1'), buffer);
@@ -67,7 +66,7 @@ describe('SimpleMemoryHost', () => {
   it('can delete directory', () => {
     const host = new SyncDelegateHost(new SimpleMemoryHost());
 
-    const buffer = stringToFileBuffer('hello');
+    const buffer = new TextEncoder().encode('hello').buffer;
 
     expect(host.exists(normalize('/sub/file1'))).toBe(false);
     host.write(normalize('/sub/file1'), buffer);
@@ -83,7 +82,7 @@ describe('SimpleMemoryHost', () => {
   it('can rename', () => {
     const host = new SyncDelegateHost(new SimpleMemoryHost());
 
-    const buffer = stringToFileBuffer('hello');
+    const buffer = new TextEncoder().encode('hello').buffer;
 
     expect(host.exists(normalize('/sub/file1'))).toBe(false);
     host.write(normalize('/sub/file1'), buffer);
@@ -97,7 +96,7 @@ describe('SimpleMemoryHost', () => {
   it('can list', () => {
     const host = new SyncDelegateHost(new SimpleMemoryHost());
 
-    const buffer = stringToFileBuffer('hello');
+    const buffer = new TextEncoder().encode('hello').buffer;
 
     host.write(normalize('/sub/file1'), buffer);
     host.write(normalize('/sub/file2'), buffer);
@@ -116,7 +115,7 @@ describe('SimpleMemoryHost', () => {
   it('supports isFile / isDirectory', () => {
     const host = new SyncDelegateHost(new SimpleMemoryHost());
 
-    const buffer = stringToFileBuffer('hello');
+    const buffer = new TextEncoder().encode('hello').buffer;
 
     host.write(normalize('/sub/file1'), buffer);
     host.write(normalize('/sub/file2'), buffer);
@@ -135,8 +134,8 @@ describe('SimpleMemoryHost', () => {
   it('makes every path absolute', () => {
     const host = new SyncDelegateHost(new SimpleMemoryHost());
 
-    const buffer = stringToFileBuffer('hello');
-    const buffer2 = stringToFileBuffer('hello 2');
+    const buffer = new TextEncoder().encode('hello').buffer;
+    const buffer2 = new TextEncoder().encode('hello 2').buffer;
 
     host.write(normalize('file1'), buffer);
     host.write(normalize('/sub/file2'), buffer);

--- a/packages/angular_devkit/core/src/virtual-fs/host/pattern_spec.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/pattern_spec.ts
@@ -7,14 +7,13 @@
  */
 
 import { normalize } from '..';
-import { stringToFileBuffer } from './buffer';
 import { SimpleMemoryHost } from './memory';
 import { PatternMatchingHost } from './pattern';
 
 describe('PatternMatchingHost', () => {
   it('works for NativeScript', () => {
-    const content = stringToFileBuffer('hello world');
-    const content2 = stringToFileBuffer('hello world 2');
+    const content = new TextEncoder().encode('hello world').buffer;
+    const content2 = new TextEncoder().encode('hello world 2').buffer;
 
     const host = new SimpleMemoryHost();
     host.write(normalize('/some/file.tns.ts'), content).subscribe();

--- a/packages/angular_devkit/core/src/virtual-fs/host/record_spec.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/record_spec.ts
@@ -7,7 +7,6 @@
  */
 
 import { path } from '../path';
-import { stringToFileBuffer } from './buffer';
 import { CordHost } from './record';
 import * as test from './test';
 
@@ -21,7 +20,7 @@ describe('CordHost', () => {
     });
 
     const host = new CordHost(base);
-    host.write(path`/blue`, stringToFileBuffer(`hi`)).subscribe(undefined, done.fail);
+    host.write(path`/blue`, new TextEncoder().encode(`hi`).buffer).subscribe(undefined, done.fail);
 
     const target = new TestHost();
     host.commit(target).subscribe(undefined, done.fail);
@@ -41,8 +40,10 @@ describe('CordHost', () => {
     });
 
     const host = new CordHost(base);
-    host.write(path`/blue`, stringToFileBuffer(`hi`)).subscribe(undefined, done.fail);
-    host.write(path`/blue`, stringToFileBuffer(`hi again`)).subscribe(undefined, done.fail);
+    host.write(path`/blue`, new TextEncoder().encode(`hi`).buffer).subscribe(undefined, done.fail);
+    host
+      .write(path`/blue`, new TextEncoder().encode(`hi again`).buffer)
+      .subscribe(undefined, done.fail);
 
     const target = new TestHost();
     host.commit(target).subscribe(undefined, done.fail);
@@ -63,7 +64,7 @@ describe('CordHost', () => {
     });
 
     const host = new CordHost(base);
-    host.write(path`/blue`, stringToFileBuffer(`hi`)).subscribe(undefined, done.fail);
+    host.write(path`/blue`, new TextEncoder().encode(`hi`).buffer).subscribe(undefined, done.fail);
     host.delete(path`/blue`).subscribe(undefined, done.fail);
 
     const target = new TestHost();
@@ -82,7 +83,7 @@ describe('CordHost', () => {
     });
 
     const host = new CordHost(base);
-    host.write(path`/blue`, stringToFileBuffer(`hi`)).subscribe(undefined, done.fail);
+    host.write(path`/blue`, new TextEncoder().encode(`hi`).buffer).subscribe(undefined, done.fail);
     host.rename(path`/blue`, path`/red`).subscribe(undefined, done.fail);
 
     const target = new TestHost();
@@ -106,7 +107,7 @@ describe('CordHost', () => {
     });
 
     const host = new CordHost(base);
-    host.write(path`/blue`, stringToFileBuffer(`hi`)).subscribe(undefined, done.fail);
+    host.write(path`/blue`, new TextEncoder().encode(`hi`).buffer).subscribe(undefined, done.fail);
     host.rename(path`/blue`, path`/blue`).subscribe(undefined, done.fail);
 
     const target = new TestHost();
@@ -129,7 +130,7 @@ describe('CordHost', () => {
     });
 
     const host = new CordHost(base);
-    host.write(path`/blue`, stringToFileBuffer(`hi`)).subscribe(undefined, done.fail);
+    host.write(path`/blue`, new TextEncoder().encode(`hi`).buffer).subscribe(undefined, done.fail);
     host.rename(path`/blue`, path`/red`).subscribe(undefined, done.fail);
     host.rename(path`/red`, path`/yellow`).subscribe(undefined, done.fail);
 
@@ -202,7 +203,9 @@ describe('CordHost', () => {
 
     const host = new CordHost(base);
     host.rename(path`/hello`, path`/blue`).subscribe(undefined, done.fail);
-    host.write(path`/hello`, stringToFileBuffer(`beautiful world`)).subscribe(undefined, done.fail);
+    host
+      .write(path`/hello`, new TextEncoder().encode(`beautiful world`).buffer)
+      .subscribe(undefined, done.fail);
 
     const target = base.clone();
     host.commit(target).subscribe(undefined, done.fail);
@@ -225,7 +228,9 @@ describe('CordHost', () => {
     });
 
     const host = new CordHost(base);
-    host.write(path`/hello`, stringToFileBuffer(`beautiful world`)).subscribe(undefined, done.fail);
+    host
+      .write(path`/hello`, new TextEncoder().encode(`beautiful world`).buffer)
+      .subscribe(undefined, done.fail);
 
     const target = base.clone();
     host.commit(target).subscribe(undefined, done.fail);
@@ -247,8 +252,12 @@ describe('CordHost', () => {
     });
 
     const host = new CordHost(base);
-    host.write(path`/hello`, stringToFileBuffer(`beautiful world`)).subscribe(undefined, done.fail);
-    host.write(path`/hello`, stringToFileBuffer(`again`)).subscribe(undefined, done.fail);
+    host
+      .write(path`/hello`, new TextEncoder().encode(`beautiful world`).buffer)
+      .subscribe(undefined, done.fail);
+    host
+      .write(path`/hello`, new TextEncoder().encode(`again`).buffer)
+      .subscribe(undefined, done.fail);
 
     const target = base.clone();
     host.commit(target).subscribe(undefined, done.fail);
@@ -270,7 +279,9 @@ describe('CordHost', () => {
     });
 
     const host = new CordHost(base);
-    host.write(path`/hello`, stringToFileBuffer(`beautiful world`)).subscribe(undefined, done.fail);
+    host
+      .write(path`/hello`, new TextEncoder().encode(`beautiful world`).buffer)
+      .subscribe(undefined, done.fail);
     host.rename(path`/hello`, path`/blue`).subscribe(undefined, done.fail);
 
     const target = base.clone();
@@ -294,7 +305,9 @@ describe('CordHost', () => {
     });
 
     const host = new CordHost(base);
-    host.write(path`/hello`, stringToFileBuffer(`beautiful world`)).subscribe(undefined, done.fail);
+    host
+      .write(path`/hello`, new TextEncoder().encode(`beautiful world`).buffer)
+      .subscribe(undefined, done.fail);
     host.delete(path`/hello`).subscribe(undefined, done.fail);
 
     const target = base.clone();
@@ -315,7 +328,9 @@ describe('CordHost', () => {
 
     const host = new CordHost(base);
     host.rename(path`/hello`, path`/blue`).subscribe(undefined, done.fail);
-    host.write(path`/blue`, stringToFileBuffer(`beautiful world`)).subscribe(undefined, done.fail);
+    host
+      .write(path`/blue`, new TextEncoder().encode(`beautiful world`).buffer)
+      .subscribe(undefined, done.fail);
 
     const target = base.clone();
     host.commit(target).subscribe(undefined, done.fail);
@@ -358,7 +373,9 @@ describe('CordHost', () => {
 
     const host = new CordHost(base);
     host.delete(path`/hello`).subscribe(undefined, done.fail);
-    host.write(path`/hello`, stringToFileBuffer(`beautiful world`)).subscribe(undefined, done.fail);
+    host
+      .write(path`/hello`, new TextEncoder().encode(`beautiful world`).buffer)
+      .subscribe(undefined, done.fail);
 
     const target = base.clone();
     host.commit(target).subscribe(undefined, done.fail);
@@ -420,7 +437,7 @@ describe('CordHost', () => {
     });
 
     const host = new CordHost(base);
-    host.write(path`/blue`, stringToFileBuffer(`hi`)).subscribe();
+    host.write(path`/blue`, new TextEncoder().encode(`hi`).buffer).subscribe();
 
     const target = new TestHost({
       '/blue': 'test',
@@ -441,7 +458,7 @@ describe('CordHost', () => {
     });
 
     const host = new CordHost(base);
-    host.write(path`/hello`, stringToFileBuffer(`hi`)).subscribe();
+    host.write(path`/hello`, new TextEncoder().encode(`hi`).buffer).subscribe();
 
     const target = new TestHost({});
 
@@ -501,7 +518,7 @@ describe('CordHost', () => {
 
     const host = new CordHost(base);
     let error = false;
-    host.write(path`/dir`, stringToFileBuffer(`beautiful world`)).subscribe(
+    host.write(path`/dir`, new TextEncoder().encode(`beautiful world`).buffer).subscribe(
       undefined,
       () => (error = true),
       () => (error = false),

--- a/packages/angular_devkit/core/src/virtual-fs/host/test.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/test.ts
@@ -8,7 +8,6 @@
 
 import { Observable } from 'rxjs';
 import { Path, PathFragment, join, normalize } from '../path';
-import { fileBufferToString, stringToFileBuffer } from './buffer';
 import { FileBuffer, HostWatchEvent, HostWatchOptions, Stats } from './interface';
 import { SimpleMemoryHost, SimpleMemoryHostStats } from './memory';
 import { SyncDelegateHost } from './sync';
@@ -41,7 +40,7 @@ export class TestHost extends SimpleMemoryHost {
     super();
 
     for (const filePath of Object.getOwnPropertyNames(map)) {
-      this._write(normalize(filePath), stringToFileBuffer(map[filePath]));
+      this._write(normalize(filePath), new TextEncoder().encode(map[filePath]).buffer);
     }
   }
 
@@ -138,11 +137,11 @@ export class TestHost extends SimpleMemoryHost {
   }
 
   $write(path: string, content: string): void {
-    return super._write(normalize(path), stringToFileBuffer(content));
+    return super._write(normalize(path), new TextEncoder().encode(content).buffer);
   }
 
   $read(path: string): string {
-    return fileBufferToString(super._read(normalize(path)));
+    return new TextDecoder().decode(super._read(normalize(path)));
   }
 
   $list(path: string): PathFragment[] {

--- a/packages/angular_devkit/core/src/workspace/host.ts
+++ b/packages/angular_devkit/core/src/workspace/host.ts
@@ -21,14 +21,17 @@ export interface WorkspaceHost {
 }
 
 export function createWorkspaceHost(host: virtualFs.Host): WorkspaceHost {
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+
   const workspaceHost: WorkspaceHost = {
     async readFile(path: string): Promise<string> {
       const data = await lastValueFrom(host.read(normalize(path)));
 
-      return virtualFs.fileBufferToString(data);
+      return decoder.decode(data);
     },
     async writeFile(path: string, data: string): Promise<void> {
-      return lastValueFrom(host.write(normalize(path), virtualFs.stringToFileBuffer(data)));
+      return lastValueFrom(host.write(normalize(path), encoder.encode(data).buffer));
     },
     async isDirectory(path: string): Promise<boolean> {
       try {

--- a/packages/angular_devkit/schematics/src/sink/dryrun_spec.ts
+++ b/packages/angular_devkit/schematics/src/sink/dryrun_spec.ts
@@ -64,7 +64,7 @@ describe('DryRunSink', () => {
 
     // Need to create this file on the filesystem, otherwise the commit phase will fail.
     const outputHost = new virtualFs.SimpleMemoryHost();
-    outputHost.write(normalize('/hello'), virtualFs.stringToFileBuffer('')).subscribe();
+    outputHost.write(normalize('/hello'), new Uint8Array(0).buffer).subscribe();
 
     const sink = new DryRunSink(outputHost);
     const [infos] = await Promise.all([

--- a/packages/angular_devkit/schematics/src/sink/host_spec.ts
+++ b/packages/angular_devkit/schematics/src/sink/host_spec.ts
@@ -108,7 +108,7 @@ describe('FileSystemSink', () => {
       const sink = new HostSink(host);
       await sink.commit(tree).toPromise();
       expect(host.sync.read(normalize('/file0')).toString()).toBe('hello');
-      expect(virtualFs.fileBufferToString(host.sync.read(normalize('/file1')))).toBe('world');
+      expect(new TextDecoder().decode(host.sync.read(normalize('/file1')))).toBe('world');
     });
 
     it('can rename then modify the same file', async () => {
@@ -125,7 +125,7 @@ describe('FileSystemSink', () => {
 
       const sink = new HostSink(host);
       await sink.commit(tree).toPromise();
-      expect(virtualFs.fileBufferToString(host.sync.read(normalize('/file1')))).toBe('hello');
+      expect(new TextDecoder().decode(host.sync.read(normalize('/file1')))).toBe('hello');
     });
   });
 });


### PR DESCRIPTION
DEPRECATED: `stringToFileBuffer` and `fileBufferToString` are deprecated. Use standard Web APIs (`TextEncoder` and `TextDecoder`) instead.

Internal usages within the repository have been removed and replaced with standard Web APIs. The public API golden file for `@angular-devkit/core` has been updated to reflect the deprecations.