### PR TITLE
fix(@angular/build): respect tsconfig customConditions in unit-test builder

### DIFF
--- a/packages/angular/build/src/builders/unit-test/builder.ts
+++ b/packages/angular/build/src/builders/unit-test/builder.ts
@@ -327,6 +327,22 @@ export async function* execute(
       progress: normalizedOptions.buildProgress ?? buildTargetOptions.progress,
       quiet: normalizedOptions.quiet,
       ...(normalizedOptions.tsConfig ? { tsConfig: normalizedOptions.tsConfig } : {}),
+      // The `@angular/build:ng-packagr` builder has no `conditions` option, so
+      // its synthesized application options never carry custom resolve
+      // conditions. The application builder forwards `conditions` into
+      // esbuild, and the Angular compiler plugin reuses esbuild's conditions
+      // for the in-plugin TypeScript program; leaving `conditions` unset
+      // therefore makes both esbuild and TypeScript resolve with default
+      // conditions only, diverging from `ng build` via
+      // `@angular/build:ng-packagr` which honors
+      // `compilerOptions.customConditions` natively. Backfill from the test
+      // tsconfig's `compilerOptions.customConditions` to realign all
+      // resolvers. The `@angular/build:application` buildTarget already
+      // exposes `conditions`; only fill in when it wasn't explicitly set.
+      ...((buildTargetOptions as { conditions?: string[] }).conditions === undefined &&
+      normalizedOptions.customConditions
+        ? { conditions: normalizedOptions.customConditions }
+        : {}),
     } satisfies ApplicationBuilderInternalOptions;
 
     const dumpDirectory = normalizedOptions.dumpVirtualFiles

--- a/packages/angular/build/src/builders/unit-test/options.ts
+++ b/packages/angular/build/src/builders/unit-test/options.ts
@@ -9,6 +9,7 @@
 import { type BuilderContext, targetFromTargetString } from '@angular-devkit/architect';
 import { constants, promises as fs } from 'node:fs';
 import path from 'node:path';
+import ts from 'typescript';
 import { normalizeCacheOptions } from '../../utils/normalize-cache';
 import { getProjectRootPaths } from '../../utils/project-metadata';
 import { isTTY } from '../../utils/tty';
@@ -24,6 +25,29 @@ async function exists(path: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+/**
+ * Reads the `compilerOptions.customConditions` from a tsconfig file, honoring
+ * the `extends` chain. Returns `undefined` when no conditions are declared.
+ */
+function readCustomConditionsFromTsConfig(tsConfigPath: string): string[] | undefined {
+  const { config, error } = ts.readConfigFile(tsConfigPath, (p) => ts.sys.readFile(p));
+  if (error || !config) {
+    return undefined;
+  }
+
+  const parsed = ts.parseJsonConfigFileContent(
+    config,
+    ts.sys,
+    path.dirname(tsConfigPath),
+    /* existingOptions */ undefined,
+    tsConfigPath,
+  );
+
+  const conditions = parsed.options.customConditions;
+
+  return Array.isArray(conditions) && conditions.length > 0 ? [...conditions] : undefined;
 }
 
 function normalizeReporterOption(
@@ -89,6 +113,20 @@ export async function normalizeOptions(
     watch = true;
   }
 
+  // Resolve custom package resolution conditions from the test tsconfig so
+  // library tests get parity with `ng build` via `@angular/build:ng-packagr`,
+  // which honors `compilerOptions.customConditions` natively. The unit-test
+  // builder synthesizes an application-builder build whose `conditions` then
+  // feed esbuild's `build.initialOptions.conditions`; the Angular compiler
+  // plugin assigns those esbuild conditions onto `compilerOptions.customConditions`
+  // for the in-plugin TypeScript program. Forwarding the tsconfig values here
+  // therefore aligns esbuild, the in-plugin TS program, and Vitest's resolver
+  // on the same condition set. The `extends` chain is followed by the
+  // TypeScript config parser.
+  const customConditions = tsConfig
+    ? readCustomConditionsFromTsConfig(path.join(workspaceRoot, tsConfig))
+    : undefined;
+
   return {
     // Project/workspace information
     workspaceRoot,
@@ -140,6 +178,7 @@ export async function normalizeOptions(
           ? true
           : path.resolve(workspaceRoot, runnerConfig)
         : runnerConfig,
+    customConditions,
   };
 }
 

--- a/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
@@ -379,6 +379,7 @@ export class VitestExecutor implements TestExecutor {
           include,
           watch,
           isolate: this.options.isolate,
+          customConditions: this.options.customConditions,
         }),
       ],
     };

--- a/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
@@ -55,6 +55,7 @@ interface VitestConfigPluginOptions {
   optimizeDepsInclude: string[];
   watch: boolean;
   isolate: boolean;
+  customConditions: string[] | undefined;
 }
 
 async function findTestEnvironment(
@@ -156,6 +157,7 @@ export async function createVitestConfigPlugin(
     setupFiles,
     projectPlugins,
     projectSourceRoot,
+    customConditions,
   } = options;
 
   const { mergeConfig } = await import('vitest/config');
@@ -257,7 +259,13 @@ export async function createVitestConfigPlugin(
         },
         resolve: {
           mainFields: ['es2020', 'module', 'main'],
-          conditions: ['es2015', 'es2020', 'module', ...(browser ? ['browser'] : [])],
+          conditions: [
+            'es2015',
+            'es2020',
+            'module',
+            ...(browser ? ['browser'] : []),
+            ...(customConditions ?? []),
+          ],
         },
       };
 

--- a/packages/angular/build/src/builders/unit-test/tests/options/conditions_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/conditions_spec.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  setTargetMapping,
+  setupConditionImport,
+} from '../../../../../../../../modules/testing/builder/src/dev_prod_mode';
+import { execute } from '../../builder';
+import {
+  BASE_OPTIONS,
+  describeBuilder,
+  UNIT_TEST_BUILDER_INFO,
+  setupApplicationTarget,
+} from '../setup';
+
+describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
+  describe('Behavior: "customConditions"', () => {
+    const GOOD_TARGET = './src/good.js';
+    const BAD_TARGET = './src/bad.js';
+
+    beforeEach(async () => {
+      setupApplicationTarget(harness);
+      await setupConditionImport(harness);
+
+      // The spec file imports the conditionally-resolved module and only passes
+      // when it resolves to `good.ts`. If `compilerOptions.customConditions`
+      // from the test tsconfig is not honored, resolution falls through to
+      // `bad.ts` and the assertion fails.
+      await harness.writeFile(
+        'src/app/conditions.spec.ts',
+        `
+          import { VALUE } from '#target';
+          describe('custom conditions', () => {
+            it('should resolve through the test tsconfig customConditions', () => {
+              expect(VALUE).toBe('good-value');
+            });
+          });
+        `,
+      );
+
+      // Ensure good/bad sources are reachable by the spec compilation and that
+      // bundler-mode resolution is enabled so `#target` is resolved via the
+      // package.json imports map.
+      await harness.modifyFile('src/tsconfig.spec.json', (content) => {
+        const tsConfig = JSON.parse(content);
+        tsConfig.compilerOptions ??= {};
+        tsConfig.compilerOptions.moduleResolution = 'bundler';
+        tsConfig.files ??= [];
+        tsConfig.files.push('good.ts', 'bad.ts', 'wrong.ts');
+
+        return JSON.stringify(tsConfig);
+      });
+    });
+
+    it('uses tsconfig customConditions when buildTarget has none', async () => {
+      // Map `#target` so only the `staging` condition resolves to the good
+      // target. The unit-test builder must read `customConditions` from the
+      // test tsconfig and forward them to the application build, otherwise
+      // resolution falls back to the `default` entry.
+      await setTargetMapping(harness, {
+        staging: GOOD_TARGET,
+        default: BAD_TARGET,
+      });
+
+      await harness.modifyFile('src/tsconfig.spec.json', (content) => {
+        const tsConfig = JSON.parse(content);
+        tsConfig.compilerOptions ??= {};
+        tsConfig.compilerOptions.customConditions = ['staging'];
+
+        return JSON.stringify(tsConfig);
+      });
+
+      harness.useTarget('test', { ...BASE_OPTIONS });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+    });
+
+    it('does not apply unrelated conditions when tsconfig declares none', async () => {
+      // Same mapping but no `customConditions` declared in the tsconfig: the
+      // `staging` entry must NOT be selected, resolution must land on the
+      // `default` (bad) target, and the spec assertion must fail.
+      await setTargetMapping(harness, {
+        staging: GOOD_TARGET,
+        default: BAD_TARGET,
+      });
+
+      harness.useTarget('test', { ...BASE_OPTIONS });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeFalse();
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When `@angular/build:unit-test` is configured with an `@angular/build:ng-packagr` build target, the synthesized application-builder build never receives the test tsconfig's `compilerOptions.customConditions`. Module resolution therefore diverges from `ng build`, which honors `customConditions` natively through ng-packagr:

- `transformNgPackagrOptions()` only forwards `stylePreprocessorOptions`, `assets` and `inlineStyleLanguage` from `ng-package.json`; ng-packagr's schema has no `conditions` field, so nothing is carried over.
- The synthesized `ApplicationBuilderInternalOptions` is then handed to `buildApplicationInternal()` without `conditions`, so esbuild resolves library imports with only the default conditions (`module`, `development`/`production`, plus `browser`/`node`).
- The Vitest runner's `resolve.conditions` was hardcoded to `['es2015', 'es2020', 'module', (browser)]`, also ignoring custom conditions.

Concrete impact: monorepo setups that use `customConditions` (e.g. a `source` condition) to redirect workspace library imports to local TypeScript sources during development work as expected for `ng build`, but `ng test` silently falls back to the published entry points — defeating the purpose of source‑mapped local development and making library tests harder to debug.

Issue Number: N/A

## What is the new behavior?

The `unit-test` builder now reads `compilerOptions.customConditions` from the test tsconfig (following the `extends` chain via the TypeScript config parser) and:

- forwards them as `conditions` into the synthesized application-builder options, but **only** when the build target did not already set `conditions`. This preserves the existing application-builder behavior, including explicit opt‑outs (`conditions: []`) and user-supplied lists.
- appends them to Vite's `resolve.conditions` in the Vitest plugin, so the runner's own resolver matches the build-time resolution.

No schema changes and no public API surface changes; the new behavior is opt‑in via the existing `compilerOptions.customConditions` tsconfig field (TS 5.0+).

A new integration spec at `packages/angular/build/src/builders/unit-test/tests/options/conditions_spec.ts` locks the behavior in with two cases:

1. **Positive** – with `customConditions: ['staging']` in `tsconfig.spec.json` and a `#target` `imports` map that exposes the good source only under the `staging` condition, the spec resolves to the good source and passes.
2. **Negative regression guard** – same target mapping but no `customConditions` declared; the spec must fall back to the `default` (bad) target, proving the new behavior is opt‑in and does not inject unrelated conditions.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

The new behavior only activates when `compilerOptions.customConditions` is present in the test tsconfig — a field most projects do not set today. For `@angular/build:application` build targets that explicitly set `conditions`, that value is preserved (the backfill is guarded by `conditions === undefined`). For ng-packagr targets, this brings `ng test` into parity with `ng build`, which is a convergence rather than a divergence.

## Other information

Files changed:

- `packages/angular/build/src/builders/unit-test/options.ts` — read `customConditions` from the test tsconfig via `ts.parseJsonConfigFileContent` (extends‑aware) and expose it on the normalized options.
- `packages/angular/build/src/builders/unit-test/builder.ts` — backfill `conditions` into the application-builder options only when the build target did not set it.
- `packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts` — thread `customConditions` through to the Vitest config plugin.
- `packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts` — append `customConditions` to Vite's `resolve.conditions`.
- `packages/angular/build/src/builders/unit-test/tests/options/conditions_spec.ts` — new integration spec.

The Karma runner intentionally was not touched: it does not share the Vite resolver code path, and forwarding `conditions` through the application build it consumes is already covered by the same `builder.ts` change.](https://github.com/angular/angular-cli/pull/33246)