### PR TITLE
docs: add comma in README intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 
 ## Documentation
 
-Get started with Angular CLI, learn the fundamentals and explore advanced topics on our documentation website.
+Get started with Angular CLI, learn the fundamentals, and explore advanced topics on our documentation website.
 
 - [Getting started][quickstart]
 - [CLI][cli]


### PR DESCRIPTION
Tiny documentation punctuation fix for workflow approval probing.