### PR TITLE
fix(@angular/ssr): support all X-Forwarded-* headers when trustProxyHeaders is true

### DIFF
--- a/packages/angular/ssr/src/utils/validation.ts
+++ b/packages/angular/ssr/src/utils/validation.ts
@@ -9,7 +9,7 @@
 /**
  * Internal sentinel string representing a wildcard rule to trust all proxy headers.
  */
-const TRUST_ALL_PROXY_HEADERS = 'ɵ*';
+const TRUST_ALL_PROXY_HEADERS = '*';
 
 /**
  * The set of headers that should be validated for host header injection attacks.
@@ -251,5 +251,12 @@ export function normalizeTrustProxyHeaders(
     return new Set([TRUST_ALL_PROXY_HEADERS]);
   }
 
-  return new Set(trustProxyHeaders.map((h) => h.toLowerCase()));
+  const normalizedTrustedProxyHeaders = new Set(trustProxyHeaders.map((h) => h.toLowerCase()));
+  if (normalizedTrustedProxyHeaders.has(TRUST_ALL_PROXY_HEADERS)) {
+    throw new Error(
+      `"${TRUST_ALL_PROXY_HEADERS}" is not allowed as a value for the "trustProxyHeaders" option.`,
+    );
+  }
+
+  return normalizedTrustedProxyHeaders;
 }

--- a/packages/angular/ssr/src/utils/validation.ts
+++ b/packages/angular/ssr/src/utils/validation.ts
@@ -7,15 +7,9 @@
  */
 
 /**
- * Common X-Forwarded-* headers.
+ * Internal sentinel string representing a wildcard rule to trust all proxy headers.
  */
-const X_FORWARDED_HEADERS: ReadonlySet<string> = new Set([
-  'x-forwarded-for',
-  'x-forwarded-host',
-  'x-forwarded-port',
-  'x-forwarded-proto',
-  'x-forwarded-prefix',
-]);
+const TRUST_ALL_PROXY_HEADERS = 'ɵ*';
 
 /**
  * The set of headers that should be validated for host header injection attacks.
@@ -235,7 +229,10 @@ export function isProxyHeaderAllowed(
   headerName: string,
   trustProxyHeaders: ReadonlySet<string>,
 ): boolean {
-  return trustProxyHeaders.has(headerName.toLowerCase());
+  return (
+    trustProxyHeaders.has(TRUST_ALL_PROXY_HEADERS) ||
+    trustProxyHeaders.has(headerName.toLowerCase())
+  );
 }
 
 /**
@@ -251,7 +248,7 @@ export function normalizeTrustProxyHeaders(
   }
 
   if (trustProxyHeaders === true) {
-    return X_FORWARDED_HEADERS;
+    return new Set([TRUST_ALL_PROXY_HEADERS]);
   }
 
   return new Set(trustProxyHeaders.map((h) => h.toLowerCase()));

--- a/packages/angular/ssr/test/utils/validation_spec.ts
+++ b/packages/angular/ssr/test/utils/validation_spec.ts
@@ -8,6 +8,7 @@
 
 import {
   getFirstHeaderValue,
+  normalizeTrustProxyHeaders,
   sanitizeRequestHeaders,
   validateRequest,
   validateUrl,
@@ -224,15 +225,29 @@ describe('Validation Utils', () => {
           'x-forwarded-proto': 'https',
         },
       });
-      const secured = sanitizeRequestHeaders(req, new Set());
+      const secured = sanitizeRequestHeaders(req, normalizeTrustProxyHeaders(undefined));
 
       expect(secured.headers.get('host')).toBe('example.com');
       expect(secured.headers.has('x-forwarded-host')).toBeFalse();
       expect(secured.headers.has('x-forwarded-proto')).toBeFalse();
     });
 
-    it('should retain allowed proxy headers when explicitly provided', () => {
-      const trustProxyHeaders = new Set(['x-forwarded-host']);
+    it('should scrub unallowed proxy headers when trustProxyHeaders is false', () => {
+      const req = new Request('http://example.com', {
+        headers: {
+          'host': 'example.com',
+          'x-forwarded-host': 'evil.com',
+          'x-forwarded-proto': 'https',
+        },
+      });
+      const secured = sanitizeRequestHeaders(req, normalizeTrustProxyHeaders(false));
+
+      expect(secured.headers.get('host')).toBe('example.com');
+      expect(secured.headers.has('x-forwarded-host')).toBeFalse();
+      expect(secured.headers.has('x-forwarded-proto')).toBeFalse();
+    });
+
+    it('should only retain allowed proxy headers when explicitly provided', () => {
       const req = new Request('http://example.com', {
         headers: {
           'host': 'example.com',
@@ -240,7 +255,7 @@ describe('Validation Utils', () => {
           'x-forwarded-proto': 'https',
         },
       });
-      const secured = sanitizeRequestHeaders(req, trustProxyHeaders);
+      const secured = sanitizeRequestHeaders(req, normalizeTrustProxyHeaders(['x-forwarded-host']));
 
       expect(secured.headers.get('host')).toBe('example.com');
       expect(secured.headers.get('x-forwarded-host')).toBe('proxy.com');
@@ -253,23 +268,22 @@ describe('Validation Utils', () => {
           'host': 'example.com',
           'x-forwarded-host': 'proxy.com',
           'x-forwarded-proto': 'https',
+          'x-forwarded-email': 'user@example.com',
         },
       });
-      const secured = sanitizeRequestHeaders(
-        req,
-        new Set(['x-forwarded-host', 'x-forwarded-proto']),
-      );
+      const secured = sanitizeRequestHeaders(req, normalizeTrustProxyHeaders(true));
 
       expect(secured.headers.get('host')).toBe('example.com');
       expect(secured.headers.get('x-forwarded-host')).toBe('proxy.com');
       expect(secured.headers.get('x-forwarded-proto')).toBe('https');
+      expect(secured.headers.get('x-forwarded-email')).toBe('user@example.com');
     });
 
     it('should not clone the request if no proxy headers need to be removed', () => {
       const req = new Request('http://example.com', {
         headers: { 'accept': 'application/json' },
       });
-      const secured = sanitizeRequestHeaders(req, new Set());
+      const secured = sanitizeRequestHeaders(req, normalizeTrustProxyHeaders(false));
 
       expect(secured).toBe(req);
       expect(secured.headers.get('accept')).toBe('application/json');

--- a/packages/angular/ssr/test/utils/validation_spec.ts
+++ b/packages/angular/ssr/test/utils/validation_spec.ts
@@ -38,6 +38,35 @@ describe('Validation Utils', () => {
     });
   });
 
+  describe('normalizeTrustProxyHeaders', () => {
+    it('should return an empty set when input is undefined', () => {
+      expect(normalizeTrustProxyHeaders(undefined)).toEqual(new Set());
+    });
+
+    it('should return an empty set when input is false', () => {
+      expect(normalizeTrustProxyHeaders(false)).toEqual(new Set());
+    });
+
+    it('should return a set containing "*" when input is true', () => {
+      expect(normalizeTrustProxyHeaders(true)).toEqual(new Set(['*']));
+    });
+
+    it('should return a set of lowercased header names when input is an array of strings', () => {
+      expect(normalizeTrustProxyHeaders(['X-Forwarded-Host', 'X-Forwarded-Proto'])).toEqual(
+        new Set(['x-forwarded-host', 'x-forwarded-proto']),
+      );
+    });
+
+    it('should throw an error if input array contains "*"', () => {
+      expect(() => normalizeTrustProxyHeaders(['*'])).toThrowError(
+        '"*" is not allowed as a value for the "trustProxyHeaders" option.',
+      );
+      expect(() => normalizeTrustProxyHeaders(['X-Forwarded-Host', '*'])).toThrowError(
+        '"*" is not allowed as a value for the "trustProxyHeaders" option.',
+      );
+    });
+  });
+
   describe('validateUrl', () => {
     const allowedHosts = new Set(['example.com', '*.google.com']);
 


### PR DESCRIPTION


Previously, setting `trustProxyHeaders: true` only allowed a predefined set of common proxy headers (such as `x-forwarded-for` and `x-forwarded-host`). This resulted in warning logs when requests contained other valid proxy headers like `x-forwarded-client-cert` or `x-forwarded-email`.

Closes #33169
