### PR TITLE
build: update minimum Node.js 24 version to 24.15.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -66,15 +66,15 @@ node_dev = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node", dev_dep
 node_dev.toolchain(
     name = "node22",
     node_repositories = {
-        "22.22.0-darwin_arm64": ("node-v22.22.0-darwin-arm64.tar.gz", "node-v22.22.0-darwin-arm64", "5ed4db0fcf1eaf84d91ad12462631d73bf4576c1377e192d222e48026a902640"),
-        "22.22.0-darwin_amd64": ("node-v22.22.0-darwin-x64.tar.gz", "node-v22.22.0-darwin-x64", "5ea50c9d6dea3dfa3abb66b2656f7a4e1c8cef23432b558d45fb538c7b5dedce"),
-        "22.22.0-linux_arm64": ("node-v22.22.0-linux-arm64.tar.xz", "node-v22.22.0-linux-arm64", "1bf1eb9ee63ffc4e5d324c0b9b62cf4a289f44332dfef9607cea1a0d9596ba6f"),
-        "22.22.0-linux_ppc64le": ("node-v22.22.0-linux-ppc64le.tar.xz", "node-v22.22.0-linux-ppc64le", "d83b9957431cc18e1fc143a4b99f89cde7b8a18f53ef392231b4336afd058865"),
-        "22.22.0-linux_s390x": ("node-v22.22.0-linux-s390x.tar.xz", "node-v22.22.0-linux-s390x", "5aa0e520689448c4233e8d73f284e8e0634fdcd32b479735698494be5641f3e4"),
-        "22.22.0-linux_amd64": ("node-v22.22.0-linux-x64.tar.xz", "node-v22.22.0-linux-x64", "9aa8e9d2298ab68c600bd6fb86a6c13bce11a4eca1ba9b39d79fa021755d7c37"),
-        "22.22.0-windows_amd64": ("node-v22.22.0-win-x64.zip", "node-v22.22.0-win-x64", "c97fa376d2becdc8863fcd3ca2dd9a83a9f3468ee7ccf7a6d076ec66a645c77a"),
+        "22.22.3-darwin_arm64": ("node-v22.22.3-darwin-arm64.tar.gz", "node-v22.22.3-darwin-arm64", "0da7ff74ef8611328c8212f17943368713a2ad953fb7d89a8c8a0eae87c23207"),
+        "22.22.3-darwin_amd64": ("node-v22.22.3-darwin-x64.tar.gz", "node-v22.22.3-darwin-x64", "45830ba752fa0d892c6dcd640946669801293cac820a33591ded40ac075198ec"),
+        "22.22.3-linux_arm64": ("node-v22.22.3-linux-arm64.tar.xz", "node-v22.22.3-linux-arm64", "1c4a9933a5e45bc88f54f70b5f91232c127ec49f1a5989d23fb85824c7adf9b7"),
+        "22.22.3-linux_ppc64le": ("node-v22.22.3-linux-ppc64le.tar.xz", "node-v22.22.3-linux-ppc64le", "edb5478071bd1375e80195ca52f72823998bb5141b1a09e68bc54b3e2eb67754"),
+        "22.22.3-linux_s390x": ("node-v22.22.3-linux-s390x.tar.xz", "node-v22.22.3-linux-s390x", "ce398c057830d57a24c458177279a17bc51742d5c22dd4cbe97b10dbd43f2617"),
+        "22.22.3-linux_amd64": ("node-v22.22.3-linux-x64.tar.xz", "node-v22.22.3-linux-x64", "2e5d13569282d016861fae7c8f935e741693c269101a5bebcf761a5376d1f99f"),
+        "22.22.3-windows_amd64": ("node-v22.22.3-win-x64.zip", "node-v22.22.3-win-x64", "6c8d54f635feff4df76c2ca80f45332eb2ff57d25226edce36592e51a177ee33"),
     },
-    node_version = "22.22.0",
+    node_version = "22.22.3",
 )
 
 # Node.js 24

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -81,15 +81,15 @@ node_dev.toolchain(
 node_dev.toolchain(
     name = "node24",
     node_repositories = {
-        "24.13.1-darwin_arm64": ("node-v24.13.1-darwin-arm64.tar.gz", "node-v24.13.1-darwin-arm64", "8c039d59f2fec6195e4281ad5b0d02b9a940897b4df7b849c6fb48be6787bba6"),
-        "24.13.1-darwin_amd64": ("node-v24.13.1-darwin-x64.tar.gz", "node-v24.13.1-darwin-x64", "527f0578d9812e7dfa225121bda0b1546a6a0e4b5f556295fc8299c272de5fbf"),
-        "24.13.1-linux_arm64": ("node-v24.13.1-linux-arm64.tar.xz", "node-v24.13.1-linux-arm64", "c827d3d301e2eed1a51f36d0116b71b9e3d9e3b728f081615270ea40faac34c1"),
-        "24.13.1-linux_ppc64le": ("node-v24.13.1-linux-ppc64le.tar.xz", "node-v24.13.1-linux-ppc64le", "fb712a08d317655dbf776c90f60ac2105109d802e33811df6c9ed33d12f801c6"),
-        "24.13.1-linux_s390x": ("node-v24.13.1-linux-s390x.tar.xz", "node-v24.13.1-linux-s390x", "8e2c0d9b5545c3db22623e8cb8d6f0c28fcd470f29d32dbeabf9432dda289de2"),
-        "24.13.1-linux_amd64": ("node-v24.13.1-linux-x64.tar.xz", "node-v24.13.1-linux-x64", "30215f90ea3cd04dfbc06e762c021393fa173a1d392974298bbc871a8e461089"),
-        "24.13.1-windows_amd64": ("node-v24.13.1-win-x64.zip", "node-v24.13.1-win-x64", "fba577c4bb87df04d54dd87bbdaa5a2272f1f99a2acbf9152e1a91b8b5f0b279"),
+        "24.15.0-darwin_arm64": ("node-v24.15.0-darwin-arm64.tar.gz", "node-v24.15.0-darwin-arm64", "372331b969779ab5d15b949884fc6eaf88d5afe87bde8ba881d6400b9100ffc4"),
+        "24.15.0-darwin_amd64": ("node-v24.15.0-darwin-x64.tar.gz", "node-v24.15.0-darwin-x64", "ffd5ee293467927f3ee731a553eb88fd1f48cf74eebc2d74a6babe4af228673b"),
+        "24.15.0-linux_arm64": ("node-v24.15.0-linux-arm64.tar.xz", "node-v24.15.0-linux-arm64", "f3d5a797b5d210ce8e2cb265544c8e482eaedcb8aa409a8b46da7e8595d0dda0"),
+        "24.15.0-linux_ppc64le": ("node-v24.15.0-linux-ppc64le.tar.xz", "node-v24.15.0-linux-ppc64le", "6a6560a27bd2817013c28c3d917bfe9eebf26bbd4b1d88475190f216cc411fbb"),
+        "24.15.0-linux_s390x": ("node-v24.15.0-linux-s390x.tar.xz", "node-v24.15.0-linux-s390x", "940d4cbfadf736b34519630a05d144c09f8a5aca291a802f2f559ee1562f6f24"),
+        "24.15.0-linux_amd64": ("node-v24.15.0-linux-x64.tar.xz", "node-v24.15.0-linux-x64", "472655581fb851559730c48763e0c9d3bc25975c59d518003fc0849d3e4ba0f6"),
+        "24.15.0-windows_amd64": ("node-v24.15.0-win-x64.zip", "node-v24.15.0-win-x64", "cc5149eabd53779ce1e7bdc5401643622d0c7e6800ade18928a767e940bb0e62"),
     },
-    node_version = "24.13.1",
+    node_version = "24.15.0",
 )
 
 # Node.js 26

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -951,7 +951,7 @@
     "@@rules_nodejs+//nodejs:extensions.bzl%node": {
       "general": {
         "bzlTransitiveDigest": "oZFClfRhTTwsYzpxVPkOpOt/r0+OzEfEV37au0jFZ0s=",
-        "usagesDigest": "wY/NydQ13j0FjFSFmSj1BtgjFqRh5ZrTIiy23+RgdSg=",
+        "usagesDigest": "6TUfLpcb/YUt4PLW/4xn3gzv5hT9PzmDfmiHSzGYLc4=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1781,46 +1781,46 @@
             "attributes": {
               "node_download_auth": {},
               "node_repositories": {
-                "24.13.1-darwin_arm64": [
-                  "node-v24.13.1-darwin-arm64.tar.gz",
-                  "node-v24.13.1-darwin-arm64",
-                  "8c039d59f2fec6195e4281ad5b0d02b9a940897b4df7b849c6fb48be6787bba6"
+                "24.15.0-darwin_arm64": [
+                  "node-v24.15.0-darwin-arm64.tar.gz",
+                  "node-v24.15.0-darwin-arm64",
+                  "372331b969779ab5d15b949884fc6eaf88d5afe87bde8ba881d6400b9100ffc4"
                 ],
-                "24.13.1-darwin_amd64": [
-                  "node-v24.13.1-darwin-x64.tar.gz",
-                  "node-v24.13.1-darwin-x64",
-                  "527f0578d9812e7dfa225121bda0b1546a6a0e4b5f556295fc8299c272de5fbf"
+                "24.15.0-darwin_amd64": [
+                  "node-v24.15.0-darwin-x64.tar.gz",
+                  "node-v24.15.0-darwin-x64",
+                  "ffd5ee293467927f3ee731a553eb88fd1f48cf74eebc2d74a6babe4af228673b"
                 ],
-                "24.13.1-linux_arm64": [
-                  "node-v24.13.1-linux-arm64.tar.xz",
-                  "node-v24.13.1-linux-arm64",
-                  "c827d3d301e2eed1a51f36d0116b71b9e3d9e3b728f081615270ea40faac34c1"
+                "24.15.0-linux_arm64": [
+                  "node-v24.15.0-linux-arm64.tar.xz",
+                  "node-v24.15.0-linux-arm64",
+                  "f3d5a797b5d210ce8e2cb265544c8e482eaedcb8aa409a8b46da7e8595d0dda0"
                 ],
-                "24.13.1-linux_ppc64le": [
-                  "node-v24.13.1-linux-ppc64le.tar.xz",
-                  "node-v24.13.1-linux-ppc64le",
-                  "fb712a08d317655dbf776c90f60ac2105109d802e33811df6c9ed33d12f801c6"
+                "24.15.0-linux_ppc64le": [
+                  "node-v24.15.0-linux-ppc64le.tar.xz",
+                  "node-v24.15.0-linux-ppc64le",
+                  "6a6560a27bd2817013c28c3d917bfe9eebf26bbd4b1d88475190f216cc411fbb"
                 ],
-                "24.13.1-linux_s390x": [
-                  "node-v24.13.1-linux-s390x.tar.xz",
-                  "node-v24.13.1-linux-s390x",
-                  "8e2c0d9b5545c3db22623e8cb8d6f0c28fcd470f29d32dbeabf9432dda289de2"
+                "24.15.0-linux_s390x": [
+                  "node-v24.15.0-linux-s390x.tar.xz",
+                  "node-v24.15.0-linux-s390x",
+                  "940d4cbfadf736b34519630a05d144c09f8a5aca291a802f2f559ee1562f6f24"
                 ],
-                "24.13.1-linux_amd64": [
-                  "node-v24.13.1-linux-x64.tar.xz",
-                  "node-v24.13.1-linux-x64",
-                  "30215f90ea3cd04dfbc06e762c021393fa173a1d392974298bbc871a8e461089"
+                "24.15.0-linux_amd64": [
+                  "node-v24.15.0-linux-x64.tar.xz",
+                  "node-v24.15.0-linux-x64",
+                  "472655581fb851559730c48763e0c9d3bc25975c59d518003fc0849d3e4ba0f6"
                 ],
-                "24.13.1-windows_amd64": [
-                  "node-v24.13.1-win-x64.zip",
-                  "node-v24.13.1-win-x64",
-                  "fba577c4bb87df04d54dd87bbdaa5a2272f1f99a2acbf9152e1a91b8b5f0b279"
+                "24.15.0-windows_amd64": [
+                  "node-v24.15.0-win-x64.zip",
+                  "node-v24.15.0-win-x64",
+                  "cc5149eabd53779ce1e7bdc5401643622d0c7e6800ade18928a767e940bb0e62"
                 ]
               },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "24.13.1",
+              "node_version": "24.15.0",
               "include_headers": false,
               "platform": "linux_amd64"
             }
@@ -1830,46 +1830,46 @@
             "attributes": {
               "node_download_auth": {},
               "node_repositories": {
-                "24.13.1-darwin_arm64": [
-                  "node-v24.13.1-darwin-arm64.tar.gz",
-                  "node-v24.13.1-darwin-arm64",
-                  "8c039d59f2fec6195e4281ad5b0d02b9a940897b4df7b849c6fb48be6787bba6"
+                "24.15.0-darwin_arm64": [
+                  "node-v24.15.0-darwin-arm64.tar.gz",
+                  "node-v24.15.0-darwin-arm64",
+                  "372331b969779ab5d15b949884fc6eaf88d5afe87bde8ba881d6400b9100ffc4"
                 ],
-                "24.13.1-darwin_amd64": [
-                  "node-v24.13.1-darwin-x64.tar.gz",
-                  "node-v24.13.1-darwin-x64",
-                  "527f0578d9812e7dfa225121bda0b1546a6a0e4b5f556295fc8299c272de5fbf"
+                "24.15.0-darwin_amd64": [
+                  "node-v24.15.0-darwin-x64.tar.gz",
+                  "node-v24.15.0-darwin-x64",
+                  "ffd5ee293467927f3ee731a553eb88fd1f48cf74eebc2d74a6babe4af228673b"
                 ],
-                "24.13.1-linux_arm64": [
-                  "node-v24.13.1-linux-arm64.tar.xz",
-                  "node-v24.13.1-linux-arm64",
-                  "c827d3d301e2eed1a51f36d0116b71b9e3d9e3b728f081615270ea40faac34c1"
+                "24.15.0-linux_arm64": [
+                  "node-v24.15.0-linux-arm64.tar.xz",
+                  "node-v24.15.0-linux-arm64",
+                  "f3d5a797b5d210ce8e2cb265544c8e482eaedcb8aa409a8b46da7e8595d0dda0"
                 ],
-                "24.13.1-linux_ppc64le": [
-                  "node-v24.13.1-linux-ppc64le.tar.xz",
-                  "node-v24.13.1-linux-ppc64le",
-                  "fb712a08d317655dbf776c90f60ac2105109d802e33811df6c9ed33d12f801c6"
+                "24.15.0-linux_ppc64le": [
+                  "node-v24.15.0-linux-ppc64le.tar.xz",
+                  "node-v24.15.0-linux-ppc64le",
+                  "6a6560a27bd2817013c28c3d917bfe9eebf26bbd4b1d88475190f216cc411fbb"
                 ],
-                "24.13.1-linux_s390x": [
-                  "node-v24.13.1-linux-s390x.tar.xz",
-                  "node-v24.13.1-linux-s390x",
-                  "8e2c0d9b5545c3db22623e8cb8d6f0c28fcd470f29d32dbeabf9432dda289de2"
+                "24.15.0-linux_s390x": [
+                  "node-v24.15.0-linux-s390x.tar.xz",
+                  "node-v24.15.0-linux-s390x",
+                  "940d4cbfadf736b34519630a05d144c09f8a5aca291a802f2f559ee1562f6f24"
                 ],
-                "24.13.1-linux_amd64": [
-                  "node-v24.13.1-linux-x64.tar.xz",
-                  "node-v24.13.1-linux-x64",
-                  "30215f90ea3cd04dfbc06e762c021393fa173a1d392974298bbc871a8e461089"
+                "24.15.0-linux_amd64": [
+                  "node-v24.15.0-linux-x64.tar.xz",
+                  "node-v24.15.0-linux-x64",
+                  "472655581fb851559730c48763e0c9d3bc25975c59d518003fc0849d3e4ba0f6"
                 ],
-                "24.13.1-windows_amd64": [
-                  "node-v24.13.1-win-x64.zip",
-                  "node-v24.13.1-win-x64",
-                  "fba577c4bb87df04d54dd87bbdaa5a2272f1f99a2acbf9152e1a91b8b5f0b279"
+                "24.15.0-windows_amd64": [
+                  "node-v24.15.0-win-x64.zip",
+                  "node-v24.15.0-win-x64",
+                  "cc5149eabd53779ce1e7bdc5401643622d0c7e6800ade18928a767e940bb0e62"
                 ]
               },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "24.13.1",
+              "node_version": "24.15.0",
               "include_headers": false,
               "platform": "linux_arm64"
             }
@@ -1879,46 +1879,46 @@
             "attributes": {
               "node_download_auth": {},
               "node_repositories": {
-                "24.13.1-darwin_arm64": [
-                  "node-v24.13.1-darwin-arm64.tar.gz",
-                  "node-v24.13.1-darwin-arm64",
-                  "8c039d59f2fec6195e4281ad5b0d02b9a940897b4df7b849c6fb48be6787bba6"
+                "24.15.0-darwin_arm64": [
+                  "node-v24.15.0-darwin-arm64.tar.gz",
+                  "node-v24.15.0-darwin-arm64",
+                  "372331b969779ab5d15b949884fc6eaf88d5afe87bde8ba881d6400b9100ffc4"
                 ],
-                "24.13.1-darwin_amd64": [
-                  "node-v24.13.1-darwin-x64.tar.gz",
-                  "node-v24.13.1-darwin-x64",
-                  "527f0578d9812e7dfa225121bda0b1546a6a0e4b5f556295fc8299c272de5fbf"
+                "24.15.0-darwin_amd64": [
+                  "node-v24.15.0-darwin-x64.tar.gz",
+                  "node-v24.15.0-darwin-x64",
+                  "ffd5ee293467927f3ee731a553eb88fd1f48cf74eebc2d74a6babe4af228673b"
                 ],
-                "24.13.1-linux_arm64": [
-                  "node-v24.13.1-linux-arm64.tar.xz",
-                  "node-v24.13.1-linux-arm64",
-                  "c827d3d301e2eed1a51f36d0116b71b9e3d9e3b728f081615270ea40faac34c1"
+                "24.15.0-linux_arm64": [
+                  "node-v24.15.0-linux-arm64.tar.xz",
+                  "node-v24.15.0-linux-arm64",
+                  "f3d5a797b5d210ce8e2cb265544c8e482eaedcb8aa409a8b46da7e8595d0dda0"
                 ],
-                "24.13.1-linux_ppc64le": [
-                  "node-v24.13.1-linux-ppc64le.tar.xz",
-                  "node-v24.13.1-linux-ppc64le",
-                  "fb712a08d317655dbf776c90f60ac2105109d802e33811df6c9ed33d12f801c6"
+                "24.15.0-linux_ppc64le": [
+                  "node-v24.15.0-linux-ppc64le.tar.xz",
+                  "node-v24.15.0-linux-ppc64le",
+                  "6a6560a27bd2817013c28c3d917bfe9eebf26bbd4b1d88475190f216cc411fbb"
                 ],
-                "24.13.1-linux_s390x": [
-                  "node-v24.13.1-linux-s390x.tar.xz",
-                  "node-v24.13.1-linux-s390x",
-                  "8e2c0d9b5545c3db22623e8cb8d6f0c28fcd470f29d32dbeabf9432dda289de2"
+                "24.15.0-linux_s390x": [
+                  "node-v24.15.0-linux-s390x.tar.xz",
+                  "node-v24.15.0-linux-s390x",
+                  "940d4cbfadf736b34519630a05d144c09f8a5aca291a802f2f559ee1562f6f24"
                 ],
-                "24.13.1-linux_amd64": [
-                  "node-v24.13.1-linux-x64.tar.xz",
-                  "node-v24.13.1-linux-x64",
-                  "30215f90ea3cd04dfbc06e762c021393fa173a1d392974298bbc871a8e461089"
+                "24.15.0-linux_amd64": [
+                  "node-v24.15.0-linux-x64.tar.xz",
+                  "node-v24.15.0-linux-x64",
+                  "472655581fb851559730c48763e0c9d3bc25975c59d518003fc0849d3e4ba0f6"
                 ],
-                "24.13.1-windows_amd64": [
-                  "node-v24.13.1-win-x64.zip",
-                  "node-v24.13.1-win-x64",
-                  "fba577c4bb87df04d54dd87bbdaa5a2272f1f99a2acbf9152e1a91b8b5f0b279"
+                "24.15.0-windows_amd64": [
+                  "node-v24.15.0-win-x64.zip",
+                  "node-v24.15.0-win-x64",
+                  "cc5149eabd53779ce1e7bdc5401643622d0c7e6800ade18928a767e940bb0e62"
                 ]
               },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "24.13.1",
+              "node_version": "24.15.0",
               "include_headers": false,
               "platform": "linux_s390x"
             }
@@ -1928,46 +1928,46 @@
             "attributes": {
               "node_download_auth": {},
               "node_repositories": {
-                "24.13.1-darwin_arm64": [
-                  "node-v24.13.1-darwin-arm64.tar.gz",
-                  "node-v24.13.1-darwin-arm64",
-                  "8c039d59f2fec6195e4281ad5b0d02b9a940897b4df7b849c6fb48be6787bba6"
+                "24.15.0-darwin_arm64": [
+                  "node-v24.15.0-darwin-arm64.tar.gz",
+                  "node-v24.15.0-darwin-arm64",
+                  "372331b969779ab5d15b949884fc6eaf88d5afe87bde8ba881d6400b9100ffc4"
                 ],
-                "24.13.1-darwin_amd64": [
-                  "node-v24.13.1-darwin-x64.tar.gz",
-                  "node-v24.13.1-darwin-x64",
-                  "527f0578d9812e7dfa225121bda0b1546a6a0e4b5f556295fc8299c272de5fbf"
+                "24.15.0-darwin_amd64": [
+                  "node-v24.15.0-darwin-x64.tar.gz",
+                  "node-v24.15.0-darwin-x64",
+                  "ffd5ee293467927f3ee731a553eb88fd1f48cf74eebc2d74a6babe4af228673b"
                 ],
-                "24.13.1-linux_arm64": [
-                  "node-v24.13.1-linux-arm64.tar.xz",
-                  "node-v24.13.1-linux-arm64",
-                  "c827d3d301e2eed1a51f36d0116b71b9e3d9e3b728f081615270ea40faac34c1"
+                "24.15.0-linux_arm64": [
+                  "node-v24.15.0-linux-arm64.tar.xz",
+                  "node-v24.15.0-linux-arm64",
+                  "f3d5a797b5d210ce8e2cb265544c8e482eaedcb8aa409a8b46da7e8595d0dda0"
                 ],
-                "24.13.1-linux_ppc64le": [
-                  "node-v24.13.1-linux-ppc64le.tar.xz",
-                  "node-v24.13.1-linux-ppc64le",
-                  "fb712a08d317655dbf776c90f60ac2105109d802e33811df6c9ed33d12f801c6"
+                "24.15.0-linux_ppc64le": [
+                  "node-v24.15.0-linux-ppc64le.tar.xz",
+                  "node-v24.15.0-linux-ppc64le",
+                  "6a6560a27bd2817013c28c3d917bfe9eebf26bbd4b1d88475190f216cc411fbb"
                 ],
-                "24.13.1-linux_s390x": [
-                  "node-v24.13.1-linux-s390x.tar.xz",
-                  "node-v24.13.1-linux-s390x",
-                  "8e2c0d9b5545c3db22623e8cb8d6f0c28fcd470f29d32dbeabf9432dda289de2"
+                "24.15.0-linux_s390x": [
+                  "node-v24.15.0-linux-s390x.tar.xz",
+                  "node-v24.15.0-linux-s390x",
+                  "940d4cbfadf736b34519630a05d144c09f8a5aca291a802f2f559ee1562f6f24"
                 ],
-                "24.13.1-linux_amd64": [
-                  "node-v24.13.1-linux-x64.tar.xz",
-                  "node-v24.13.1-linux-x64",
-                  "30215f90ea3cd04dfbc06e762c021393fa173a1d392974298bbc871a8e461089"
+                "24.15.0-linux_amd64": [
+                  "node-v24.15.0-linux-x64.tar.xz",
+                  "node-v24.15.0-linux-x64",
+                  "472655581fb851559730c48763e0c9d3bc25975c59d518003fc0849d3e4ba0f6"
                 ],
-                "24.13.1-windows_amd64": [
-                  "node-v24.13.1-win-x64.zip",
-                  "node-v24.13.1-win-x64",
-                  "fba577c4bb87df04d54dd87bbdaa5a2272f1f99a2acbf9152e1a91b8b5f0b279"
+                "24.15.0-windows_amd64": [
+                  "node-v24.15.0-win-x64.zip",
+                  "node-v24.15.0-win-x64",
+                  "cc5149eabd53779ce1e7bdc5401643622d0c7e6800ade18928a767e940bb0e62"
                 ]
               },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "24.13.1",
+              "node_version": "24.15.0",
               "include_headers": false,
               "platform": "linux_ppc64le"
             }
@@ -1977,46 +1977,46 @@
             "attributes": {
               "node_download_auth": {},
               "node_repositories": {
-                "24.13.1-darwin_arm64": [
-                  "node-v24.13.1-darwin-arm64.tar.gz",
-                  "node-v24.13.1-darwin-arm64",
-                  "8c039d59f2fec6195e4281ad5b0d02b9a940897b4df7b849c6fb48be6787bba6"
+                "24.15.0-darwin_arm64": [
+                  "node-v24.15.0-darwin-arm64.tar.gz",
+                  "node-v24.15.0-darwin-arm64",
+                  "372331b969779ab5d15b949884fc6eaf88d5afe87bde8ba881d6400b9100ffc4"
                 ],
-                "24.13.1-darwin_amd64": [
-                  "node-v24.13.1-darwin-x64.tar.gz",
-                  "node-v24.13.1-darwin-x64",
-                  "527f0578d9812e7dfa225121bda0b1546a6a0e4b5f556295fc8299c272de5fbf"
+                "24.15.0-darwin_amd64": [
+                  "node-v24.15.0-darwin-x64.tar.gz",
+                  "node-v24.15.0-darwin-x64",
+                  "ffd5ee293467927f3ee731a553eb88fd1f48cf74eebc2d74a6babe4af228673b"
                 ],
-                "24.13.1-linux_arm64": [
-                  "node-v24.13.1-linux-arm64.tar.xz",
-                  "node-v24.13.1-linux-arm64",
-                  "c827d3d301e2eed1a51f36d0116b71b9e3d9e3b728f081615270ea40faac34c1"
+                "24.15.0-linux_arm64": [
+                  "node-v24.15.0-linux-arm64.tar.xz",
+                  "node-v24.15.0-linux-arm64",
+                  "f3d5a797b5d210ce8e2cb265544c8e482eaedcb8aa409a8b46da7e8595d0dda0"
                 ],
-                "24.13.1-linux_ppc64le": [
-                  "node-v24.13.1-linux-ppc64le.tar.xz",
-                  "node-v24.13.1-linux-ppc64le",
-                  "fb712a08d317655dbf776c90f60ac2105109d802e33811df6c9ed33d12f801c6"
+                "24.15.0-linux_ppc64le": [
+                  "node-v24.15.0-linux-ppc64le.tar.xz",
+                  "node-v24.15.0-linux-ppc64le",
+                  "6a6560a27bd2817013c28c3d917bfe9eebf26bbd4b1d88475190f216cc411fbb"
                 ],
-                "24.13.1-linux_s390x": [
-                  "node-v24.13.1-linux-s390x.tar.xz",
-                  "node-v24.13.1-linux-s390x",
-                  "8e2c0d9b5545c3db22623e8cb8d6f0c28fcd470f29d32dbeabf9432dda289de2"
+                "24.15.0-linux_s390x": [
+                  "node-v24.15.0-linux-s390x.tar.xz",
+                  "node-v24.15.0-linux-s390x",
+                  "940d4cbfadf736b34519630a05d144c09f8a5aca291a802f2f559ee1562f6f24"
                 ],
-                "24.13.1-linux_amd64": [
-                  "node-v24.13.1-linux-x64.tar.xz",
-                  "node-v24.13.1-linux-x64",
-                  "30215f90ea3cd04dfbc06e762c021393fa173a1d392974298bbc871a8e461089"
+                "24.15.0-linux_amd64": [
+                  "node-v24.15.0-linux-x64.tar.xz",
+                  "node-v24.15.0-linux-x64",
+                  "472655581fb851559730c48763e0c9d3bc25975c59d518003fc0849d3e4ba0f6"
                 ],
-                "24.13.1-windows_amd64": [
-                  "node-v24.13.1-win-x64.zip",
-                  "node-v24.13.1-win-x64",
-                  "fba577c4bb87df04d54dd87bbdaa5a2272f1f99a2acbf9152e1a91b8b5f0b279"
+                "24.15.0-windows_amd64": [
+                  "node-v24.15.0-win-x64.zip",
+                  "node-v24.15.0-win-x64",
+                  "cc5149eabd53779ce1e7bdc5401643622d0c7e6800ade18928a767e940bb0e62"
                 ]
               },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "24.13.1",
+              "node_version": "24.15.0",
               "include_headers": false,
               "platform": "darwin_amd64"
             }
@@ -2026,46 +2026,46 @@
             "attributes": {
               "node_download_auth": {},
               "node_repositories": {
-                "24.13.1-darwin_arm64": [
-                  "node-v24.13.1-darwin-arm64.tar.gz",
-                  "node-v24.13.1-darwin-arm64",
-                  "8c039d59f2fec6195e4281ad5b0d02b9a940897b4df7b849c6fb48be6787bba6"
+                "24.15.0-darwin_arm64": [
+                  "node-v24.15.0-darwin-arm64.tar.gz",
+                  "node-v24.15.0-darwin-arm64",
+                  "372331b969779ab5d15b949884fc6eaf88d5afe87bde8ba881d6400b9100ffc4"
                 ],
-                "24.13.1-darwin_amd64": [
-                  "node-v24.13.1-darwin-x64.tar.gz",
-                  "node-v24.13.1-darwin-x64",
-                  "527f0578d9812e7dfa225121bda0b1546a6a0e4b5f556295fc8299c272de5fbf"
+                "24.15.0-darwin_amd64": [
+                  "node-v24.15.0-darwin-x64.tar.gz",
+                  "node-v24.15.0-darwin-x64",
+                  "ffd5ee293467927f3ee731a553eb88fd1f48cf74eebc2d74a6babe4af228673b"
                 ],
-                "24.13.1-linux_arm64": [
-                  "node-v24.13.1-linux-arm64.tar.xz",
-                  "node-v24.13.1-linux-arm64",
-                  "c827d3d301e2eed1a51f36d0116b71b9e3d9e3b728f081615270ea40faac34c1"
+                "24.15.0-linux_arm64": [
+                  "node-v24.15.0-linux-arm64.tar.xz",
+                  "node-v24.15.0-linux-arm64",
+                  "f3d5a797b5d210ce8e2cb265544c8e482eaedcb8aa409a8b46da7e8595d0dda0"
                 ],
-                "24.13.1-linux_ppc64le": [
-                  "node-v24.13.1-linux-ppc64le.tar.xz",
-                  "node-v24.13.1-linux-ppc64le",
-                  "fb712a08d317655dbf776c90f60ac2105109d802e33811df6c9ed33d12f801c6"
+                "24.15.0-linux_ppc64le": [
+                  "node-v24.15.0-linux-ppc64le.tar.xz",
+                  "node-v24.15.0-linux-ppc64le",
+                  "6a6560a27bd2817013c28c3d917bfe9eebf26bbd4b1d88475190f216cc411fbb"
                 ],
-                "24.13.1-linux_s390x": [
-                  "node-v24.13.1-linux-s390x.tar.xz",
-                  "node-v24.13.1-linux-s390x",
-                  "8e2c0d9b5545c3db22623e8cb8d6f0c28fcd470f29d32dbeabf9432dda289de2"
+                "24.15.0-linux_s390x": [
+                  "node-v24.15.0-linux-s390x.tar.xz",
+                  "node-v24.15.0-linux-s390x",
+                  "940d4cbfadf736b34519630a05d144c09f8a5aca291a802f2f559ee1562f6f24"
                 ],
-                "24.13.1-linux_amd64": [
-                  "node-v24.13.1-linux-x64.tar.xz",
-                  "node-v24.13.1-linux-x64",
-                  "30215f90ea3cd04dfbc06e762c021393fa173a1d392974298bbc871a8e461089"
+                "24.15.0-linux_amd64": [
+                  "node-v24.15.0-linux-x64.tar.xz",
+                  "node-v24.15.0-linux-x64",
+                  "472655581fb851559730c48763e0c9d3bc25975c59d518003fc0849d3e4ba0f6"
                 ],
-                "24.13.1-windows_amd64": [
-                  "node-v24.13.1-win-x64.zip",
-                  "node-v24.13.1-win-x64",
-                  "fba577c4bb87df04d54dd87bbdaa5a2272f1f99a2acbf9152e1a91b8b5f0b279"
+                "24.15.0-windows_amd64": [
+                  "node-v24.15.0-win-x64.zip",
+                  "node-v24.15.0-win-x64",
+                  "cc5149eabd53779ce1e7bdc5401643622d0c7e6800ade18928a767e940bb0e62"
                 ]
               },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "24.13.1",
+              "node_version": "24.15.0",
               "include_headers": false,
               "platform": "darwin_arm64"
             }
@@ -2075,46 +2075,46 @@
             "attributes": {
               "node_download_auth": {},
               "node_repositories": {
-                "24.13.1-darwin_arm64": [
-                  "node-v24.13.1-darwin-arm64.tar.gz",
-                  "node-v24.13.1-darwin-arm64",
-                  "8c039d59f2fec6195e4281ad5b0d02b9a940897b4df7b849c6fb48be6787bba6"
+                "24.15.0-darwin_arm64": [
+                  "node-v24.15.0-darwin-arm64.tar.gz",
+                  "node-v24.15.0-darwin-arm64",
+                  "372331b969779ab5d15b949884fc6eaf88d5afe87bde8ba881d6400b9100ffc4"
                 ],
-                "24.13.1-darwin_amd64": [
-                  "node-v24.13.1-darwin-x64.tar.gz",
-                  "node-v24.13.1-darwin-x64",
-                  "527f0578d9812e7dfa225121bda0b1546a6a0e4b5f556295fc8299c272de5fbf"
+                "24.15.0-darwin_amd64": [
+                  "node-v24.15.0-darwin-x64.tar.gz",
+                  "node-v24.15.0-darwin-x64",
+                  "ffd5ee293467927f3ee731a553eb88fd1f48cf74eebc2d74a6babe4af228673b"
                 ],
-                "24.13.1-linux_arm64": [
-                  "node-v24.13.1-linux-arm64.tar.xz",
-                  "node-v24.13.1-linux-arm64",
-                  "c827d3d301e2eed1a51f36d0116b71b9e3d9e3b728f081615270ea40faac34c1"
+                "24.15.0-linux_arm64": [
+                  "node-v24.15.0-linux-arm64.tar.xz",
+                  "node-v24.15.0-linux-arm64",
+                  "f3d5a797b5d210ce8e2cb265544c8e482eaedcb8aa409a8b46da7e8595d0dda0"
                 ],
-                "24.13.1-linux_ppc64le": [
-                  "node-v24.13.1-linux-ppc64le.tar.xz",
-                  "node-v24.13.1-linux-ppc64le",
-                  "fb712a08d317655dbf776c90f60ac2105109d802e33811df6c9ed33d12f801c6"
+                "24.15.0-linux_ppc64le": [
+                  "node-v24.15.0-linux-ppc64le.tar.xz",
+                  "node-v24.15.0-linux-ppc64le",
+                  "6a6560a27bd2817013c28c3d917bfe9eebf26bbd4b1d88475190f216cc411fbb"
                 ],
-                "24.13.1-linux_s390x": [
-                  "node-v24.13.1-linux-s390x.tar.xz",
-                  "node-v24.13.1-linux-s390x",
-                  "8e2c0d9b5545c3db22623e8cb8d6f0c28fcd470f29d32dbeabf9432dda289de2"
+                "24.15.0-linux_s390x": [
+                  "node-v24.15.0-linux-s390x.tar.xz",
+                  "node-v24.15.0-linux-s390x",
+                  "940d4cbfadf736b34519630a05d144c09f8a5aca291a802f2f559ee1562f6f24"
                 ],
-                "24.13.1-linux_amd64": [
-                  "node-v24.13.1-linux-x64.tar.xz",
-                  "node-v24.13.1-linux-x64",
-                  "30215f90ea3cd04dfbc06e762c021393fa173a1d392974298bbc871a8e461089"
+                "24.15.0-linux_amd64": [
+                  "node-v24.15.0-linux-x64.tar.xz",
+                  "node-v24.15.0-linux-x64",
+                  "472655581fb851559730c48763e0c9d3bc25975c59d518003fc0849d3e4ba0f6"
                 ],
-                "24.13.1-windows_amd64": [
-                  "node-v24.13.1-win-x64.zip",
-                  "node-v24.13.1-win-x64",
-                  "fba577c4bb87df04d54dd87bbdaa5a2272f1f99a2acbf9152e1a91b8b5f0b279"
+                "24.15.0-windows_amd64": [
+                  "node-v24.15.0-win-x64.zip",
+                  "node-v24.15.0-win-x64",
+                  "cc5149eabd53779ce1e7bdc5401643622d0c7e6800ade18928a767e940bb0e62"
                 ]
               },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "24.13.1",
+              "node_version": "24.15.0",
               "include_headers": false,
               "platform": "windows_amd64"
             }
@@ -2124,46 +2124,46 @@
             "attributes": {
               "node_download_auth": {},
               "node_repositories": {
-                "24.13.1-darwin_arm64": [
-                  "node-v24.13.1-darwin-arm64.tar.gz",
-                  "node-v24.13.1-darwin-arm64",
-                  "8c039d59f2fec6195e4281ad5b0d02b9a940897b4df7b849c6fb48be6787bba6"
+                "24.15.0-darwin_arm64": [
+                  "node-v24.15.0-darwin-arm64.tar.gz",
+                  "node-v24.15.0-darwin-arm64",
+                  "372331b969779ab5d15b949884fc6eaf88d5afe87bde8ba881d6400b9100ffc4"
                 ],
-                "24.13.1-darwin_amd64": [
-                  "node-v24.13.1-darwin-x64.tar.gz",
-                  "node-v24.13.1-darwin-x64",
-                  "527f0578d9812e7dfa225121bda0b1546a6a0e4b5f556295fc8299c272de5fbf"
+                "24.15.0-darwin_amd64": [
+                  "node-v24.15.0-darwin-x64.tar.gz",
+                  "node-v24.15.0-darwin-x64",
+                  "ffd5ee293467927f3ee731a553eb88fd1f48cf74eebc2d74a6babe4af228673b"
                 ],
-                "24.13.1-linux_arm64": [
-                  "node-v24.13.1-linux-arm64.tar.xz",
-                  "node-v24.13.1-linux-arm64",
-                  "c827d3d301e2eed1a51f36d0116b71b9e3d9e3b728f081615270ea40faac34c1"
+                "24.15.0-linux_arm64": [
+                  "node-v24.15.0-linux-arm64.tar.xz",
+                  "node-v24.15.0-linux-arm64",
+                  "f3d5a797b5d210ce8e2cb265544c8e482eaedcb8aa409a8b46da7e8595d0dda0"
                 ],
-                "24.13.1-linux_ppc64le": [
-                  "node-v24.13.1-linux-ppc64le.tar.xz",
-                  "node-v24.13.1-linux-ppc64le",
-                  "fb712a08d317655dbf776c90f60ac2105109d802e33811df6c9ed33d12f801c6"
+                "24.15.0-linux_ppc64le": [
+                  "node-v24.15.0-linux-ppc64le.tar.xz",
+                  "node-v24.15.0-linux-ppc64le",
+                  "6a6560a27bd2817013c28c3d917bfe9eebf26bbd4b1d88475190f216cc411fbb"
                 ],
-                "24.13.1-linux_s390x": [
-                  "node-v24.13.1-linux-s390x.tar.xz",
-                  "node-v24.13.1-linux-s390x",
-                  "8e2c0d9b5545c3db22623e8cb8d6f0c28fcd470f29d32dbeabf9432dda289de2"
+                "24.15.0-linux_s390x": [
+                  "node-v24.15.0-linux-s390x.tar.xz",
+                  "node-v24.15.0-linux-s390x",
+                  "940d4cbfadf736b34519630a05d144c09f8a5aca291a802f2f559ee1562f6f24"
                 ],
-                "24.13.1-linux_amd64": [
-                  "node-v24.13.1-linux-x64.tar.xz",
-                  "node-v24.13.1-linux-x64",
-                  "30215f90ea3cd04dfbc06e762c021393fa173a1d392974298bbc871a8e461089"
+                "24.15.0-linux_amd64": [
+                  "node-v24.15.0-linux-x64.tar.xz",
+                  "node-v24.15.0-linux-x64",
+                  "472655581fb851559730c48763e0c9d3bc25975c59d518003fc0849d3e4ba0f6"
                 ],
-                "24.13.1-windows_amd64": [
-                  "node-v24.13.1-win-x64.zip",
-                  "node-v24.13.1-win-x64",
-                  "fba577c4bb87df04d54dd87bbdaa5a2272f1f99a2acbf9152e1a91b8b5f0b279"
+                "24.15.0-windows_amd64": [
+                  "node-v24.15.0-win-x64.zip",
+                  "node-v24.15.0-win-x64",
+                  "cc5149eabd53779ce1e7bdc5401643622d0c7e6800ade18928a767e940bb0e62"
                 ]
               },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "24.13.1",
+              "node_version": "24.15.0",
               "include_headers": false,
               "platform": "windows_arm64"
             }

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -951,7 +951,7 @@
     "@@rules_nodejs+//nodejs:extensions.bzl%node": {
       "general": {
         "bzlTransitiveDigest": "oZFClfRhTTwsYzpxVPkOpOt/r0+OzEfEV37au0jFZ0s=",
-        "usagesDigest": "6TUfLpcb/YUt4PLW/4xn3gzv5hT9PzmDfmiHSzGYLc4=",
+        "usagesDigest": "fynsPIyZ0zhPfB73TUTjVQQVGTFUuMTdQwRXcFzXh2s=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1371,46 +1371,46 @@
             "attributes": {
               "node_download_auth": {},
               "node_repositories": {
-                "22.22.0-darwin_arm64": [
-                  "node-v22.22.0-darwin-arm64.tar.gz",
-                  "node-v22.22.0-darwin-arm64",
-                  "5ed4db0fcf1eaf84d91ad12462631d73bf4576c1377e192d222e48026a902640"
+                "22.22.3-darwin_arm64": [
+                  "node-v22.22.3-darwin-arm64.tar.gz",
+                  "node-v22.22.3-darwin-arm64",
+                  "0da7ff74ef8611328c8212f17943368713a2ad953fb7d89a8c8a0eae87c23207"
                 ],
-                "22.22.0-darwin_amd64": [
-                  "node-v22.22.0-darwin-x64.tar.gz",
-                  "node-v22.22.0-darwin-x64",
-                  "5ea50c9d6dea3dfa3abb66b2656f7a4e1c8cef23432b558d45fb538c7b5dedce"
+                "22.22.3-darwin_amd64": [
+                  "node-v22.22.3-darwin-x64.tar.gz",
+                  "node-v22.22.3-darwin-x64",
+                  "45830ba752fa0d892c6dcd640946669801293cac820a33591ded40ac075198ec"
                 ],
-                "22.22.0-linux_arm64": [
-                  "node-v22.22.0-linux-arm64.tar.xz",
-                  "node-v22.22.0-linux-arm64",
-                  "1bf1eb9ee63ffc4e5d324c0b9b62cf4a289f44332dfef9607cea1a0d9596ba6f"
+                "22.22.3-linux_arm64": [
+                  "node-v22.22.3-linux-arm64.tar.xz",
+                  "node-v22.22.3-linux-arm64",
+                  "1c4a9933a5e45bc88f54f70b5f91232c127ec49f1a5989d23fb85824c7adf9b7"
                 ],
-                "22.22.0-linux_ppc64le": [
-                  "node-v22.22.0-linux-ppc64le.tar.xz",
-                  "node-v22.22.0-linux-ppc64le",
-                  "d83b9957431cc18e1fc143a4b99f89cde7b8a18f53ef392231b4336afd058865"
+                "22.22.3-linux_ppc64le": [
+                  "node-v22.22.3-linux-ppc64le.tar.xz",
+                  "node-v22.22.3-linux-ppc64le",
+                  "edb5478071bd1375e80195ca52f72823998bb5141b1a09e68bc54b3e2eb67754"
                 ],
-                "22.22.0-linux_s390x": [
-                  "node-v22.22.0-linux-s390x.tar.xz",
-                  "node-v22.22.0-linux-s390x",
-                  "5aa0e520689448c4233e8d73f284e8e0634fdcd32b479735698494be5641f3e4"
+                "22.22.3-linux_s390x": [
+                  "node-v22.22.3-linux-s390x.tar.xz",
+                  "node-v22.22.3-linux-s390x",
+                  "ce398c057830d57a24c458177279a17bc51742d5c22dd4cbe97b10dbd43f2617"
                 ],
-                "22.22.0-linux_amd64": [
-                  "node-v22.22.0-linux-x64.tar.xz",
-                  "node-v22.22.0-linux-x64",
-                  "9aa8e9d2298ab68c600bd6fb86a6c13bce11a4eca1ba9b39d79fa021755d7c37"
+                "22.22.3-linux_amd64": [
+                  "node-v22.22.3-linux-x64.tar.xz",
+                  "node-v22.22.3-linux-x64",
+                  "2e5d13569282d016861fae7c8f935e741693c269101a5bebcf761a5376d1f99f"
                 ],
-                "22.22.0-windows_amd64": [
-                  "node-v22.22.0-win-x64.zip",
-                  "node-v22.22.0-win-x64",
-                  "c97fa376d2becdc8863fcd3ca2dd9a83a9f3468ee7ccf7a6d076ec66a645c77a"
+                "22.22.3-windows_amd64": [
+                  "node-v22.22.3-win-x64.zip",
+                  "node-v22.22.3-win-x64",
+                  "6c8d54f635feff4df76c2ca80f45332eb2ff57d25226edce36592e51a177ee33"
                 ]
               },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.22.0",
+              "node_version": "22.22.3",
               "include_headers": false,
               "platform": "linux_amd64"
             }
@@ -1420,46 +1420,46 @@
             "attributes": {
               "node_download_auth": {},
               "node_repositories": {
-                "22.22.0-darwin_arm64": [
-                  "node-v22.22.0-darwin-arm64.tar.gz",
-                  "node-v22.22.0-darwin-arm64",
-                  "5ed4db0fcf1eaf84d91ad12462631d73bf4576c1377e192d222e48026a902640"
+                "22.22.3-darwin_arm64": [
+                  "node-v22.22.3-darwin-arm64.tar.gz",
+                  "node-v22.22.3-darwin-arm64",
+                  "0da7ff74ef8611328c8212f17943368713a2ad953fb7d89a8c8a0eae87c23207"
                 ],
-                "22.22.0-darwin_amd64": [
-                  "node-v22.22.0-darwin-x64.tar.gz",
-                  "node-v22.22.0-darwin-x64",
-                  "5ea50c9d6dea3dfa3abb66b2656f7a4e1c8cef23432b558d45fb538c7b5dedce"
+                "22.22.3-darwin_amd64": [
+                  "node-v22.22.3-darwin-x64.tar.gz",
+                  "node-v22.22.3-darwin-x64",
+                  "45830ba752fa0d892c6dcd640946669801293cac820a33591ded40ac075198ec"
                 ],
-                "22.22.0-linux_arm64": [
-                  "node-v22.22.0-linux-arm64.tar.xz",
-                  "node-v22.22.0-linux-arm64",
-                  "1bf1eb9ee63ffc4e5d324c0b9b62cf4a289f44332dfef9607cea1a0d9596ba6f"
+                "22.22.3-linux_arm64": [
+                  "node-v22.22.3-linux-arm64.tar.xz",
+                  "node-v22.22.3-linux-arm64",
+                  "1c4a9933a5e45bc88f54f70b5f91232c127ec49f1a5989d23fb85824c7adf9b7"
                 ],
-                "22.22.0-linux_ppc64le": [
-                  "node-v22.22.0-linux-ppc64le.tar.xz",
-                  "node-v22.22.0-linux-ppc64le",
-                  "d83b9957431cc18e1fc143a4b99f89cde7b8a18f53ef392231b4336afd058865"
+                "22.22.3-linux_ppc64le": [
+                  "node-v22.22.3-linux-ppc64le.tar.xz",
+                  "node-v22.22.3-linux-ppc64le",
+                  "edb5478071bd1375e80195ca52f72823998bb5141b1a09e68bc54b3e2eb67754"
                 ],
-                "22.22.0-linux_s390x": [
-                  "node-v22.22.0-linux-s390x.tar.xz",
-                  "node-v22.22.0-linux-s390x",
-                  "5aa0e520689448c4233e8d73f284e8e0634fdcd32b479735698494be5641f3e4"
+                "22.22.3-linux_s390x": [
+                  "node-v22.22.3-linux-s390x.tar.xz",
+                  "node-v22.22.3-linux-s390x",
+                  "ce398c057830d57a24c458177279a17bc51742d5c22dd4cbe97b10dbd43f2617"
                 ],
-                "22.22.0-linux_amd64": [
-                  "node-v22.22.0-linux-x64.tar.xz",
-                  "node-v22.22.0-linux-x64",
-                  "9aa8e9d2298ab68c600bd6fb86a6c13bce11a4eca1ba9b39d79fa021755d7c37"
+                "22.22.3-linux_amd64": [
+                  "node-v22.22.3-linux-x64.tar.xz",
+                  "node-v22.22.3-linux-x64",
+                  "2e5d13569282d016861fae7c8f935e741693c269101a5bebcf761a5376d1f99f"
                 ],
-                "22.22.0-windows_amd64": [
-                  "node-v22.22.0-win-x64.zip",
-                  "node-v22.22.0-win-x64",
-                  "c97fa376d2becdc8863fcd3ca2dd9a83a9f3468ee7ccf7a6d076ec66a645c77a"
+                "22.22.3-windows_amd64": [
+                  "node-v22.22.3-win-x64.zip",
+                  "node-v22.22.3-win-x64",
+                  "6c8d54f635feff4df76c2ca80f45332eb2ff57d25226edce36592e51a177ee33"
                 ]
               },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.22.0",
+              "node_version": "22.22.3",
               "include_headers": false,
               "platform": "linux_arm64"
             }
@@ -1469,46 +1469,46 @@
             "attributes": {
               "node_download_auth": {},
               "node_repositories": {
-                "22.22.0-darwin_arm64": [
-                  "node-v22.22.0-darwin-arm64.tar.gz",
-                  "node-v22.22.0-darwin-arm64",
-                  "5ed4db0fcf1eaf84d91ad12462631d73bf4576c1377e192d222e48026a902640"
+                "22.22.3-darwin_arm64": [
+                  "node-v22.22.3-darwin-arm64.tar.gz",
+                  "node-v22.22.3-darwin-arm64",
+                  "0da7ff74ef8611328c8212f17943368713a2ad953fb7d89a8c8a0eae87c23207"
                 ],
-                "22.22.0-darwin_amd64": [
-                  "node-v22.22.0-darwin-x64.tar.gz",
-                  "node-v22.22.0-darwin-x64",
-                  "5ea50c9d6dea3dfa3abb66b2656f7a4e1c8cef23432b558d45fb538c7b5dedce"
+                "22.22.3-darwin_amd64": [
+                  "node-v22.22.3-darwin-x64.tar.gz",
+                  "node-v22.22.3-darwin-x64",
+                  "45830ba752fa0d892c6dcd640946669801293cac820a33591ded40ac075198ec"
                 ],
-                "22.22.0-linux_arm64": [
-                  "node-v22.22.0-linux-arm64.tar.xz",
-                  "node-v22.22.0-linux-arm64",
-                  "1bf1eb9ee63ffc4e5d324c0b9b62cf4a289f44332dfef9607cea1a0d9596ba6f"
+                "22.22.3-linux_arm64": [
+                  "node-v22.22.3-linux-arm64.tar.xz",
+                  "node-v22.22.3-linux-arm64",
+                  "1c4a9933a5e45bc88f54f70b5f91232c127ec49f1a5989d23fb85824c7adf9b7"
                 ],
-                "22.22.0-linux_ppc64le": [
-                  "node-v22.22.0-linux-ppc64le.tar.xz",
-                  "node-v22.22.0-linux-ppc64le",
-                  "d83b9957431cc18e1fc143a4b99f89cde7b8a18f53ef392231b4336afd058865"
+                "22.22.3-linux_ppc64le": [
+                  "node-v22.22.3-linux-ppc64le.tar.xz",
+                  "node-v22.22.3-linux-ppc64le",
+                  "edb5478071bd1375e80195ca52f72823998bb5141b1a09e68bc54b3e2eb67754"
                 ],
-                "22.22.0-linux_s390x": [
-                  "node-v22.22.0-linux-s390x.tar.xz",
-                  "node-v22.22.0-linux-s390x",
-                  "5aa0e520689448c4233e8d73f284e8e0634fdcd32b479735698494be5641f3e4"
+                "22.22.3-linux_s390x": [
+                  "node-v22.22.3-linux-s390x.tar.xz",
+                  "node-v22.22.3-linux-s390x",
+                  "ce398c057830d57a24c458177279a17bc51742d5c22dd4cbe97b10dbd43f2617"
                 ],
-                "22.22.0-linux_amd64": [
-                  "node-v22.22.0-linux-x64.tar.xz",
-                  "node-v22.22.0-linux-x64",
-                  "9aa8e9d2298ab68c600bd6fb86a6c13bce11a4eca1ba9b39d79fa021755d7c37"
+                "22.22.3-linux_amd64": [
+                  "node-v22.22.3-linux-x64.tar.xz",
+                  "node-v22.22.3-linux-x64",
+                  "2e5d13569282d016861fae7c8f935e741693c269101a5bebcf761a5376d1f99f"
                 ],
-                "22.22.0-windows_amd64": [
-                  "node-v22.22.0-win-x64.zip",
-                  "node-v22.22.0-win-x64",
-                  "c97fa376d2becdc8863fcd3ca2dd9a83a9f3468ee7ccf7a6d076ec66a645c77a"
+                "22.22.3-windows_amd64": [
+                  "node-v22.22.3-win-x64.zip",
+                  "node-v22.22.3-win-x64",
+                  "6c8d54f635feff4df76c2ca80f45332eb2ff57d25226edce36592e51a177ee33"
                 ]
               },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.22.0",
+              "node_version": "22.22.3",
               "include_headers": false,
               "platform": "linux_s390x"
             }
@@ -1518,46 +1518,46 @@
             "attributes": {
               "node_download_auth": {},
               "node_repositories": {
-                "22.22.0-darwin_arm64": [
-                  "node-v22.22.0-darwin-arm64.tar.gz",
-                  "node-v22.22.0-darwin-arm64",
-                  "5ed4db0fcf1eaf84d91ad12462631d73bf4576c1377e192d222e48026a902640"
+                "22.22.3-darwin_arm64": [
+                  "node-v22.22.3-darwin-arm64.tar.gz",
+                  "node-v22.22.3-darwin-arm64",
+                  "0da7ff74ef8611328c8212f17943368713a2ad953fb7d89a8c8a0eae87c23207"
                 ],
-                "22.22.0-darwin_amd64": [
-                  "node-v22.22.0-darwin-x64.tar.gz",
-                  "node-v22.22.0-darwin-x64",
-                  "5ea50c9d6dea3dfa3abb66b2656f7a4e1c8cef23432b558d45fb538c7b5dedce"
+                "22.22.3-darwin_amd64": [
+                  "node-v22.22.3-darwin-x64.tar.gz",
+                  "node-v22.22.3-darwin-x64",
+                  "45830ba752fa0d892c6dcd640946669801293cac820a33591ded40ac075198ec"
                 ],
-                "22.22.0-linux_arm64": [
-                  "node-v22.22.0-linux-arm64.tar.xz",
-                  "node-v22.22.0-linux-arm64",
-                  "1bf1eb9ee63ffc4e5d324c0b9b62cf4a289f44332dfef9607cea1a0d9596ba6f"
+                "22.22.3-linux_arm64": [
+                  "node-v22.22.3-linux-arm64.tar.xz",
+                  "node-v22.22.3-linux-arm64",
+                  "1c4a9933a5e45bc88f54f70b5f91232c127ec49f1a5989d23fb85824c7adf9b7"
                 ],
-                "22.22.0-linux_ppc64le": [
-                  "node-v22.22.0-linux-ppc64le.tar.xz",
-                  "node-v22.22.0-linux-ppc64le",
-                  "d83b9957431cc18e1fc143a4b99f89cde7b8a18f53ef392231b4336afd058865"
+                "22.22.3-linux_ppc64le": [
+                  "node-v22.22.3-linux-ppc64le.tar.xz",
+                  "node-v22.22.3-linux-ppc64le",
+                  "edb5478071bd1375e80195ca52f72823998bb5141b1a09e68bc54b3e2eb67754"
                 ],
-                "22.22.0-linux_s390x": [
-                  "node-v22.22.0-linux-s390x.tar.xz",
-                  "node-v22.22.0-linux-s390x",
-                  "5aa0e520689448c4233e8d73f284e8e0634fdcd32b479735698494be5641f3e4"
+                "22.22.3-linux_s390x": [
+                  "node-v22.22.3-linux-s390x.tar.xz",
+                  "node-v22.22.3-linux-s390x",
+                  "ce398c057830d57a24c458177279a17bc51742d5c22dd4cbe97b10dbd43f2617"
                 ],
-                "22.22.0-linux_amd64": [
-                  "node-v22.22.0-linux-x64.tar.xz",
-                  "node-v22.22.0-linux-x64",
-                  "9aa8e9d2298ab68c600bd6fb86a6c13bce11a4eca1ba9b39d79fa021755d7c37"
+                "22.22.3-linux_amd64": [
+                  "node-v22.22.3-linux-x64.tar.xz",
+                  "node-v22.22.3-linux-x64",
+                  "2e5d13569282d016861fae7c8f935e741693c269101a5bebcf761a5376d1f99f"
                 ],
-                "22.22.0-windows_amd64": [
-                  "node-v22.22.0-win-x64.zip",
-                  "node-v22.22.0-win-x64",
-                  "c97fa376d2becdc8863fcd3ca2dd9a83a9f3468ee7ccf7a6d076ec66a645c77a"
+                "22.22.3-windows_amd64": [
+                  "node-v22.22.3-win-x64.zip",
+                  "node-v22.22.3-win-x64",
+                  "6c8d54f635feff4df76c2ca80f45332eb2ff57d25226edce36592e51a177ee33"
                 ]
               },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.22.0",
+              "node_version": "22.22.3",
               "include_headers": false,
               "platform": "linux_ppc64le"
             }
@@ -1567,46 +1567,46 @@
             "attributes": {
               "node_download_auth": {},
               "node_repositories": {
-                "22.22.0-darwin_arm64": [
-                  "node-v22.22.0-darwin-arm64.tar.gz",
-                  "node-v22.22.0-darwin-arm64",
-                  "5ed4db0fcf1eaf84d91ad12462631d73bf4576c1377e192d222e48026a902640"
+                "22.22.3-darwin_arm64": [
+                  "node-v22.22.3-darwin-arm64.tar.gz",
+                  "node-v22.22.3-darwin-arm64",
+                  "0da7ff74ef8611328c8212f17943368713a2ad953fb7d89a8c8a0eae87c23207"
                 ],
-                "22.22.0-darwin_amd64": [
-                  "node-v22.22.0-darwin-x64.tar.gz",
-                  "node-v22.22.0-darwin-x64",
-                  "5ea50c9d6dea3dfa3abb66b2656f7a4e1c8cef23432b558d45fb538c7b5dedce"
+                "22.22.3-darwin_amd64": [
+                  "node-v22.22.3-darwin-x64.tar.gz",
+                  "node-v22.22.3-darwin-x64",
+                  "45830ba752fa0d892c6dcd640946669801293cac820a33591ded40ac075198ec"
                 ],
-                "22.22.0-linux_arm64": [
-                  "node-v22.22.0-linux-arm64.tar.xz",
-                  "node-v22.22.0-linux-arm64",
-                  "1bf1eb9ee63ffc4e5d324c0b9b62cf4a289f44332dfef9607cea1a0d9596ba6f"
+                "22.22.3-linux_arm64": [
+                  "node-v22.22.3-linux-arm64.tar.xz",
+                  "node-v22.22.3-linux-arm64",
+                  "1c4a9933a5e45bc88f54f70b5f91232c127ec49f1a5989d23fb85824c7adf9b7"
                 ],
-                "22.22.0-linux_ppc64le": [
-                  "node-v22.22.0-linux-ppc64le.tar.xz",
-                  "node-v22.22.0-linux-ppc64le",
-                  "d83b9957431cc18e1fc143a4b99f89cde7b8a18f53ef392231b4336afd058865"
+                "22.22.3-linux_ppc64le": [
+                  "node-v22.22.3-linux-ppc64le.tar.xz",
+                  "node-v22.22.3-linux-ppc64le",
+                  "edb5478071bd1375e80195ca52f72823998bb5141b1a09e68bc54b3e2eb67754"
                 ],
-                "22.22.0-linux_s390x": [
-                  "node-v22.22.0-linux-s390x.tar.xz",
-                  "node-v22.22.0-linux-s390x",
-                  "5aa0e520689448c4233e8d73f284e8e0634fdcd32b479735698494be5641f3e4"
+                "22.22.3-linux_s390x": [
+                  "node-v22.22.3-linux-s390x.tar.xz",
+                  "node-v22.22.3-linux-s390x",
+                  "ce398c057830d57a24c458177279a17bc51742d5c22dd4cbe97b10dbd43f2617"
                 ],
-                "22.22.0-linux_amd64": [
-                  "node-v22.22.0-linux-x64.tar.xz",
-                  "node-v22.22.0-linux-x64",
-                  "9aa8e9d2298ab68c600bd6fb86a6c13bce11a4eca1ba9b39d79fa021755d7c37"
+                "22.22.3-linux_amd64": [
+                  "node-v22.22.3-linux-x64.tar.xz",
+                  "node-v22.22.3-linux-x64",
+                  "2e5d13569282d016861fae7c8f935e741693c269101a5bebcf761a5376d1f99f"
                 ],
-                "22.22.0-windows_amd64": [
-                  "node-v22.22.0-win-x64.zip",
-                  "node-v22.22.0-win-x64",
-                  "c97fa376d2becdc8863fcd3ca2dd9a83a9f3468ee7ccf7a6d076ec66a645c77a"
+                "22.22.3-windows_amd64": [
+                  "node-v22.22.3-win-x64.zip",
+                  "node-v22.22.3-win-x64",
+                  "6c8d54f635feff4df76c2ca80f45332eb2ff57d25226edce36592e51a177ee33"
                 ]
               },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.22.0",
+              "node_version": "22.22.3",
               "include_headers": false,
               "platform": "darwin_amd64"
             }
@@ -1616,46 +1616,46 @@
             "attributes": {
               "node_download_auth": {},
               "node_repositories": {
-                "22.22.0-darwin_arm64": [
-                  "node-v22.22.0-darwin-arm64.tar.gz",
-                  "node-v22.22.0-darwin-arm64",
-                  "5ed4db0fcf1eaf84d91ad12462631d73bf4576c1377e192d222e48026a902640"
+                "22.22.3-darwin_arm64": [
+                  "node-v22.22.3-darwin-arm64.tar.gz",
+                  "node-v22.22.3-darwin-arm64",
+                  "0da7ff74ef8611328c8212f17943368713a2ad953fb7d89a8c8a0eae87c23207"
                 ],
-                "22.22.0-darwin_amd64": [
-                  "node-v22.22.0-darwin-x64.tar.gz",
-                  "node-v22.22.0-darwin-x64",
-                  "5ea50c9d6dea3dfa3abb66b2656f7a4e1c8cef23432b558d45fb538c7b5dedce"
+                "22.22.3-darwin_amd64": [
+                  "node-v22.22.3-darwin-x64.tar.gz",
+                  "node-v22.22.3-darwin-x64",
+                  "45830ba752fa0d892c6dcd640946669801293cac820a33591ded40ac075198ec"
                 ],
-                "22.22.0-linux_arm64": [
-                  "node-v22.22.0-linux-arm64.tar.xz",
-                  "node-v22.22.0-linux-arm64",
-                  "1bf1eb9ee63ffc4e5d324c0b9b62cf4a289f44332dfef9607cea1a0d9596ba6f"
+                "22.22.3-linux_arm64": [
+                  "node-v22.22.3-linux-arm64.tar.xz",
+                  "node-v22.22.3-linux-arm64",
+                  "1c4a9933a5e45bc88f54f70b5f91232c127ec49f1a5989d23fb85824c7adf9b7"
                 ],
-                "22.22.0-linux_ppc64le": [
-                  "node-v22.22.0-linux-ppc64le.tar.xz",
-                  "node-v22.22.0-linux-ppc64le",
-                  "d83b9957431cc18e1fc143a4b99f89cde7b8a18f53ef392231b4336afd058865"
+                "22.22.3-linux_ppc64le": [
+                  "node-v22.22.3-linux-ppc64le.tar.xz",
+                  "node-v22.22.3-linux-ppc64le",
+                  "edb5478071bd1375e80195ca52f72823998bb5141b1a09e68bc54b3e2eb67754"
                 ],
-                "22.22.0-linux_s390x": [
-                  "node-v22.22.0-linux-s390x.tar.xz",
-                  "node-v22.22.0-linux-s390x",
-                  "5aa0e520689448c4233e8d73f284e8e0634fdcd32b479735698494be5641f3e4"
+                "22.22.3-linux_s390x": [
+                  "node-v22.22.3-linux-s390x.tar.xz",
+                  "node-v22.22.3-linux-s390x",
+                  "ce398c057830d57a24c458177279a17bc51742d5c22dd4cbe97b10dbd43f2617"
                 ],
-                "22.22.0-linux_amd64": [
-                  "node-v22.22.0-linux-x64.tar.xz",
-                  "node-v22.22.0-linux-x64",
-                  "9aa8e9d2298ab68c600bd6fb86a6c13bce11a4eca1ba9b39d79fa021755d7c37"
+                "22.22.3-linux_amd64": [
+                  "node-v22.22.3-linux-x64.tar.xz",
+                  "node-v22.22.3-linux-x64",
+                  "2e5d13569282d016861fae7c8f935e741693c269101a5bebcf761a5376d1f99f"
                 ],
-                "22.22.0-windows_amd64": [
-                  "node-v22.22.0-win-x64.zip",
-                  "node-v22.22.0-win-x64",
-                  "c97fa376d2becdc8863fcd3ca2dd9a83a9f3468ee7ccf7a6d076ec66a645c77a"
+                "22.22.3-windows_amd64": [
+                  "node-v22.22.3-win-x64.zip",
+                  "node-v22.22.3-win-x64",
+                  "6c8d54f635feff4df76c2ca80f45332eb2ff57d25226edce36592e51a177ee33"
                 ]
               },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.22.0",
+              "node_version": "22.22.3",
               "include_headers": false,
               "platform": "darwin_arm64"
             }
@@ -1665,46 +1665,46 @@
             "attributes": {
               "node_download_auth": {},
               "node_repositories": {
-                "22.22.0-darwin_arm64": [
-                  "node-v22.22.0-darwin-arm64.tar.gz",
-                  "node-v22.22.0-darwin-arm64",
-                  "5ed4db0fcf1eaf84d91ad12462631d73bf4576c1377e192d222e48026a902640"
+                "22.22.3-darwin_arm64": [
+                  "node-v22.22.3-darwin-arm64.tar.gz",
+                  "node-v22.22.3-darwin-arm64",
+                  "0da7ff74ef8611328c8212f17943368713a2ad953fb7d89a8c8a0eae87c23207"
                 ],
-                "22.22.0-darwin_amd64": [
-                  "node-v22.22.0-darwin-x64.tar.gz",
-                  "node-v22.22.0-darwin-x64",
-                  "5ea50c9d6dea3dfa3abb66b2656f7a4e1c8cef23432b558d45fb538c7b5dedce"
+                "22.22.3-darwin_amd64": [
+                  "node-v22.22.3-darwin-x64.tar.gz",
+                  "node-v22.22.3-darwin-x64",
+                  "45830ba752fa0d892c6dcd640946669801293cac820a33591ded40ac075198ec"
                 ],
-                "22.22.0-linux_arm64": [
-                  "node-v22.22.0-linux-arm64.tar.xz",
-                  "node-v22.22.0-linux-arm64",
-                  "1bf1eb9ee63ffc4e5d324c0b9b62cf4a289f44332dfef9607cea1a0d9596ba6f"
+                "22.22.3-linux_arm64": [
+                  "node-v22.22.3-linux-arm64.tar.xz",
+                  "node-v22.22.3-linux-arm64",
+                  "1c4a9933a5e45bc88f54f70b5f91232c127ec49f1a5989d23fb85824c7adf9b7"
                 ],
-                "22.22.0-linux_ppc64le": [
-                  "node-v22.22.0-linux-ppc64le.tar.xz",
-                  "node-v22.22.0-linux-ppc64le",
-                  "d83b9957431cc18e1fc143a4b99f89cde7b8a18f53ef392231b4336afd058865"
+                "22.22.3-linux_ppc64le": [
+                  "node-v22.22.3-linux-ppc64le.tar.xz",
+                  "node-v22.22.3-linux-ppc64le",
+                  "edb5478071bd1375e80195ca52f72823998bb5141b1a09e68bc54b3e2eb67754"
                 ],
-                "22.22.0-linux_s390x": [
-                  "node-v22.22.0-linux-s390x.tar.xz",
-                  "node-v22.22.0-linux-s390x",
-                  "5aa0e520689448c4233e8d73f284e8e0634fdcd32b479735698494be5641f3e4"
+                "22.22.3-linux_s390x": [
+                  "node-v22.22.3-linux-s390x.tar.xz",
+                  "node-v22.22.3-linux-s390x",
+                  "ce398c057830d57a24c458177279a17bc51742d5c22dd4cbe97b10dbd43f2617"
                 ],
-                "22.22.0-linux_amd64": [
-                  "node-v22.22.0-linux-x64.tar.xz",
-                  "node-v22.22.0-linux-x64",
-                  "9aa8e9d2298ab68c600bd6fb86a6c13bce11a4eca1ba9b39d79fa021755d7c37"
+                "22.22.3-linux_amd64": [
+                  "node-v22.22.3-linux-x64.tar.xz",
+                  "node-v22.22.3-linux-x64",
+                  "2e5d13569282d016861fae7c8f935e741693c269101a5bebcf761a5376d1f99f"
                 ],
-                "22.22.0-windows_amd64": [
-                  "node-v22.22.0-win-x64.zip",
-                  "node-v22.22.0-win-x64",
-                  "c97fa376d2becdc8863fcd3ca2dd9a83a9f3468ee7ccf7a6d076ec66a645c77a"
+                "22.22.3-windows_amd64": [
+                  "node-v22.22.3-win-x64.zip",
+                  "node-v22.22.3-win-x64",
+                  "6c8d54f635feff4df76c2ca80f45332eb2ff57d25226edce36592e51a177ee33"
                 ]
               },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.22.0",
+              "node_version": "22.22.3",
               "include_headers": false,
               "platform": "windows_amd64"
             }
@@ -1714,46 +1714,46 @@
             "attributes": {
               "node_download_auth": {},
               "node_repositories": {
-                "22.22.0-darwin_arm64": [
-                  "node-v22.22.0-darwin-arm64.tar.gz",
-                  "node-v22.22.0-darwin-arm64",
-                  "5ed4db0fcf1eaf84d91ad12462631d73bf4576c1377e192d222e48026a902640"
+                "22.22.3-darwin_arm64": [
+                  "node-v22.22.3-darwin-arm64.tar.gz",
+                  "node-v22.22.3-darwin-arm64",
+                  "0da7ff74ef8611328c8212f17943368713a2ad953fb7d89a8c8a0eae87c23207"
                 ],
-                "22.22.0-darwin_amd64": [
-                  "node-v22.22.0-darwin-x64.tar.gz",
-                  "node-v22.22.0-darwin-x64",
-                  "5ea50c9d6dea3dfa3abb66b2656f7a4e1c8cef23432b558d45fb538c7b5dedce"
+                "22.22.3-darwin_amd64": [
+                  "node-v22.22.3-darwin-x64.tar.gz",
+                  "node-v22.22.3-darwin-x64",
+                  "45830ba752fa0d892c6dcd640946669801293cac820a33591ded40ac075198ec"
                 ],
-                "22.22.0-linux_arm64": [
-                  "node-v22.22.0-linux-arm64.tar.xz",
-                  "node-v22.22.0-linux-arm64",
-                  "1bf1eb9ee63ffc4e5d324c0b9b62cf4a289f44332dfef9607cea1a0d9596ba6f"
+                "22.22.3-linux_arm64": [
+                  "node-v22.22.3-linux-arm64.tar.xz",
+                  "node-v22.22.3-linux-arm64",
+                  "1c4a9933a5e45bc88f54f70b5f91232c127ec49f1a5989d23fb85824c7adf9b7"
                 ],
-                "22.22.0-linux_ppc64le": [
-                  "node-v22.22.0-linux-ppc64le.tar.xz",
-                  "node-v22.22.0-linux-ppc64le",
-                  "d83b9957431cc18e1fc143a4b99f89cde7b8a18f53ef392231b4336afd058865"
+                "22.22.3-linux_ppc64le": [
+                  "node-v22.22.3-linux-ppc64le.tar.xz",
+                  "node-v22.22.3-linux-ppc64le",
+                  "edb5478071bd1375e80195ca52f72823998bb5141b1a09e68bc54b3e2eb67754"
                 ],
-                "22.22.0-linux_s390x": [
-                  "node-v22.22.0-linux-s390x.tar.xz",
-                  "node-v22.22.0-linux-s390x",
-                  "5aa0e520689448c4233e8d73f284e8e0634fdcd32b479735698494be5641f3e4"
+                "22.22.3-linux_s390x": [
+                  "node-v22.22.3-linux-s390x.tar.xz",
+                  "node-v22.22.3-linux-s390x",
+                  "ce398c057830d57a24c458177279a17bc51742d5c22dd4cbe97b10dbd43f2617"
                 ],
-                "22.22.0-linux_amd64": [
-                  "node-v22.22.0-linux-x64.tar.xz",
-                  "node-v22.22.0-linux-x64",
-                  "9aa8e9d2298ab68c600bd6fb86a6c13bce11a4eca1ba9b39d79fa021755d7c37"
+                "22.22.3-linux_amd64": [
+                  "node-v22.22.3-linux-x64.tar.xz",
+                  "node-v22.22.3-linux-x64",
+                  "2e5d13569282d016861fae7c8f935e741693c269101a5bebcf761a5376d1f99f"
                 ],
-                "22.22.0-windows_amd64": [
-                  "node-v22.22.0-win-x64.zip",
-                  "node-v22.22.0-win-x64",
-                  "c97fa376d2becdc8863fcd3ca2dd9a83a9f3468ee7ccf7a6d076ec66a645c77a"
+                "22.22.3-windows_amd64": [
+                  "node-v22.22.3-win-x64.zip",
+                  "node-v22.22.3-win-x64",
+                  "6c8d54f635feff4df76c2ca80f45332eb2ff57d25226edce36592e51a177ee33"
                 ]
               },
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.22.0",
+              "node_version": "22.22.3",
               "include_headers": false,
               "platform": "windows_arm64"
             }

--- a/constants.bzl
+++ b/constants.bzl
@@ -1,5 +1,5 @@
 # Engine versions to stamp in a release package.json
-RELEASE_ENGINES_NODE = "^22.22.0 || ^24.15.0 || >=26.0.0"
+RELEASE_ENGINES_NODE = "^22.22.3 || ^24.15.0 || >=26.0.0"
 RELEASE_ENGINES_NPM = "^6.11.0 || ^7.5.6 || >=8.0.0"
 RELEASE_ENGINES_YARN = ">= 1.13.0"
 

--- a/constants.bzl
+++ b/constants.bzl
@@ -1,5 +1,5 @@
 # Engine versions to stamp in a release package.json
-RELEASE_ENGINES_NODE = "^22.22.0 || ^24.13.1 || >=26.0.0"
+RELEASE_ENGINES_NODE = "^22.22.0 || ^24.15.0 || >=26.0.0"
 RELEASE_ENGINES_NPM = "^6.11.0 || ^7.5.6 || >=8.0.0"
 RELEASE_ENGINES_YARN = ">= 1.13.0"
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "packageManager": "pnpm@11.1.3",
   "engines": {
-    "node": "^22.22.0 || ^24.13.1 || >=26.0.0",
+    "node": "^22.22.0 || ^24.15.0 || >=26.0.0",
     "npm": "Please use pnpm instead of NPM to install dependencies",
     "yarn": "Please use pnpm instead of Yarn to install dependencies",
     "pnpm": "11.1.3"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "packageManager": "pnpm@11.1.3",
   "engines": {
-    "node": "^22.22.0 || ^24.15.0 || >=26.0.0",
+    "node": "^22.22.3 || ^24.15.0 || >=26.0.0",
     "npm": "Please use pnpm instead of NPM to install dependencies",
     "yarn": "Please use pnpm instead of Yarn to install dependencies",
     "pnpm": "11.1.3"

--- a/packages/angular/cli/bin/ng.js
+++ b/packages/angular/cli/bin/ng.js
@@ -57,7 +57,7 @@ if (major === 23 || major === 25) {
 
   require('./bootstrap');
 } else if (!nodeUtils.isNodeVersionSupported()) {
-  // Error and exit if less than 22.22 or 24.15.0
+  // Error and exit if less than the supported versions.
   console.error(
     'Node.js version ' +
       process.version +

--- a/packages/angular/cli/bin/ng.js
+++ b/packages/angular/cli/bin/ng.js
@@ -57,7 +57,7 @@ if (major === 23 || major === 25) {
 
   require('./bootstrap');
 } else if (!nodeUtils.isNodeVersionSupported()) {
-  // Error and exit if less than 22.22 or 24.13.1
+  // Error and exit if less than 22.22 or 24.15.0
   console.error(
     'Node.js version ' +
       process.version +


### PR DESCRIPTION
Updates the minimum supported version of Node.js 24 from 24.13.1 to 24.15.0. This includes upgrading the dev toolchain configured for rules_nodejs in MODULE.bazel to Node.js v24.15.0, along with the corresponding archive checksums across all targeted platforms (Darwin, Linux, and Windows).

Also updates target version range constraints in constants.bzl, package.json, and packages/angular/cli/bin/ng.js.

The MODULE.bazel.lock has been updated by running module resolution.
