### PR TITLE
refactor(@angular/build): add missing `OutputFile` import

### DIFF
--- a/packages/angular/build/src/tools/esbuild/bundler-context.ts
+++ b/packages/angular/build/src/tools/esbuild/bundler-context.ts
@@ -13,6 +13,7 @@ import {
   BuildResult,
   Message,
   Metafile,
+  OutputFile,
   build,
   context,
 } from 'esbuild';


### PR DESCRIPTION
The cherry pick of b06849a939948c92c139c218f34ea68d0ba28112 onto the patch branch seems to have removed an import which was still needed.

TBH, I'm not 100% how exactly we ended up in this situation, but adding an import seems like the clear fix.