### PR TITLE
build: bump devkit-repo version to 22.1.0-next.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/devkit-repo",
-  "version": "22.0.0-next.8",
+  "version": "22.1.0-next.0",
   "private": true,
   "description": "Software Development Kit for Angular",
   "keywords": [


### PR DESCRIPTION
This was not correctly bumped during the release process.
