### PR TITLE
fix(@angular/ssr): allow all hosts in common engine rendering options to prevent validation errors

### DIFF
--- a/packages/angular/ssr/node/src/common-engine/common-engine.ts
+++ b/packages/angular/ssr/node/src/common-engine/common-engine.ts
@@ -207,6 +207,8 @@ export class CommonEngine {
     const commonRenderingOptions = {
       url: opts.url,
       document,
+      // Validation is already happened in the render method.
+      allowedHosts: ['*'],
     };
 
     return isBootstrapFn(moduleOrFactory)


### PR DESCRIPTION


This is needed due to the https://github.com/angular/angular/pull/68593
