### PR TITLE
fix(@schematics/angular): support spy call arguments migration in refactor-jasmine-vitest

### DIFF
--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-spy.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-spy.ts
@@ -505,6 +505,53 @@ function transformThisFor(
   );
 }
 
+function transformAllCallsArgs(
+  node: ts.Node,
+  { sourceFile, reporter, pendingVitestValueImports }: RefactorContext,
+): ts.Node {
+  if (
+    !ts.isPropertyAccessExpression(node) ||
+    !ts.isIdentifier(node.name) ||
+    node.name.text !== 'args'
+  ) {
+    return node;
+  }
+
+  const elementAccess = node.expression;
+  if (!ts.isElementAccessExpression(elementAccess)) {
+    return node;
+  }
+
+  const allCall = elementAccess.expression;
+  if (!ts.isCallExpression(allCall) || !ts.isPropertyAccessExpression(allCall.expression)) {
+    return node;
+  }
+
+  const allPae = allCall.expression;
+  if (!ts.isIdentifier(allPae.name) || allPae.name.text !== 'all') {
+    return node;
+  }
+
+  if (!ts.isPropertyAccessExpression(allPae.expression)) {
+    return node;
+  }
+
+  const spyIdentifier = getSpyIdentifierFromCalls(allPae.expression);
+  if (!spyIdentifier) {
+    return node;
+  }
+
+  reporter.reportTransformation(
+    sourceFile,
+    node,
+    'Transformed `spy.calls.all()[i].args` to `vi.mocked(spy).mock.calls[i]`.',
+  );
+  const mockProperty = createMockedSpyMockProperty(spyIdentifier, pendingVitestValueImports);
+  const callsProperty = createPropertyAccess(mockProperty, 'calls');
+
+  return ts.factory.createElementAccessExpression(callsProperty, elementAccess.argumentExpression);
+}
+
 export function transformSpyCallInspection(node: ts.Node, refactorCtx: RefactorContext): ts.Node {
   const mostRecentArgsTransformed = transformMostRecentArgs(node, refactorCtx);
   if (mostRecentArgsTransformed !== node) {
@@ -514,6 +561,11 @@ export function transformSpyCallInspection(node: ts.Node, refactorCtx: RefactorC
   const thisForTransformed = transformThisFor(node, refactorCtx);
   if (thisForTransformed !== node) {
     return thisForTransformed;
+  }
+
+  const allCallsArgsTransformed = transformAllCallsArgs(node, refactorCtx);
+  if (allCallsArgsTransformed !== node) {
+    return allCallsArgsTransformed;
   }
 
   if (!ts.isCallExpression(node) || !ts.isPropertyAccessExpression(node.expression)) {

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-spy_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-spy_spec.ts
@@ -271,6 +271,11 @@ describe('transformSpyCallInspection', () => {
       expected: `const allCalls = vi.mocked(mySpy).mock.calls;`,
     },
     {
+      description: 'should transform spy.calls.all()[i].args',
+      input: `expect(mySpy.calls.all()[2].args[0]).toBeInstanceOf(RemoveShareUrlAction);`,
+      expected: `expect(vi.mocked(mySpy).mock.calls[2][0]).toBeInstanceOf(RemoveShareUrlAction);`,
+    },
+    {
       description: 'should transform spy.calls.mostRecent().args',
       input: `const recentArgs = mySpy.calls.mostRecent().args;`,
       expected: `const recentArgs = vi.mocked(mySpy).mock.lastCall;`,


### PR DESCRIPTION
The `refactor-jasmine-vitest` schematic fails to remove `.args` when migrating `spy.calls.all()[i].args`, resulting in uncompilable code in Vitest.

Now, a specialized transformer detects `spy.calls.all()[i].args` and transforms it to `vi.mocked(spy).mock.calls[i]`, removing the unnecessary `.args` property access.

Fixes #33112