### PR TITLE
ci: update Renovate base branch patterns to 22.0.x

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "baseBranchPatterns": ["main", "21.2.x"],
+  "baseBranchPatterns": ["main", "22.0.x"],
   "extends": ["github>angular/dev-infra//renovate-presets/default.json5"],
   "ignorePaths": ["tests/e2e/assets/**", "tests/schematics/update/packages/**"],
   "packageRules": [


### PR DESCRIPTION
This should have been done by the release process but it failed.
