### PR TITLE
build: add package metadata to `@angular/ssr` package.json

### DIFF
--- a/packages/angular/ssr/package.json
+++ b/packages/angular/ssr/package.json
@@ -8,6 +8,16 @@
     "ssr",
     "universal"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/angular/angular-cli.git"
+  },
+  "author": "Angular Authors",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/angular/angular-cli/issues"
+  },
+  "homepage": "https://github.com/angular/angular-cli",
   "ng-add": {
     "save": "dependencies"
   },


### PR DESCRIPTION
Unlike ng_package doesn't add these fields.
