### PR TITLE
refactor(@angular/build): remove unused target parameter from getFeatureSupport

### DIFF
--- a/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
@@ -67,7 +67,7 @@ export function createBrowserCodeBundleOptions(
       entryNames: outputNames.bundles,
       entryPoints,
       target,
-      supported: getFeatureSupport(target, zoneless),
+      supported: getFeatureSupport(zoneless),
     };
 
     buildOptions.plugins ??= [];
@@ -278,7 +278,7 @@ export function createServerMainCodeBundleOptions(
         js: `import './polyfills.server.mjs';`,
       },
       entryPoints,
-      supported: getFeatureSupport(target, zoneless),
+      supported: getFeatureSupport(zoneless),
     };
 
     buildOptions.plugins ??= [];
@@ -423,7 +423,7 @@ export function createSsrEntryCodeBundleOptions(
       entryPoints: {
         'server': ssrEntryNamespace,
       },
-      supported: getFeatureSupport(target, true),
+      supported: getFeatureSupport(true),
     };
 
     buildOptions.plugins ??= [];

--- a/packages/angular/build/src/tools/esbuild/utils.ts
+++ b/packages/angular/build/src/tools/esbuild/utils.ts
@@ -187,16 +187,12 @@ export async function withNoProgress<T>(text: string, action: () => T | Promise<
 }
 
 /**
- * Generates a syntax feature object map for Angular applications based on a list of targets.
+ * Generates a syntax feature object map for Angular applications.
  * A full set of feature names can be found here: https://esbuild.github.io/api/#supported
- * @param target An array of browser/engine targets in the format accepted by the esbuild `target` option.
  * @param nativeAsyncAwait Indicate whether to support native async/await.
  * @returns An object that can be used with the esbuild build `supported` option.
  */
-export function getFeatureSupport(
-  target: string[],
-  nativeAsyncAwait: boolean,
-): BuildOptions['supported'] {
+export function getFeatureSupport(nativeAsyncAwait: boolean): BuildOptions['supported'] {
   return {
     // Native async/await is not supported with Zone.js. Disabling support here will cause
     // esbuild to downlevel async/await, async generators, and for await...of to a Zone.js supported form.

--- a/packages/angular/build/src/tools/vite/utils.ts
+++ b/packages/angular/build/src/tools/vite/utils.ts
@@ -100,7 +100,7 @@ export function getDepOptimizationConfig({
     esbuildOptions: {
       // Set esbuild supported targets.
       target,
-      supported: getFeatureSupport(target, zoneless),
+      supported: getFeatureSupport(zoneless),
       plugins,
       loader,
       define: {


### PR DESCRIPTION


The `target` parameter in the `getFeatureSupport` function is no longer used internally, so it has been removed to simplify the function signature and call sites.
