### PR TITLE
fix(@angular/build): Proper shutdown of esbuild workers

### DIFF
--- a/packages/angular/build/src/builders/application/build-action.ts
+++ b/packages/angular/build/src/builders/application/build-action.ts
@@ -9,6 +9,7 @@
 import { BuilderContext } from '@angular-devkit/architect';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
+import { shutdownEsbuild } from '../../tools/esbuild/bundler-context';
 import { ExecutionResult, RebuildState } from '../../tools/esbuild/bundler-execution-result';
 import { BuildOutputFile, BuildOutputFileType } from '../../tools/esbuild/bundler-files';
 import { shutdownSassWorkerPool } from '../../tools/esbuild/stylesheets/sass-language';
@@ -89,9 +90,10 @@ export async function* runEsBuildBuildAction(
     // Log all diagnostic (error/warning/logs) messages
     await logMessages(logger, result, colors, jsonLogs);
   } finally {
-    // Ensure Sass workers are shutdown if not watching
+    // Ensure workers are shutdown if not watching
     if (!watch) {
       shutdownSassWorkerPool();
+      await shutdownEsbuild();
     }
   }
 
@@ -219,6 +221,7 @@ export async function* runEsBuildBuildAction(
     await Promise.allSettled([watcher.close(), result.dispose()]);
 
     shutdownSassWorkerPool();
+    await shutdownEsbuild();
   }
 }
 

--- a/packages/angular/build/src/tools/esbuild/bundler-context.ts
+++ b/packages/angular/build/src/tools/esbuild/bundler-context.ts
@@ -16,6 +16,7 @@ import {
   OutputFile,
   build,
   context,
+  stop,
 } from 'esbuild';
 import assert from 'node:assert';
 import { builtinModules } from 'node:module';
@@ -55,6 +56,10 @@ export type BundlerOptionsFactory<T extends BuildOptions = BuildOptions> = (
  */
 function isEsBuildFailure(value: unknown): value is BuildFailure {
   return !!value && typeof value === 'object' && 'errors' in value && 'warnings' in value;
+}
+
+export function shutdownEsbuild(): Promise<void> {
+  return stop();
 }
 
 export class BundlerContext {


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  #33201

## What is the new behavior?

esbuild is now correctly shutdown after the Angular application build flow. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
