### PR TITLE
test(@angular-devkit/build-webpack): remove unused createConsoleLogger usage

### DIFF
--- a/goldens/public-api/angular_devkit/core/node/index.api.md
+++ b/goldens/public-api/angular_devkit/core/node/index.api.md
@@ -11,7 +11,7 @@ import { Stats as Stats_2 } from 'node:fs';
 import { Subject } from 'rxjs';
 import { Subscription } from 'rxjs';
 
-// @public
+// @public @deprecated
 export function createConsoleLogger(verbose?: boolean, stdout?: ProcessOutput, stderr?: ProcessOutput, colors?: Partial<Record<logging.LogLevel, (s: string) => string>>): logging.Logger;
 
 // @public

--- a/packages/angular_devkit/build_webpack/src/builders/webpack/index_spec.ts
+++ b/packages/angular_devkit/build_webpack/src/builders/webpack/index_spec.ts
@@ -10,9 +10,8 @@ import { Architect } from '@angular-devkit/architect';
 import { WorkspaceNodeModulesArchitectHost } from '@angular-devkit/architect/node';
 import { TestingArchitectHost } from '@angular-devkit/architect/testing';
 import { join, normalize, schema, workspaces } from '@angular-devkit/core';
-import { NodeJsSyncHost, createConsoleLogger } from '@angular-devkit/core/node';
+import { NodeJsSyncHost } from '@angular-devkit/core/node';
 import * as path from 'node:path';
-import { BuildResult } from './index';
 
 describe('Webpack Builder basic test', () => {
   let testArchitectHost: TestingArchitectHost;
@@ -99,11 +98,7 @@ describe('Webpack Builder basic test', () => {
     });
 
     it('works', async () => {
-      const run = await architect.scheduleTarget(
-        { project: 'app', target: 'build-webpack' },
-        {},
-        { logger: createConsoleLogger() },
-      );
+      const run = await architect.scheduleTarget({ project: 'app', target: 'build-webpack' });
       const output = await run.result;
 
       expect(output.success).toBe(true);

--- a/packages/angular_devkit/core/node/cli-logger.ts
+++ b/packages/angular_devkit/core/node/cli-logger.ts
@@ -15,6 +15,8 @@ export interface ProcessOutput {
 
 /**
  * A Logger that sends information to STDOUT and STDERR.
+ *
+ * @deprecated Use a custom logger implementation instead.
  */
 export function createConsoleLogger(
   verbose = false,


### PR DESCRIPTION
Removes the last usage of `createConsoleLogger` in the repository from the webpack builder tests. This makes the test consistent with others in the file and allows for potential removal of the function.