### PR TITLE
fix(@angular/build): escape prerender redirect URLs

### DIFF
--- a/packages/angular/build/src/utils/server-rendering/manifest.ts
+++ b/packages/angular/build/src/utils/server-rendering/manifest.ts
@@ -18,6 +18,7 @@ import {
   BuildOutputFileType,
   createOutputFile,
 } from '../../tools/esbuild/bundler-files';
+import { calculateHash } from '../hash';
 import { findNonce } from '../index-file/nonce';
 import { joinUrlParts } from '../url';
 
@@ -61,6 +62,37 @@ function escapeUnsafeChars(str: string): string {
 }
 
 /**
+ * Matches every character which is not safe in the name of a generated server asset chunk.
+ */
+const UNSAFE_CHUNK_NAME_CHARACTER_REGEXP = /[^a-zA-Z0-9_-]/g;
+
+/**
+ * The maximum number of characters of an asset path kept in the name of its generated chunk.
+ * The appended digest is what makes the name unique, so the readable part can be truncated to
+ * stay well within the file name length limits of all supported platforms.
+ */
+const MAX_CHUNK_NAME_LENGTH = 128;
+
+/**
+ * Builds the path of the generated chunk which holds the content of a server asset.
+ *
+ * Asset paths are derived from route paths and can therefore contain characters which are unusable
+ * in a file name (`?`, `:` and `*` are invalid on Windows) or which change how the generated
+ * dynamic import is resolved (`?`, `#` and `%` are URL syntax). Those characters are replaced, and
+ * a digest of the asset path is appended so that two asset paths never share a chunk.
+ *
+ * @param assetPath - The path of the asset, for example `store/summer sale/index.html`.
+ * @returns The path of the chunk to generate for the asset.
+ */
+function generateServerAssetChunkPath(assetPath: string): string {
+  const name = assetPath
+    .replace(UNSAFE_CHUNK_NAME_CHARACTER_REGEXP, '_')
+    .slice(0, MAX_CHUNK_NAME_LENGTH);
+
+  return `assets-chunks/${name}-${calculateHash(assetPath)}.mjs`;
+}
+
+/**
  * Generates the server manifest for the App Engine environment.
  *
  * This manifest is used to configure the server-side rendering (SSR) setup for the
@@ -85,7 +117,7 @@ export function generateAngularServerAppEngineManifest(
     for (const locale of i18nOptions.inlineLocales) {
       const { subPath } = i18nOptions.locales[locale];
       const importPath = `${subPath ? `${subPath}/` : ''}${MAIN_SERVER_OUTPUT_FILENAME}`;
-      entryPoints[subPath] = `() => import('./${importPath}')`;
+      entryPoints[subPath] = `() => import(${JSON.stringify(`./${importPath}`)})`;
       supportedLocales[locale] = subPath;
     }
   } else {
@@ -101,12 +133,12 @@ export function generateAngularServerAppEngineManifest(
 
   const manifestContent = `
 export default {
-  basePath: '${basePath}',
+  basePath: ${JSON.stringify(basePath)},
   allowedHosts: ${JSON.stringify(allowedHosts, undefined, 2)},
   supportedLocales: ${JSON.stringify(supportedLocales, undefined, 2)},
   entryPoints: {
     ${Object.entries(entryPoints)
-      .map(([key, value]) => `'${key}': ${value}`)
+      .map(([key, value]) => `${JSON.stringify(key)}: ${value}`)
       .join(',\n    ')}
   },
 };
@@ -170,7 +202,7 @@ export async function generateAngularServerAppManifest(
   for (const file of [...additionalHtmlOutputFiles.values(), ...outputFiles]) {
     const extension = extname(file.path);
     if (extension === '.html') {
-      const jsChunkFilePath = `assets-chunks/${file.path.replace(/[./]/g, '_')}.mjs`;
+      const jsChunkFilePath = generateServerAssetChunkPath(file.path);
       const escapedContent = escapeUnsafeChars(file.text);
 
       serverAssetsChunks.push(
@@ -190,8 +222,11 @@ export async function generateAngularServerAppManifest(
         pos = file.text.indexOf('\r\n', pos + 2);
       }
 
+      // Asset paths are derived from route paths and can contain arbitrary characters, so they are
+      // serialized rather than interpolated into the generated executable manifest.
       serverAssets[file.path] =
-        `{size: ${size}, hash: '${file.hash}', text: () => import('./${jsChunkFilePath}').then(m => m.default)}`;
+        `{size: ${size}, hash: ${JSON.stringify(file.hash)}, ` +
+        `text: () => import(${JSON.stringify(`./${jsChunkFilePath}`)}).then(m => m.default)}`;
     } else if (inlineCriticalCss && extension === '.css') {
       const sheet = compileSheet(file.text, {
         href: joinUrlParts(publicPath ?? '', file.path),
@@ -213,7 +248,7 @@ export async function generateAngularServerAppManifest(
   const manifestContent = `
 export default {
   bootstrap: () => import('./main.server.mjs').then(m => m.default),
-  baseHref: '${baseHref}',
+  baseHref: ${JSON.stringify(baseHref)},
 ${criticalCssPlans.length ? `  criticalCssPlans: ${JSON.stringify(criticalCssPlans)},\n` : ''}${
     nonce ? `  nonce: ${JSON.stringify(nonce)},\n` : ''
   }  locale: ${JSON.stringify(locale)},
@@ -221,7 +256,7 @@ ${criticalCssPlans.length ? `  criticalCssPlans: ${JSON.stringify(criticalCssPla
   entryPointToBrowserMapping: ${JSON.stringify(entryPointToBrowserMapping, undefined, 2)},
   assets: {
     ${Object.entries(serverAssets)
-      .map(([key, value]) => `'${key}': ${value}`)
+      .map(([key, value]) => `${JSON.stringify(key)}: ${value}`)
       .join(',\n    ')}
   },
 };

--- a/packages/angular/build/src/utils/server-rendering/manifest_spec.ts
+++ b/packages/angular/build/src/utils/server-rendering/manifest_spec.ts
@@ -11,12 +11,47 @@ import { BuildOutputFileType, createOutputFile } from '../../tools/esbuild/bundl
 import { initializeHash } from '../hash';
 import { generateAngularServerAppManifest } from './manifest';
 
+/**
+ * Evaluates a generated manifest, which both asserts that it is syntactically valid JavaScript and
+ * gives access to the values it declares. The dynamic imports it contains are never invoked.
+ */
+function evaluateManifest(manifestContent: string): Record<string, unknown> {
+  return new Function(manifestContent.replace('export default', 'return'))() as Record<
+    string,
+    unknown
+  >;
+}
+
+const dummyMetafile = { inputs: {}, outputs: {} } as unknown as Metafile;
+
+function generateManifest(
+  htmlOutputFiles: Record<string, string>,
+  baseHref = '/',
+): ReturnType<typeof generateAngularServerAppManifest> {
+  const additionalHtmlOutputFiles = new Map(
+    Object.entries(htmlOutputFiles).map(([path, content]) => [
+      path,
+      createOutputFile(path, content, BuildOutputFileType.Browser),
+    ]),
+  );
+
+  return generateAngularServerAppManifest(
+    additionalHtmlOutputFiles,
+    [],
+    false,
+    undefined,
+    undefined,
+    baseHref,
+    new Set(),
+    dummyMetafile,
+    undefined,
+  );
+}
+
 describe('generateAngularServerAppManifest', () => {
   beforeAll(async () => {
     await initializeHash();
   });
-
-  const dummyMetafile = { inputs: {}, outputs: {} } as unknown as Metafile;
 
   it('should include criticalCssPlans when inlineCriticalCss is true', async () => {
     const additionalHtml = new Map([
@@ -138,6 +173,66 @@ describe('generateAngularServerAppManifest', () => {
     );
 
     expect(serverAssetsChunks.some((chunk) => chunk.path.includes('styles'))).toBeFalse();
-    expect(manifestContent).not.toContain("'styles.css':");
+    expect(manifestContent).not.toContain('"styles.css":');
+  });
+
+  it('serializes asset paths which contain JavaScript string delimiters', async () => {
+    const assetPath = "catalog/customer's-choice/index.html";
+    const { manifestContent } = await generateManifest({
+      [assetPath]: '<main>Featured</main>',
+    });
+
+    const assets = evaluateManifest(manifestContent)['assets'] as Record<string, unknown>;
+    expect(Object.keys(assets)).toEqual([assetPath]);
+  });
+
+  it('serializes a base href which contains JavaScript string delimiters', async () => {
+    const { manifestContent } = await generateManifest(
+      { 'index.html': '<main></main>' },
+      "/o'brien/",
+    );
+
+    expect(evaluateManifest(manifestContent)['baseHref']).toBe("/o'brien/");
+  });
+
+  it('generates chunk names which are usable as a file name and as a module specifier', async () => {
+    const assetPath = "catalog/customer's#featured?ratio=50%/index.html";
+    const { serverAssetsChunks } = await generateManifest({
+      [assetPath]: '<main>Featured</main>',
+    });
+
+    expect(serverAssetsChunks).toHaveSize(1);
+    expect(serverAssetsChunks[0].path).toMatch(/^assets-chunks\/[a-zA-Z0-9_-]+\.mjs$/);
+  });
+
+  it('generates a dynamic import which resolves back to the emitted chunk', async () => {
+    // The in-memory ESM loader used while prerendering resolves the specifier as a URL and looks the
+    // result up by output file path, so the two have to match exactly.
+    const assetPath = "catalog/customer's#featured?ratio=50%/index.html";
+    const { manifestContent, serverAssetsChunks } = await generateManifest({
+      [assetPath]: '<main>Featured</main>',
+    });
+
+    const assets = evaluateManifest(manifestContent)['assets'] as Record<
+      string,
+      { text: () => Promise<string> }
+    >;
+    const specifier = /import\("(.+?)"\)/.exec(assets[assetPath].text.toString())?.[1];
+
+    const root = 'file:///virtual/root/';
+    expect(specifier).toBeDefined();
+    expect(new URL(specifier as string, root).href.slice(root.length)).toBe(
+      serverAssetsChunks[0].path,
+    );
+  });
+
+  it('generates a distinct chunk for asset paths which map to the same name', async () => {
+    const { serverAssetsChunks } = await generateManifest({
+      'foo/bar/index.html': '<main>nested</main>',
+      'foo_bar/index.html': '<main>flat</main>',
+    });
+
+    expect(serverAssetsChunks).toHaveSize(2);
+    expect(serverAssetsChunks[0].path).not.toBe(serverAssetsChunks[1].path);
   });
 });

--- a/packages/angular/build/src/utils/server-rendering/prerender.ts
+++ b/packages/angular/build/src/utils/server-rendering/prerender.ts
@@ -26,7 +26,7 @@ import {
   WritableSerializableRouteTreeNode,
 } from './models';
 import type { RenderWorkerData } from './render-worker';
-import { generateRedirectStaticPage } from './utils';
+import { generateRedirectStaticPage, validateStaticRedirectUrl } from './utils';
 
 type PrerenderOptions = NormalizedApplicationBuildOptions['prerenderOptions'];
 type AppShellOptions = NormalizedApplicationBuildOptions['appShellOptions'];
@@ -131,6 +131,14 @@ export async function prerenderPages(
 
   const serializableRouteTreeNodeForPrerender: WritableSerializableRouteTreeNode = [];
   for (const metadata of serializableRouteTreeNode) {
+    if (outputMode === OutputMode.Static) {
+      const invalidStaticRedirect = validateExtractedStaticRedirect(metadata);
+      if (invalidStaticRedirect) {
+        errors.push(invalidStaticRedirect);
+        continue;
+      }
+    }
+
     if (outputMode !== OutputMode.Static && metadata.redirectTo) {
       // Skip redirects if output mode is not static.
       continue;
@@ -288,6 +296,37 @@ async function renderPages(
     errors,
     output,
   };
+}
+
+function validateExtractedStaticRedirect({
+  route,
+  redirectTo,
+  headers,
+}: SerializableRouteTreeNode[number]): string | undefined {
+  if (redirectTo !== undefined) {
+    const invalidRedirectReason = validateStaticRedirectUrl(redirectTo);
+    if (invalidRedirectReason) {
+      return (
+        `Invalid 'redirectTo' for route '${stripLeadingSlash(route)}': ${invalidRedirectReason} ` +
+        `Such values would be embedded verbatim in the generated static redirect page, ` +
+        `which can lead to HTML injection. Percent-encode the value or sanitize the source.`
+      );
+    }
+  }
+
+  const location = headers?.['Location'] ?? headers?.['location'];
+  if (location !== undefined) {
+    const invalidLocationReason = validateStaticRedirectUrl(location);
+    if (invalidLocationReason) {
+      return (
+        `Invalid 'headers.Location' for route '${stripLeadingSlash(route)}': ${invalidLocationReason} ` +
+        `Such values would be embedded verbatim in the generated static redirect page, ` +
+        `which can lead to HTML injection. Percent-encode the value or sanitize the source.`
+      );
+    }
+  }
+
+  return undefined;
 }
 
 async function getAllRoutes(

--- a/packages/angular/build/src/utils/server-rendering/utils.ts
+++ b/packages/angular/build/src/utils/server-rendering/utils.ts
@@ -22,26 +22,90 @@ export function isSsrRequestHandler(
   return typeof value === 'function' && '__ng_request_handler__' in value;
 }
 
+const htmlEscapeCharacters: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+function escapeHtml(text: string): string {
+  return text.replace(/[&<>"']/g, (character) => htmlEscapeCharacters[character]);
+}
+
+const unsafeStaticRedirectCharacters = /[\\<>"'`]/;
+const allowedStaticRedirectProtocols = new Set(['http:', 'https:']);
+
+function hasUnsafeStaticRedirectCharacters(value: string): boolean {
+  for (let index = 0; index < value.length; index++) {
+    const characterCode = value.charCodeAt(index);
+    if (characterCode <= 0x20 || characterCode === 0x7f) {
+      return true;
+    }
+  }
+
+  return unsafeStaticRedirectCharacters.test(value);
+}
+
+export function validateStaticRedirectUrl(url: string): string | undefined {
+  if (hasUnsafeStaticRedirectCharacters(url)) {
+    return (
+      `the value '${url}' contains characters that are not allowed in a statically ` +
+      `emitted URL (control characters, whitespace, backslash, or HTML-significant characters).`
+    );
+  }
+
+  if (url.startsWith('/')) {
+    return url.startsWith('//')
+      ? 'protocol-relative URLs are not supported for statically emitted redirects. ' +
+          'Only HTTP(S) URLs and same-origin absolute paths are supported.'
+      : undefined;
+  }
+
+  const schemeMatch = /^([a-zA-Z][a-zA-Z0-9+\-.]*):/.exec(url);
+  if (!schemeMatch) {
+    return (
+      `the value '${url}' is not a valid absolute URL or same-origin absolute path. ` +
+      `Only HTTP(S) URLs and same-origin absolute paths are supported.`
+    );
+  }
+
+  const protocol = `${schemeMatch[1].toLowerCase()}:`;
+  if (!allowedStaticRedirectProtocols.has(protocol)) {
+    return (
+      `the protocol '${protocol}' is not allowed for a statically emitted redirect. ` +
+      `Only HTTP(S) URLs and same-origin absolute paths are supported.`
+    );
+  }
+
+  return undefined;
+}
+
 /**
  * Generates a static HTML page with a meta refresh tag to redirect the user to a specified URL.
  *
  * This function creates a simple HTML page that performs a redirect using a meta tag.
  * It includes a fallback link in case the meta-refresh doesn't work.
  *
+ * The provided URL is HTML-escaped before being interpolated.
+ *
  * @param url - The URL to which the page should redirect.
  * @returns The HTML content of the static redirect page.
  */
 export function generateRedirectStaticPage(url: string): string {
+  const escapedUrl = escapeHtml(url);
+
   return `
 <!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8">
     <title>Redirecting</title>
-    <meta http-equiv="refresh" content="0; url=${url}">
+    <meta http-equiv="refresh" content="0; url=${escapedUrl}">
   </head>
   <body>
-    <pre>Redirecting to <a href="${url}">${url}</a></pre>
+    <pre>Redirecting to <a href="${escapedUrl}">${escapedUrl}</a></pre>
   </body>
 </html>
 `.trim();

--- a/packages/angular/build/src/utils/server-rendering/utils.ts
+++ b/packages/angular/build/src/utils/server-rendering/utils.ts
@@ -23,25 +23,52 @@ export function isSsrRequestHandler(
 }
 
 /**
+ * A mapping of the characters which have to be escaped to be interpolated into HTML,
+ * to their entity equivalents.
+ */
+const HTML_ESCAPE_CHARACTER_MAP: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+/**
+ * Escapes the characters of a value which is interpolated into HTML text or into a quoted
+ * attribute value.
+ *
+ * @param text - The value to escape.
+ * @returns The escaped value.
+ */
+function escapeHtml(text: string): string {
+  return text.replace(/[&<>"']/g, (character) => HTML_ESCAPE_CHARACTER_MAP[character]);
+}
+
+/**
  * Generates a static HTML page with a meta refresh tag to redirect the user to a specified URL.
  *
  * This function creates a simple HTML page that performs a redirect using a meta tag.
  * It includes a fallback link in case the meta-refresh doesn't work.
  *
+ * The provided URL is HTML-escaped before being interpolated.
+ *
  * @param url - The URL to which the page should redirect.
  * @returns The HTML content of the static redirect page.
  */
 export function generateRedirectStaticPage(url: string): string {
+  const escapedUrl = escapeHtml(url);
+
   return `
 <!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8">
     <title>Redirecting</title>
-    <meta http-equiv="refresh" content="0; url=${url}">
+    <meta http-equiv="refresh" content="0; url=${escapedUrl}">
   </head>
   <body>
-    <pre>Redirecting to <a href="${url}">${url}</a></pre>
+    <pre>Redirecting to <a href="${escapedUrl}">${escapedUrl}</a></pre>
   </body>
 </html>
 `.trim();

--- a/packages/angular/build/src/utils/server-rendering/utils_spec.ts
+++ b/packages/angular/build/src/utils/server-rendering/utils_spec.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { generateRedirectStaticPage } from './utils';
+
+describe('generateRedirectStaticPage', () => {
+  it('escapes the ampersands of a redirect target', () => {
+    const page = generateRedirectStaticPage('https://example.com/docs?from=ssg&next=/ssg');
+
+    expect(page).toContain(
+      '<meta http-equiv="refresh" content="0; url=https://example.com/docs?from=ssg&amp;next=/ssg">',
+    );
+    expect(page).toContain(
+      '<a href="https://example.com/docs?from=ssg&amp;next=/ssg">' +
+        'https://example.com/docs?from=ssg&amp;next=/ssg</a>',
+    );
+  });
+
+  it('escapes characters which would break out of the attribute or the tag', () => {
+    const page = generateRedirectStaticPage(`/"><script>alert('1')</script>`);
+
+    expect(page).not.toContain('<script>');
+    expect(page).toContain(
+      '<meta http-equiv="refresh" content="0; url=' +
+        '/&quot;&gt;&lt;script&gt;alert(&#39;1&#39;)&lt;/script&gt;">',
+    );
+    expect(page).toContain('<a href="/&quot;&gt;&lt;script&gt;alert(&#39;1&#39;)&lt;/script&gt;">');
+  });
+});

--- a/packages/angular/ssr/src/routes/ng-routes.ts
+++ b/packages/angular/ssr/src/routes/ng-routes.ts
@@ -30,7 +30,11 @@ import { Console } from '../console';
 import { AngularAppManifest, getAngularAppManifest } from '../manifest';
 import { AngularBootstrap, isNgModule } from '../utils/ng';
 import { promiseWithAbort } from '../utils/promise';
-import { VALID_REDIRECT_RESPONSE_CODES, isValidRedirectResponseCode } from '../utils/redirect';
+import {
+  VALID_REDIRECT_RESPONSE_CODES,
+  isValidRedirectResponseCode,
+  validateUrlForStaticEmission,
+} from '../utils/redirect';
 import { addTrailingSlash, joinUrlParts, stripLeadingSlash } from '../utils/url';
 import {
   PrerenderFallback,
@@ -522,6 +526,16 @@ function handlePrerenderParamsReplacement(
           `returned a non-string value for parameter '${parameterName}'. ` +
           `Please make sure the 'getPrerenderParams' function returns values for all parameters ` +
           'specified in this route.',
+      );
+    }
+
+    const invalidValueReason = validateUrlForStaticEmission(value);
+    if (invalidValueReason) {
+      throw new Error(
+        `The 'getPrerenderParams' function defined for the '${stripLeadingSlash(currentRoutePath)}' route ` +
+          `returned an unsafe value for parameter '${parameterName}': ${invalidValueReason} ` +
+          `Such values would be embedded verbatim in generated URLs and static HTML, ` +
+          `which can lead to HTML injection. Percent-encode the value or sanitize the source.`,
       );
     }
 

--- a/packages/angular/ssr/src/routes/ng-routes.ts
+++ b/packages/angular/ssr/src/routes/ng-routes.ts
@@ -30,8 +30,14 @@ import { Console } from '../console';
 import { AngularAppManifest, getAngularAppManifest } from '../manifest';
 import { AngularBootstrap, isNgModule } from '../utils/ng';
 import { promiseWithAbort } from '../utils/promise';
-import { VALID_REDIRECT_RESPONSE_CODES, isValidRedirectResponseCode } from '../utils/redirect';
-import { addTrailingSlash, joinUrlParts, stripLeadingSlash } from '../utils/url';
+import {
+  NormalizedUrl,
+  VALID_REDIRECT_RESPONSE_CODES,
+  isValidRedirectResponseCode,
+  normalizeAndValidateRedirect,
+  normalizeAndValidateRoutePath,
+} from '../utils/redirect';
+import { addLeadingSlash, addTrailingSlash, joinUrlParts, stripLeadingSlash } from '../utils/url';
 import {
   PrerenderFallback,
   RenderMode,
@@ -189,10 +195,15 @@ async function* handleRoute(options: {
             `Please use one of the following redirect response codes: ${[...VALID_REDIRECT_RESPONSE_CODES.values()].join(', ')}.`,
         };
       } else if (typeof redirectTo === 'string') {
-        yield {
-          ...metadata,
-          redirectTo: resolveRedirectTo(metadata.route, redirectTo),
-        };
+        const { url, error } = resolveRedirectTo(metadata.route, redirectTo);
+        if (error !== undefined) {
+          yield { error: invalidRedirectError(metadata.route, error) };
+        } else {
+          yield {
+            ...metadata,
+            redirectTo: url,
+          };
+        }
       } else {
         yield metadata;
       }
@@ -420,7 +431,14 @@ async function* handleSSGRoute(
   }
 
   if (redirectTo !== undefined) {
-    meta.redirectTo = resolveRedirectTo(currentRoutePath, redirectTo);
+    const { url, error } = resolveRedirectTo(currentRoutePath, redirectTo);
+    if (error !== undefined) {
+      yield { error: invalidRedirectError(currentRoutePath, error) };
+
+      return;
+    }
+
+    meta.redirectTo = url;
   }
 
   const isCatchAllRoute = CATCH_ALL_REGEXP.test(currentRoutePath);
@@ -472,13 +490,38 @@ async function* handleSSGRoute(
           .replace(URL_PARAMETER_GLOBAL_REGEXP, replacer)
           .replace(CATCH_ALL_REGEXP, replacer);
 
+        // A parameter value is only meaningful in the context of the route it is substituted into,
+        // so the composed path is what gets normalized and validated. This also catches values that
+        // only become unsafe once combined with the route, such as a protocol-relative `//`.
+        const { url: route, error: routeError } = normalizeAndValidateRoutePath(
+          addLeadingSlash(routeWithResolvedParams),
+        );
+        if (routeError !== undefined) {
+          yield {
+            error:
+              `The '${stripLeadingSlash(currentRoutePath)}' route produced an invalid ` +
+              `prerender path: ${routeError}`,
+          };
+
+          continue;
+        }
+
+        let resolvedRedirectTo: string | undefined;
+        if (redirectTo !== undefined) {
+          const { url, error } = resolveRedirectTo(routeWithResolvedParams, redirectTo);
+          if (error !== undefined) {
+            yield { error: invalidRedirectError(routeWithResolvedParams, error) };
+
+            continue;
+          }
+
+          resolvedRedirectTo = url;
+        }
+
         yield {
           ...meta,
-          route: routeWithResolvedParams,
-          redirectTo:
-            redirectTo === undefined
-              ? undefined
-              : resolveRedirectTo(routeWithResolvedParams, redirectTo),
+          route,
+          redirectTo: resolvedRedirectTo,
         };
       }
     } catch (error) {
@@ -525,7 +568,10 @@ function handlePrerenderParamsReplacement(
       );
     }
 
-    return parameterName === '**' ? `/${value}` : value;
+    // The matched placeholder includes the separator, so it has to be re-added. The documented
+    // value of a `**` parameter is a path, which may already carry it: re-adding it unconditionally
+    // would compose a root catch-all into a protocol-relative `//foo/bar`.
+    return parameterName === '**' ? addLeadingSlash(value) : value;
   };
 }
 
@@ -536,21 +582,69 @@ function handlePrerenderParamsReplacement(
  * resolves relative to the current route path. If `redirectTo` is an absolute path,
  * it is returned as is. If it is a relative path, it is resolved based on the current route path.
  *
+ * The resolved target is then normalized and validated, so that every `redirectTo` reaching the
+ * route tree is a safe HTTP(S) URL or same-origin path.
+ *
  * @param routePath - The current route path.
  * @param redirectTo - The target path for redirection.
- * @returns The resolved redirect path as a string.
+ * @returns The normalized redirect target, or the reason it was rejected.
  */
-function resolveRedirectTo(routePath: string, redirectTo: string): string {
+function resolveRedirectTo(routePath: string, redirectTo: string): NormalizedUrl {
   if (redirectTo[0] === '/') {
-    // If the redirectTo path is absolute, return it as is.
-    return redirectTo;
+    // If the redirectTo path is absolute, use it as is.
+    return normalizeAndValidateRedirect(redirectTo);
   }
 
   // Resolve relative redirectTo based on the current route path.
   const segments = routePath.replace(URL_PARAMETER_GLOBAL_REGEXP, '*').split('/');
   segments.pop(); // Remove the last segment to make it relative.
 
-  return joinUrlParts(...segments, redirectTo);
+  return normalizeAndValidateRedirect(joinUrlParts(...segments, redirectTo));
+}
+
+/**
+ * Builds the diagnostic emitted when a route's `redirectTo` cannot be normalized.
+ *
+ * @param routePath - The route the `redirectTo` is defined on.
+ * @param reason - The reason reported by the redirect normalization.
+ * @returns The error message to report.
+ */
+function invalidRedirectError(routePath: string, reason: string): string {
+  return `The 'redirectTo' value for the '${stripLeadingSlash(routePath)}' route is invalid: ${reason}`;
+}
+
+/**
+ * Validates and normalizes the `Location` header of a server route configuration.
+ *
+ * A configured `Location` header turns the route into a redirect, both at runtime and in the static
+ * redirect page generated when prerendering, so its value is validated as a redirect target. HTTP
+ * header names are case-insensitive, so every entry which names the `Location` header is checked.
+ *
+ * @param headers - The headers configured for the route.
+ * @returns The headers with each `Location` value normalized, or the reason one was rejected.
+ */
+function normalizeLocationHeaders(
+  headers: Record<string, string>,
+): { headers: Record<string, string>; error?: undefined } | { headers?: undefined; error: string } {
+  let normalized: Record<string, string> | undefined;
+
+  for (const [name, value] of Object.entries(headers)) {
+    if (name.toLowerCase() !== 'location') {
+      continue;
+    }
+
+    const { url, error } = normalizeAndValidateRedirect(value);
+    if (error !== undefined) {
+      return { error };
+    }
+
+    // Store the normalized value so that the header sent at runtime and the generated static
+    // redirect page are the value which was validated.
+    normalized ??= { ...headers };
+    normalized[name] = url;
+  }
+
+  return { headers: normalized ?? headers };
 }
 
 /**
@@ -593,10 +687,43 @@ function buildServerConfigRouteTree({ routes, appShellRoute }: ServerRoutesConfi
       continue;
     }
 
+    if (metadata.headers) {
+      const { headers, error } = normalizeLocationHeaders(metadata.headers);
+      if (error !== undefined) {
+        errors.push(
+          `Invalid '${path}' route configuration: the 'headers.Location' value is invalid: ${error}`,
+        );
+        continue;
+      }
+
+      metadata.headers = headers;
+    }
+
     serverConfigRouteTree.insert(path, metadata);
   }
 
   return { serverConfigRouteTree, errors };
+}
+
+/**
+ * Builds the key used to de-duplicate an extracted route.
+ *
+ * `RouteTree` percent-decodes every segment when a route is inserted, so two route paths which
+ * differ only in their encoding land on the same node, where the later one overwrites the earlier.
+ * De-duplication therefore runs on the decoded path rather than on the path as it was written:
+ * a prerendered path is normalized by the URL parser while the path of every other render mode is
+ * not, so the same route can be reached in both an encoded and an unencoded form.
+ *
+ * @param route - The route path to build a key for.
+ * @returns The decoded route path.
+ */
+function routeDeduplicationKey(route: string): string {
+  try {
+    return route.split('/').map(decodeURIComponent).join('/');
+  } catch {
+    // A malformed percent escape is reported when the route is inserted into the route tree.
+    return route;
+  }
 }
 
 /**
@@ -721,7 +848,7 @@ export async function getRoutesFromAngularRouterConfig(
 
         // If a result already exists for the exact same route, subsequent matches should be ignored.
         // This aligns with Angular's app router behavior, which prioritizes the first route.
-        const routePath = routeMetadata.route;
+        const routePath = routeDeduplicationKey(routeMetadata.route);
         if (!seenRoutes.has(routePath)) {
           routesResults.push(routeMetadata);
           seenRoutes.add(routePath);

--- a/packages/angular/ssr/src/utils/redirect.ts
+++ b/packages/angular/ssr/src/utils/redirect.ts
@@ -22,6 +22,47 @@ export function isValidRedirectResponseCode(code: number): boolean {
 }
 
 /**
+ * Characters that must never appear in a statically-emitted redirect target or
+ * in a value substituted into a prerendered URL. They are rejected during route
+ * extraction so they cannot break out of generated HTML contexts or smuggle
+ * markup through the route path.
+ *
+ * - C0 controls and DEL (`\u0000`-`\u001F`, `\u007F`) and whitespace
+ * - Backslash (`\`) - not a valid URL path separator
+ * - HTML-significant characters: `<`, `>`, `"`, `'`, `` ` ``
+ */
+const UNSAFE_URL_CHARACTERS_REGEXP = /[\\<>"'`]/;
+
+function hasUnsafeUrlCharacters(value: string): boolean {
+  for (let index = 0; index < value.length; index++) {
+    const characterCode = value.charCodeAt(index);
+    if (characterCode <= 0x20 || characterCode === 0x7f) {
+      return true;
+    }
+  }
+
+  return UNSAFE_URL_CHARACTERS_REGEXP.test(value);
+}
+
+/**
+ * Validates that the given value is safe to embed in a generated redirect page
+ * or to use as a prerendered URL path segment.
+ *
+ * Returns `undefined` when the value is safe, otherwise returns a human-readable
+ * error message describing why it was rejected.
+ */
+export function validateUrlForStaticEmission(value: string): string | undefined {
+  if (hasUnsafeUrlCharacters(value)) {
+    return (
+      `the value '${value}' contains characters that are not allowed in a statically ` +
+      `emitted URL (control characters, whitespace, backslash, or HTML-significant characters).`
+    );
+  }
+
+  return undefined;
+}
+
+/**
  * Creates an HTTP redirect response with a specified location and status code.
  *
  * @param location - The URL to which the response should redirect.

--- a/packages/angular/ssr/src/utils/redirect.ts
+++ b/packages/angular/ssr/src/utils/redirect.ts
@@ -24,13 +24,232 @@ export function isValidRedirectResponseCode(code: number): boolean {
 }
 
 /**
+ * Base URL used to resolve relative values with the WHATWG URL parser.
+ *
+ * Any origin works; a loopback address is used so that a value which manages to change the
+ * origin is trivially detectable.
+ */
+const RELATIVE_URL_BASE = 'http://127.0.0.1';
+
+/**
+ * Protocols that are supported as the target of a redirect.
+ */
+const ALLOWED_REDIRECT_PROTOCOLS: ReadonlySet<string> = new Set(['http:', 'https:']);
+
+/**
+ * Matches the URL syntax characters that a route segment must not contain once it has been
+ * percent-decoded. `/` and `\` are separators and `?`, `#` and `%` are URL syntax, so a segment
+ * which decodes into any of them is no longer the single segment that was validated.
+ */
+const UNSAFE_DECODED_SEGMENT_REGEXP = /[\\/?#%]/;
+
+/**
+ * Determines whether a percent-decoded route segment can still be used as a single path segment.
+ *
+ * Control characters are rejected in addition to the URL syntax characters, as they are valid
+ * neither in a URL nor in the directory that the prerendered page is written to.
+ *
+ * @param segment - The decoded segment to check.
+ * @returns `true` when the segment cannot be used as a path segment.
+ */
+function isUnsafeDecodedSegment(segment: string): boolean {
+  if (UNSAFE_DECODED_SEGMENT_REGEXP.test(segment)) {
+    return true;
+  }
+
+  for (let index = 0; index < segment.length; index++) {
+    const code = segment.charCodeAt(index);
+    if (code < 0x20 || code === 0x7f) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * The outcome of normalizing a URL value: either the normalized value, or the reason the value
+ * was rejected. Exactly one of `url` and `error` is set.
+ */
+export type NormalizedUrl = { url: string; error?: undefined } | { url?: undefined; error: string };
+
+/**
+ * Parses a value that has to stay within the application origin.
+ *
+ * Normalization is delegated to the WHATWG URL parser, which percent-encodes characters that are
+ * unsafe in a path (spaces, `<`, `>`, `"`, control characters, ...) and collapses `.` and `..`
+ * segments, while leaving characters that are legal in a path, such as apostrophes, untouched.
+ *
+ * The returned URL is guaranteed to resolve to the application origin and to have a path which
+ * cannot be read as protocol-relative.
+ *
+ * @param value - The value to parse, for example `/docs/a b`.
+ * @returns The parsed URL, or the reason the value was rejected.
+ */
+function parseSameOriginUrl(
+  value: string,
+): { url: URL; error?: undefined } | { url?: undefined; error: string } {
+  // The URL parser treats a leading `//` as an authority and normalizes backslashes to forward
+  // slashes for special schemes. Both allow a value to silently point at a different origin.
+  if (value.startsWith('//') || value.includes('\\')) {
+    return {
+      error:
+        `'${value}' is not a valid same-origin path. ` +
+        `Protocol-relative paths ('//') and backslashes ('\\') are not supported.`,
+    };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value, RELATIVE_URL_BASE);
+  } catch {
+    return { error: `'${value}' could not be parsed as a URL.` };
+  }
+
+  if (parsed.origin !== RELATIVE_URL_BASE) {
+    return { error: `'${value}' resolves outside of the application origin.` };
+  }
+
+  // The parser resolves `.` and `..` segments, so a value which passed the check above can still
+  // come back with a leading `//`. The origin is unchanged when that happens, which means neither
+  // check so far rejects it, yet the resulting path is read as an authority by everything the
+  // value is handed to. The check is therefore repeated on the parsed path.
+  if (parsed.pathname.startsWith('//')) {
+    return {
+      error:
+        `'${value}' is not a valid same-origin path. ` +
+        `It resolves to the protocol-relative path '${parsed.pathname}'.`,
+    };
+  }
+
+  return { url: parsed };
+}
+
+/**
+ * Normalizes and validates the path that a route is prerendered under.
+ *
+ * On top of the same-origin normalization, the path has to survive the round trip it makes through
+ * the route tree: `RouteTree` percent-decodes every segment when a route is inserted, and decodes
+ * it again on the server when the serialized tree is restored. A segment is therefore only accepted
+ * when decoding it succeeds, yields a plain path segment, and leaves nothing further to decode.
+ * Dot segments are rejected rather than resolved, because a route which is prerendered somewhere
+ * other than where it is defined would silently overwrite the output of another route.
+ *
+ * @param path - The path to normalize, for example `/store/summer sale`.
+ * @returns The normalized path, or the reason it was rejected.
+ */
+export function normalizeAndValidateRoutePath(path: string): NormalizedUrl {
+  const { url: parsed, error } = parseSameOriginUrl(path);
+  if (error !== undefined) {
+    return { error };
+  }
+
+  if (parsed.search || parsed.hash) {
+    return {
+      error: `'${path}' is not a valid route path. A route cannot carry a query string or a fragment.`,
+    };
+  }
+
+  // Segments are validated on the value which was passed in rather than on the normalized pathname.
+  // The URL parser resolves `.` and `..` segments, including their percent-encoded forms, which
+  // would otherwise silently move the route to a completely different path.
+  for (const segment of path.split('/')) {
+    if (!segment) {
+      continue;
+    }
+
+    let decoded: string;
+    try {
+      decoded = decodeURIComponent(segment);
+    } catch {
+      return {
+        error:
+          `'${path}' is not a valid route path. ` +
+          `The '${segment}' segment is not a valid percent-encoded value.`,
+      };
+    }
+
+    if (decoded === '.' || decoded === '..') {
+      return {
+        error:
+          `'${path}' is not a valid route path. ` +
+          `The '${segment}' segment decodes to the '${decoded}' path traversal segment.`,
+      };
+    }
+
+    if (isUnsafeDecodedSegment(decoded)) {
+      return {
+        error:
+          `'${path}' is not a valid route path. ` +
+          `The '${segment}' segment decodes to a value which is not a single path segment. ` +
+          `Separators, the URL syntax characters '?', '#' and '%' and control characters are not supported.`,
+      };
+    }
+  }
+
+  return { url: parsed.pathname };
+}
+
+/**
+ * Normalizes and validates a redirect target.
+ *
+ * Targets that carry a scheme must use HTTP(S). Anything else, such as `javascript:` or `data:`,
+ * is rejected because the target is emitted verbatim into the `Location` header and into the
+ * generated static redirect page. Schemeless targets are normalized as same-origin paths.
+ *
+ * @param target - The redirect target, for example `/home` or `https://example.com/docs`.
+ * @returns The normalized target, or the reason the value was rejected.
+ */
+export function normalizeAndValidateRedirect(target: string): NormalizedUrl {
+  // The value reaches this point straight from the route configuration, which is not necessarily
+  // type checked, so a non-string is reported as a diagnostic rather than thrown as a `TypeError`.
+  if (typeof target !== 'string') {
+    return {
+      error: `the redirect target must be a string, but a value of type '${typeof target}' was provided.`,
+    };
+  }
+
+  if (!target.trim()) {
+    return { error: 'the redirect target cannot be empty.' };
+  }
+
+  // A value which parses without a base is an absolute URL and therefore carries its own scheme.
+  // Letting the URL parser answer this keeps the check exact: the scheme grammar, and the leading
+  // whitespace and control characters that are stripped before it is applied, are all handled by
+  // the parser rather than restated here.
+  if (URL.canParse(target)) {
+    const { protocol, href } = new URL(target);
+    if (!ALLOWED_REDIRECT_PROTOCOLS.has(protocol)) {
+      return {
+        error:
+          `the '${protocol}' protocol is not supported as a redirect target. ` +
+          `Only 'http:', 'https:' and same-origin paths are supported.`,
+      };
+    }
+
+    return { url: href };
+  }
+
+  const { url: parsed, error } = parseSameOriginUrl(target);
+
+  return error !== undefined ? { error } : { url: parsed.pathname + parsed.search + parsed.hash };
+}
+
+/**
  * Creates an HTTP redirect response with a specified location and status code.
+ *
+ * This is the only place where a `Location` header is set, so the target is normalized and
+ * validated here rather than only where it is configured. A location is not always a configured
+ * value which route extraction has already checked: it can be produced by a guard at render time,
+ * and it can be composed from the untrusted `X-Forwarded-Prefix` request header. The normalized
+ * value is the one sent, so that the emitted header and the value which was checked are the same.
  *
  * @param location - The URL to which the response should redirect.
  * @param status - The HTTP status code for the redirection. Defaults to 302 (Found).
  *                 See: https://developer.mozilla.org/en-US/docs/Web/API/Response/redirect_static#status
  * @param headers - Additional headers to include in the response.
  * @returns A `Response` object representing the HTTP redirect.
+ * @throws If `location` is not a supported redirect target.
  */
 export function createRedirectResponse(
   location: string,
@@ -44,11 +263,16 @@ export function createRedirectResponse(
     );
   }
 
+  const { url: normalizedLocation, error } = normalizeAndValidateRedirect(location);
+  if (error !== undefined) {
+    throw new Error(`Cannot redirect to '${location}': ${error}`);
+  }
+
   const resHeaders = headers instanceof Headers ? headers : new Headers(headers);
   if (ngDevMode && resHeaders.has('location')) {
     // eslint-disable-next-line no-console
     console.warn(
-      `Location header "${resHeaders.get('location')}" will be ignored and set to "${location}".`,
+      `Location header "${resHeaders.get('location')}" will be ignored and set to "${normalizedLocation}".`,
     );
   }
 
@@ -64,7 +288,7 @@ export function createRedirectResponse(
   }
 
   resHeaders.set('Vary', [...varySet].join(', '));
-  resHeaders.set('Location', location);
+  resHeaders.set('Location', normalizedLocation);
 
   return new Response(null, {
     status,

--- a/packages/angular/ssr/test/routes/ng-routes_spec.ts
+++ b/packages/angular/ssr/test/routes/ng-routes_spec.ts
@@ -102,6 +102,62 @@ describe('extractRoutesAndCreateRouteTree', () => {
       );
     });
 
+    it("should error when 'getPrerenderParams' returns a value containing HTML-significant characters", async () => {
+      setAngularAppTestingManifest(
+        [{ path: 'store/:tenant/legacy/:slug', component: DummyComponent }],
+        [
+          {
+            path: 'store/:tenant/legacy/:slug',
+            renderMode: RenderMode.Prerender,
+            fallback: PrerenderFallback.None,
+            async getPrerenderParams() {
+              return [
+                {
+                  tenant: `x"><img src=x onerror=console.log("XSS_PARENT_IMG")>`,
+                  slug: 'old',
+                },
+              ];
+            },
+          },
+        ],
+      );
+
+      const { errors } = await extractRoutesAndCreateRouteTree({
+        url,
+        invokeGetPrerenderParams: true,
+      });
+
+      expect(errors[0]).toContain(
+        `the 'store/:tenant/legacy/:slug' route ` +
+          `returned an unsafe value for parameter 'tenant'`,
+      );
+    });
+
+    it("should error when 'getPrerenderParams' returns a value containing control characters", async () => {
+      setAngularAppTestingManifest(
+        [{ path: 'docs/:id', component: DummyComponent }],
+        [
+          {
+            path: 'docs/:id',
+            renderMode: RenderMode.Prerender,
+            fallback: PrerenderFallback.None,
+            async getPrerenderParams() {
+              return [{ id: 'a b' }];
+            },
+          },
+        ],
+      );
+
+      const { errors } = await extractRoutesAndCreateRouteTree({
+        url,
+        invokeGetPrerenderParams: true,
+      });
+
+      expect(errors[0]).toContain(
+        `the 'docs/:id' route returned an unsafe value for parameter 'id'`,
+      );
+    });
+
     it(`should not error when a catch-all route didn't match any Angular route`, async () => {
       setAngularAppTestingManifest(
         [{ path: 'home', component: DummyComponent }],

--- a/packages/angular/ssr/test/routes/ng-routes_spec.ts
+++ b/packages/angular/ssr/test/routes/ng-routes_spec.ts
@@ -102,6 +102,257 @@ describe('extractRoutesAndCreateRouteTree', () => {
       );
     });
 
+    it("should error when 'getPrerenderParams' produces a protocol-relative path", async () => {
+      setAngularAppTestingManifest(
+        [{ path: ':slug', component: DummyComponent }],
+        [
+          {
+            path: ':slug',
+            renderMode: RenderMode.Prerender,
+            fallback: PrerenderFallback.None,
+            async getPrerenderParams() {
+              return [{ slug: '/evil.example' }];
+            },
+          },
+        ],
+      );
+
+      const { errors } = await extractRoutesAndCreateRouteTree({
+        url,
+        invokeGetPrerenderParams: true,
+      });
+
+      expect(errors[0]).toContain(
+        `The ':slug' route produced an invalid prerender path: ` +
+          `'//evil.example' is not a valid same-origin path.`,
+      );
+    });
+
+    it("should error when 'getPrerenderParams' produces a path containing a backslash", async () => {
+      setAngularAppTestingManifest(
+        [{ path: 'docs/:id', component: DummyComponent }],
+        [
+          {
+            path: 'docs/:id',
+            renderMode: RenderMode.Prerender,
+            fallback: PrerenderFallback.None,
+            async getPrerenderParams() {
+              return [{ id: '\\evil.example' }];
+            },
+          },
+        ],
+      );
+
+      const { errors } = await extractRoutesAndCreateRouteTree({
+        url,
+        invokeGetPrerenderParams: true,
+      });
+
+      expect(errors[0]).toContain(
+        `The 'docs/:id' route produced an invalid prerender path: ` +
+          `'/docs/\\evil.example' is not a valid same-origin path.`,
+      );
+    });
+
+    it("should error when a 'redirectTo' is protocol-relative", async () => {
+      setAngularAppTestingManifest(
+        [
+          { path: 'home', component: DummyComponent },
+          { path: 'redirect', redirectTo: '//evil.example' },
+        ],
+        [{ path: '**', renderMode: RenderMode.Server }],
+      );
+
+      const { errors } = await extractRoutesAndCreateRouteTree({ url });
+      expect(errors[0]).toContain(
+        `The 'redirectTo' value for the 'redirect' route is invalid: ` +
+          `'//evil.example' is not a valid same-origin path.`,
+      );
+    });
+
+    it("should error when a server route 'headers.Location' uses an unsupported protocol", async () => {
+      setAngularAppTestingManifest(
+        [{ path: 'external', component: DummyComponent }],
+        [
+          {
+            path: 'external',
+            renderMode: RenderMode.Prerender,
+            headers: { Location: 'javascript:alert(1)' },
+          },
+          { path: '**', renderMode: RenderMode.Server },
+        ],
+      );
+
+      const { errors } = await extractRoutesAndCreateRouteTree({ url });
+      expect(errors[0]).toContain(
+        `Invalid 'external' route configuration: the 'headers.Location' value is invalid: ` +
+          `the 'javascript:' protocol is not supported as a redirect target.`,
+      );
+    });
+
+    it("should error when a server route 'headers.Location' contains a backslash", async () => {
+      setAngularAppTestingManifest(
+        [{ path: 'external', component: DummyComponent }],
+        [
+          {
+            path: 'external',
+            renderMode: RenderMode.Prerender,
+            headers: { Location: '/\\evil.example' },
+          },
+          { path: '**', renderMode: RenderMode.Server },
+        ],
+      );
+
+      const { errors } = await extractRoutesAndCreateRouteTree({ url });
+      expect(errors[0]).toContain(
+        `Invalid 'external' route configuration: the 'headers.Location' value is invalid: ` +
+          `'/\\evil.example' is not a valid same-origin path.`,
+      );
+    });
+
+    it("should error when a server route 'headers.Location' resolves into a protocol-relative path", async () => {
+      setAngularAppTestingManifest(
+        [{ path: 'external', component: DummyComponent }],
+        [
+          {
+            path: 'external',
+            renderMode: RenderMode.Server,
+            status: 302,
+            headers: { Location: '/..//evil.example' },
+          },
+          { path: '**', renderMode: RenderMode.Server },
+        ],
+      );
+
+      const { errors } = await extractRoutesAndCreateRouteTree({ url });
+      expect(errors[0]).toContain(
+        `Invalid 'external' route configuration: the 'headers.Location' value is invalid: ` +
+          `'/..//evil.example' is not a valid same-origin path. ` +
+          `It resolves to the protocol-relative path '//evil.example'.`,
+      );
+    });
+
+    it("should error when a server route 'headers.Location' uses an unsupported protocol regardless of the header casing", async () => {
+      setAngularAppTestingManifest(
+        [{ path: 'external', component: DummyComponent }],
+        [
+          {
+            path: 'external',
+            renderMode: RenderMode.Prerender,
+            headers: { LoCaTiOn: 'javascript:alert(1)' },
+          },
+          { path: '**', renderMode: RenderMode.Server },
+        ],
+      );
+
+      const { errors } = await extractRoutesAndCreateRouteTree({ url });
+      expect(errors[0]).toContain(
+        `Invalid 'external' route configuration: the 'headers.Location' value is invalid: ` +
+          `the 'javascript:' protocol is not supported as a redirect target.`,
+      );
+    });
+
+    it("should store the normalized value of a server route 'headers.Location'", async () => {
+      setAngularAppTestingManifest(
+        [{ path: 'external', component: DummyComponent }],
+        [
+          {
+            path: 'external',
+            renderMode: RenderMode.Server,
+            headers: { location: 'HTTPS://Example.com/A b' },
+          },
+          { path: '**', renderMode: RenderMode.Server },
+        ],
+      );
+
+      const { routeTree, errors } = await extractRoutesAndCreateRouteTree({ url });
+      expect(errors).toHaveSize(0);
+      expect(routeTree.match('/external')?.headers).toEqual({
+        location: 'https://example.com/A%20b',
+      });
+    });
+
+    it("should error when 'getPrerenderParams' produces a segment which decodes to a separator", async () => {
+      setAngularAppTestingManifest(
+        [{ path: 'store/:slug', component: DummyComponent }],
+        [
+          {
+            path: 'store/:slug',
+            renderMode: RenderMode.Prerender,
+            fallback: PrerenderFallback.None,
+            async getPrerenderParams() {
+              return [{ slug: 'foo%2Fbar' }];
+            },
+          },
+        ],
+      );
+
+      const { errors } = await extractRoutesAndCreateRouteTree({
+        url,
+        invokeGetPrerenderParams: true,
+      });
+
+      expect(errors[0]).toContain(
+        `The 'store/:slug' route produced an invalid prerender path: ` +
+          `'/store/foo%2Fbar' is not a valid route path. ` +
+          `The 'foo%2Fbar' segment decodes to a value which is not a single path segment.`,
+      );
+    });
+
+    it("should error when 'getPrerenderParams' produces an encoded dot segment", async () => {
+      setAngularAppTestingManifest(
+        [{ path: 'store/:slug', component: DummyComponent }],
+        [
+          {
+            path: 'store/:slug',
+            renderMode: RenderMode.Prerender,
+            fallback: PrerenderFallback.None,
+            async getPrerenderParams() {
+              return [{ slug: '%2E%2E' }];
+            },
+          },
+        ],
+      );
+
+      const { errors } = await extractRoutesAndCreateRouteTree({
+        url,
+        invokeGetPrerenderParams: true,
+      });
+
+      expect(errors[0]).toContain(
+        `The 'store/:slug' route produced an invalid prerender path: ` +
+          `'/store/%2E%2E' is not a valid route path. ` +
+          `The '%2E%2E' segment decodes to the '..' path traversal segment.`,
+      );
+    });
+
+    it("should error when 'getPrerenderParams' produces a malformed percent escape", async () => {
+      setAngularAppTestingManifest(
+        [{ path: 'store/:slug', component: DummyComponent }],
+        [
+          {
+            path: 'store/:slug',
+            renderMode: RenderMode.Prerender,
+            fallback: PrerenderFallback.None,
+            async getPrerenderParams() {
+              return [{ slug: '50%' }];
+            },
+          },
+        ],
+      );
+
+      const { errors } = await extractRoutesAndCreateRouteTree({
+        url,
+        invokeGetPrerenderParams: true,
+      });
+
+      expect(errors[0]).toContain(
+        `The 'store/:slug' route produced an invalid prerender path: ` +
+          `'/store/50%' is not a valid route path. ` +
+          `The '50%' segment is not a valid percent-encoded value.`,
+      );
+    });
+
     it(`should not error when a catch-all route didn't match any Angular route`, async () => {
       setAngularAppTestingManifest(
         [{ path: 'home', component: DummyComponent }],
@@ -182,6 +433,65 @@ describe('extractRoutesAndCreateRouteTree', () => {
   });
 
   describe('when `invokeGetPrerenderParams` is true', () => {
+    it("should allow 'getPrerenderParams' values containing apostrophes and spaces", async () => {
+      setAngularAppTestingManifest(
+        [{ path: 'store/:slug', component: DummyComponent }],
+        [
+          {
+            path: 'store/:slug',
+            renderMode: RenderMode.Prerender,
+            fallback: PrerenderFallback.None,
+            async getPrerenderParams() {
+              return [{ slug: `customer's-choice` }, { slug: 'summer sale' }];
+            },
+          },
+        ],
+      );
+
+      const { routeTree, errors } = await extractRoutesAndCreateRouteTree({
+        url,
+        invokeGetPrerenderParams: true,
+      });
+      expect(errors).toHaveSize(0);
+      expect(routeTree.toObject()).toEqual([
+        { route: `/store/customer's-choice`, renderMode: RenderMode.Prerender },
+        { route: '/store/summer sale', renderMode: RenderMode.Prerender },
+      ]);
+    });
+
+    it('should keep the first route when a prerendered path collides with a literal route', async () => {
+      // A prerendered path is normalized by the URL parser while a literal route path is not, so
+      // the two reach the route tree in a different encoding even though they are the same node.
+      setAngularAppTestingManifest(
+        [
+          { path: 'produits/café', component: DummyComponent },
+          { path: 'produits/:slug', component: DummyComponent },
+        ],
+        [
+          { path: 'produits/café', renderMode: RenderMode.Server, status: 201 },
+          {
+            path: 'produits/:slug',
+            renderMode: RenderMode.Prerender,
+            fallback: PrerenderFallback.None,
+            async getPrerenderParams() {
+              return [{ slug: 'café' }];
+            },
+          },
+          { path: '**', renderMode: RenderMode.Server },
+        ],
+      );
+
+      const { routeTree, errors } = await extractRoutesAndCreateRouteTree({
+        url,
+        invokeGetPrerenderParams: true,
+      });
+
+      expect(errors).toHaveSize(0);
+      expect(routeTree.toObject()).toEqual([
+        { route: '/produits/café', renderMode: RenderMode.Server, status: 201 },
+      ]);
+    });
+
     it('should resolve parameterized routes for SSG and add a fallback route if fallback is Server', async () => {
       setAngularAppTestingManifest(
         [{ path: 'user/:id/role/:role', component: DummyComponent }],
@@ -326,6 +636,62 @@ describe('extractRoutesAndCreateRouteTree', () => {
         },
         { route: '/user/*/**', renderMode: RenderMode.Server },
       ]);
+    });
+
+    it('should resolve a catch-all value which carries the leading separator', async () => {
+      // The documented value of a '**' parameter is a path such as '/foo/bar', which already
+      // carries the separator that the matched '/**' placeholder includes. A root catch-all is the
+      // case where re-adding it composes a protocol-relative '//foo/bar'.
+      setAngularAppTestingManifest(
+        [{ path: '**', component: DummyComponent }],
+        [
+          {
+            path: '**',
+            renderMode: RenderMode.Prerender,
+            fallback: PrerenderFallback.None,
+            async getPrerenderParams() {
+              return [{ '**': '/foo/bar' }, { '**': 'foo/baz' }];
+            },
+          },
+        ],
+      );
+
+      const { routeTree, errors } = await extractRoutesAndCreateRouteTree({
+        url,
+        invokeGetPrerenderParams: true,
+      });
+
+      expect(errors).toHaveSize(0);
+      expect(routeTree.toObject()).toEqual([
+        { route: '/foo/bar', renderMode: RenderMode.Prerender },
+        { route: '/foo/baz', renderMode: RenderMode.Prerender },
+      ]);
+    });
+
+    it('should still reject a catch-all value which is itself protocol-relative', async () => {
+      setAngularAppTestingManifest(
+        [{ path: '**', component: DummyComponent }],
+        [
+          {
+            path: '**',
+            renderMode: RenderMode.Prerender,
+            fallback: PrerenderFallback.None,
+            async getPrerenderParams() {
+              return [{ '**': '//evil.example' }];
+            },
+          },
+        ],
+      );
+
+      const { errors } = await extractRoutesAndCreateRouteTree({
+        url,
+        invokeGetPrerenderParams: true,
+      });
+
+      expect(errors[0]).toContain(
+        `The '**' route produced an invalid prerender path: ` +
+          `'//evil.example' is not a valid same-origin path.`,
+      );
     });
 
     it('should extract nested redirects that are not explicitly defined.', async () => {

--- a/packages/angular/ssr/test/utils/redirect_spec.ts
+++ b/packages/angular/ssr/test/utils/redirect_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { createRedirectResponse } from '../../src/utils/redirect';
+import { createRedirectResponse, validateUrlForStaticEmission } from '../../src/utils/redirect';
 
 describe('Redirect Utils', () => {
   describe('createRedirectResponse', () => {
@@ -61,6 +61,18 @@ describe('Redirect Utils', () => {
       globalThis.ngDevMode = true;
       expect(() => createRedirectResponse('/home', 200)).toThrowError(
         /Invalid redirect status code: 200/,
+      );
+    });
+  });
+
+  describe('validateUrlForStaticEmission', () => {
+    it('should allow URL-safe values', () => {
+      expect(validateUrlForStaticEmission('docs/page-1?from=ssg&next=/home')).toBeUndefined();
+    });
+
+    it('should reject HTML-significant characters', () => {
+      expect(validateUrlForStaticEmission('/docs"><script>alert(1)</script>')).toContain(
+        'contains characters that are not allowed',
       );
     });
   });

--- a/packages/angular/ssr/test/utils/redirect_spec.ts
+++ b/packages/angular/ssr/test/utils/redirect_spec.ts
@@ -6,7 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { createRedirectResponse } from '../../src/utils/redirect';
+import {
+  createRedirectResponse,
+  normalizeAndValidateRedirect,
+  normalizeAndValidateRoutePath,
+} from '../../src/utils/redirect';
 
 describe('Redirect Utils', () => {
   describe('createRedirectResponse', () => {
@@ -62,6 +66,223 @@ describe('Redirect Utils', () => {
       expect(() => createRedirectResponse('/home', 200)).toThrowError(
         /Invalid redirect status code: 200/,
       );
+    });
+
+    it('should throw for a location which uses an unsupported protocol', () => {
+      // A `Location` can also be produced at render time, for example by a guard which returns a
+      // `RedirectCommand`, so it cannot rely on the validation performed during route extraction.
+      expect(() => createRedirectResponse('javascript:alert(1)')).toThrowError(
+        /Cannot redirect to 'javascript:alert\(1\)': the 'javascript:' protocol is not supported/,
+      );
+    });
+
+    it('should throw for a location which an untrusted proxy prefix made protocol-relative', () => {
+      // 'X-Forwarded-Prefix' is a request header, so a location built from it is untrusted. The
+      // URL parser reads a leading '/\\' as an authority, which would redirect off-origin.
+      for (const location of ['/\\evil.example/home', '//evil.example/home']) {
+        expect(() => createRedirectResponse(location))
+          .withContext(location)
+          .toThrowError(/is not a valid same-origin path/);
+      }
+    });
+
+    it('should send the normalized location', () => {
+      const response = createRedirectResponse('/docs/../about');
+      expect(response.headers.get('Location')).toBe('/about');
+    });
+  });
+
+  describe('normalizeAndValidateRoutePath', () => {
+    it('should keep characters which are legal in a path', () => {
+      expect(normalizeAndValidateRoutePath(`/store/customer's-choice`)).toEqual({
+        url: `/store/customer's-choice`,
+      });
+    });
+
+    it('should percent-encode spaces, non-ASCII and HTML-significant characters', () => {
+      expect(normalizeAndValidateRoutePath('/docs/a b')).toEqual({ url: '/docs/a%20b' });
+      expect(normalizeAndValidateRoutePath('/produits/café')).toEqual({
+        url: '/produits/caf%C3%A9',
+      });
+      expect(normalizeAndValidateRoutePath('/docs/<script>')).toEqual({
+        url: '/docs/%3Cscript%3E',
+      });
+    });
+
+    it('should reject protocol-relative paths', () => {
+      expect(normalizeAndValidateRoutePath('//evil.example').error).toContain(
+        'is not a valid same-origin path',
+      );
+    });
+
+    it('should reject paths containing a backslash', () => {
+      expect(normalizeAndValidateRoutePath('/\\evil.example').error).toContain(
+        'is not a valid same-origin path',
+      );
+    });
+
+    it('should reject a query string or a fragment', () => {
+      expect(normalizeAndValidateRoutePath('/docs/a?b=1').error).toContain(
+        'A route cannot carry a query string or a fragment',
+      );
+      expect(normalizeAndValidateRoutePath('/docs/a#b').error).toContain(
+        'A route cannot carry a query string or a fragment',
+      );
+    });
+
+    it('should reject a path which the parser resolves into a protocol-relative path', () => {
+      expect(normalizeAndValidateRoutePath('/..//evil.example').error).toContain(
+        `It resolves to the protocol-relative path '//evil.example'.`,
+      );
+    });
+
+    it('should reject dot segments instead of resolving them', () => {
+      expect(normalizeAndValidateRoutePath('/docs/../about').error).toContain(
+        `The '..' segment decodes to the '..' path traversal segment`,
+      );
+      expect(normalizeAndValidateRoutePath('/docs/%2E%2E/about').error).toContain(
+        `The '%2E%2E' segment decodes to the '..' path traversal segment`,
+      );
+    });
+
+    it('should reject segments which decode into a separator', () => {
+      // `RouteTree` decodes each segment on insert, so `%2F` would add a segment after validation.
+      expect(normalizeAndValidateRoutePath('/store/foo%2Fbar').error).toContain(
+        `The 'foo%2Fbar' segment decodes to a value which is not a single path segment`,
+      );
+      expect(normalizeAndValidateRoutePath('/store/foo%5Cbar').error).toContain(
+        `The 'foo%5Cbar' segment decodes to a value which is not a single path segment`,
+      );
+    });
+
+    it('should reject segments which decode into URL syntax characters', () => {
+      expect(normalizeAndValidateRoutePath('/store/a%23b').error).toContain(
+        `The 'a%23b' segment decodes to a value which is not a single path segment`,
+      );
+      expect(normalizeAndValidateRoutePath('/store/a%3Fb').error).toContain(
+        `The 'a%3Fb' segment decodes to a value which is not a single path segment`,
+      );
+    });
+
+    it('should reject segments which still need decoding after being decoded once', () => {
+      // The decoded route is serialized into the manifest and decoded again when the route tree is
+      // restored on the server, which would throw for a value that still contains a `%`.
+      expect(normalizeAndValidateRoutePath('/store/a%2520b').error).toContain(
+        `The 'a%2520b' segment decodes to a value which is not a single path segment`,
+      );
+    });
+
+    it('should reject malformed percent escapes', () => {
+      expect(normalizeAndValidateRoutePath('/store/50%').error).toContain(
+        `The '50%' segment is not a valid percent-encoded value`,
+      );
+      expect(normalizeAndValidateRoutePath('/store/%ZZ').error).toContain(
+        `The '%ZZ' segment is not a valid percent-encoded value`,
+      );
+    });
+  });
+
+  describe('normalizeAndValidateRedirect', () => {
+    it('should normalize a same-origin path', () => {
+      expect(normalizeAndValidateRedirect('/ssg')).toEqual({ url: '/ssg' });
+    });
+
+    it('should keep a query string and a fragment', () => {
+      expect(normalizeAndValidateRedirect('/docs/page-1?from=ssg&next=/home#top')).toEqual({
+        url: '/docs/page-1?from=ssg&next=/home#top',
+      });
+    });
+
+    it('should resolve dot segments', () => {
+      expect(normalizeAndValidateRedirect('/docs/../about')).toEqual({ url: '/about' });
+    });
+
+    it('should allow HTTP(S) targets', () => {
+      expect(normalizeAndValidateRedirect('https://example.com/docs?from=ssg&next=/ssg')).toEqual({
+        url: 'https://example.com/docs?from=ssg&next=/ssg',
+      });
+    });
+
+    it('should normalize an absolute target', () => {
+      expect(normalizeAndValidateRedirect('HTTPS://Example.com/A b')).toEqual({
+        url: 'https://example.com/A%20b',
+      });
+    });
+
+    it('should reject an empty target', () => {
+      expect(normalizeAndValidateRedirect('  ').error).toContain('cannot be empty');
+    });
+
+    it('should reject a target which is not a string', () => {
+      // The value comes straight from the route configuration, which is not necessarily type
+      // checked, so it is reported as a diagnostic rather than thrown as a `TypeError`.
+      for (const [target, type] of [
+        [42, 'number'],
+        [undefined, 'undefined'],
+        [null, 'object'],
+      ] as const) {
+        expect(normalizeAndValidateRedirect(target as unknown as string).error)
+          .withContext(`${target}`)
+          .toContain(
+            `the redirect target must be a string, but a value of type '${type}' was provided.`,
+          );
+      }
+    });
+
+    it('should reject unsupported protocols', () => {
+      expect(normalizeAndValidateRedirect('javascript:alert(1)').error).toContain(
+        `the 'javascript:' protocol is not supported as a redirect target`,
+      );
+      expect(
+        normalizeAndValidateRedirect('data:text/html,<script>alert(1)</script>').error,
+      ).toContain(`the 'data:' protocol is not supported as a redirect target`);
+      expect(normalizeAndValidateRedirect('JaVaScRiPt:alert(1)').error).toContain(
+        `the 'javascript:' protocol is not supported as a redirect target`,
+      );
+    });
+
+    it('should detect the scheme of a target which is padded with whitespace', () => {
+      // The URL parser strips leading whitespace and control characters before applying the scheme
+      // grammar, so these carry a scheme even though they do not start with one.
+      expect(normalizeAndValidateRedirect(' javascript:alert(1)').error).toContain(
+        `the 'javascript:' protocol is not supported as a redirect target`,
+      );
+      expect(normalizeAndValidateRedirect('\tdata:text/html,x').error).toContain(
+        `the 'data:' protocol is not supported as a redirect target`,
+      );
+      expect(normalizeAndValidateRedirect(' https://example.com/docs')).toEqual({
+        url: 'https://example.com/docs',
+      });
+    });
+
+    it('should reject an absolute target which cannot be parsed', () => {
+      expect(normalizeAndValidateRedirect('http://').error).toContain(
+        `'http://' could not be parsed as a URL.`,
+      );
+    });
+
+    it('should reject protocol-relative and backslash targets', () => {
+      expect(normalizeAndValidateRedirect('//evil.example').error).toContain(
+        `Protocol-relative paths ('//') and backslashes ('\\') are not supported.`,
+      );
+      expect(normalizeAndValidateRedirect('/\\evil.example').error).toContain(
+        `Protocol-relative paths ('//') and backslashes ('\\') are not supported.`,
+      );
+    });
+
+    it('should reject a target which the parser resolves into a protocol-relative path', () => {
+      // Resolving the dot segments produces a leading `//`, which the raw value did not have and
+      // which leaves the origin unchanged, so it has to be rejected on the resolved path.
+      for (const target of [
+        '/..//evil.example',
+        './/evil.example',
+        '/docs/../..//evil.example',
+        '/%2e%2e//evil.example',
+      ]) {
+        expect(normalizeAndValidateRedirect(target).error)
+          .withContext(target)
+          .toContain(`It resolves to the protocol-relative path '//evil.example'.`);
+      }
     });
   });
 });

--- a/tests/e2e/tests/build/server-rendering/server-routes-output-mode-server.ts
+++ b/tests/e2e/tests/build/server-rendering/server-routes-output-mode-server.ts
@@ -77,7 +77,7 @@ export default async function () {
       path: 'ssg/:id',
       renderMode: RenderMode.Prerender,
       headers: { 'x-custom': 'ssg-with-params' },
-      getPrerenderParams: async() => [{id: 'one'}, {id: 'two'}],
+      getPrerenderParams: async() => [{id: 'one'}, {id: 'two'}, {id: "customer's-choice"}],
     },
     {
       path: 'ssr',
@@ -115,6 +115,7 @@ export default async function () {
     'ssg/index.html': 'ssg works!',
     'ssg/one/index.html': 'ssg-with-params works!',
     'ssg/two/index.html': 'ssg-with-params works!',
+    "ssg/customer's-choice/index.html": 'ssg-with-params works!',
   };
 
   for (const [filePath, fileMatch] of Object.entries(expects)) {

--- a/tests/e2e/tests/build/server-rendering/server-routes-output-mode-static.ts
+++ b/tests/e2e/tests/build/server-rendering/server-routes-output-mode-static.ts
@@ -49,6 +49,14 @@ export default async function () {
       redirectTo: 'ssg'
     },
     {
+      path: 'ssg-redirect-external',
+      component: Ssg,
+    },
+    {
+      path: 'ssg-redirect-unsafe-url',
+      component: Ssg,
+    },
+    {
       path: 'ssg-redirect-via-guard',
       canActivate: [() => {
         return inject(Router).createUrlTree(['ssg'], { queryParams: { foo: 'bar' }})
@@ -73,6 +81,11 @@ export default async function () {
   import { RenderMode, ServerRoute } from '@angular/ssr';
 
   export const serverRoutes: ServerRoute[] = [
+    {
+      path: 'ssg-redirect-external',
+      renderMode: RenderMode.Prerender,
+      headers: { Location: 'https://example.com/docs?from=ssg&next=/ssg' },
+    },
     {
       path: 'ssg/:id',
       renderMode: RenderMode.Prerender,
@@ -108,20 +121,91 @@ export default async function () {
   await replaceInFile('src/app/app.routes.server.ts', 'RenderMode.Server', 'RenderMode.Prerender');
   await noSilentNg('build', '--output-mode=static');
 
-  const expects: Record<string, RegExp | string> = {
+  const expects: Record<string, RegExp | string | (RegExp | string)[]> = {
     'index.html': /ng-server-context="ssg".+home works!/,
     'ssg/index.html': /ng-server-context="ssg".+ssg works!/,
     'ssg/one/index.html': /ng-server-context="ssg".+ssg-with-params works!/,
     'ssg/two/index.html': /ng-server-context="ssg".+ssg-with-params works!/,
     // When static redirects are generated as meta tags.
     'ssg-redirect/index.html': '<meta http-equiv="refresh" content="0; url=/ssg">',
+    'ssg-redirect-external/index.html': [
+      '<meta http-equiv="refresh" content="0; url=https://example.com/docs?from=ssg&amp;next=/ssg">',
+      '<a href="https://example.com/docs?from=ssg&amp;next=/ssg">https://example.com/docs?from=ssg&amp;next=/ssg</a>',
+    ],
     'ssg-redirect-via-guard/index.html':
       '<meta http-equiv="refresh" content="0; url=/ssg?foo=bar">',
   };
 
-  for (const [filePath, fileMatch] of Object.entries(expects)) {
-    await expectFileToMatch(join('dist/test-project/browser', filePath), fileMatch);
+  for (const [filePath, fileMatches] of Object.entries(expects)) {
+    for (const fileMatch of Array.isArray(fileMatches) ? fileMatches : [fileMatches]) {
+      await expectFileToMatch(join('dist/test-project/browser', filePath), fileMatch);
+    }
   }
+
+  await replaceInFile(
+    'src/app/app.routes.ts',
+    `redirectTo: 'ssg'`,
+    `redirectTo: '/ssg"><script>alert(1)</script>&q=x'`,
+  );
+
+  const { message: unsafeRedirectToErrorMessage } = await expectToFail(() =>
+    noSilentNg('build', '--output-mode=static'),
+  );
+  assert.match(unsafeRedirectToErrorMessage, /Invalid 'redirectTo' for route 'ssg-redirect'/);
+  assert.match(
+    unsafeRedirectToErrorMessage,
+    /contains characters that are not allowed in a statically emitted URL/,
+  );
+
+  await replaceInFile(
+    'src/app/app.routes.ts',
+    `redirectTo: '/ssg"><script>alert(1)</script>&q=x'`,
+    `redirectTo: 'ssg'`,
+  );
+
+  await replaceInFile(
+    'src/app/app.routes.server.ts',
+    `{
+      path: '**',
+      renderMode: RenderMode.Prerender,
+    },`,
+    `{
+      path: 'ssg-redirect-unsafe-url',
+      renderMode: RenderMode.Prerender,
+      headers: { Location: 'javascript:alert(1)' },
+    },
+    {
+      path: '**',
+      renderMode: RenderMode.Prerender,
+    },`,
+  );
+
+  const { message: unsafeProtocolErrorMessage } = await expectToFail(() =>
+    noSilentNg('build', '--output-mode=static'),
+  );
+  assert.match(
+    unsafeProtocolErrorMessage,
+    /Invalid 'headers\.Location' for route 'ssg-redirect-unsafe-url'/,
+  );
+  assert.match(unsafeProtocolErrorMessage, /the protocol 'javascript:' is not allowed/);
+
+  await replaceInFile(
+    'src/app/app.routes.server.ts',
+    `headers: { Location: 'javascript:alert(1)' },`,
+    `headers: { Location: '/\\\\evil.com' },`,
+  );
+
+  const { message: backslashRedirectErrorMessage } = await expectToFail(() =>
+    noSilentNg('build', '--output-mode=static'),
+  );
+  assert.match(
+    backslashRedirectErrorMessage,
+    /Invalid 'headers\.Location' for route 'ssg-redirect-unsafe-url'/,
+  );
+  assert.match(
+    backslashRedirectErrorMessage,
+    /contains characters that are not allowed in a statically emitted URL/,
+  );
 
   // Check that server directory does not exist
   assert(

--- a/tests/e2e/tests/build/server-rendering/server-routes-output-mode-static.ts
+++ b/tests/e2e/tests/build/server-rendering/server-routes-output-mode-static.ts
@@ -49,6 +49,10 @@ export default async function () {
       redirectTo: 'ssg'
     },
     {
+      path: 'ssg-redirect-external',
+      component: Ssg,
+    },
+    {
       path: 'ssg-redirect-via-guard',
       canActivate: [() => {
         return inject(Router).createUrlTree(['ssg'], { queryParams: { foo: 'bar' }})
@@ -73,6 +77,11 @@ export default async function () {
   import { RenderMode, ServerRoute } from '@angular/ssr';
 
   export const serverRoutes: ServerRoute[] = [
+    {
+      path: 'ssg-redirect-external',
+      renderMode: RenderMode.Prerender,
+      headers: { Location: 'https://example.com/docs?from=ssg&next=/ssg' },
+    },
     {
       path: 'ssg/:id',
       renderMode: RenderMode.Prerender,
@@ -115,6 +124,9 @@ export default async function () {
     'ssg/two/index.html': /ng-server-context="ssg".+ssg-with-params works!/,
     // When static redirects are generated as meta tags.
     'ssg-redirect/index.html': '<meta http-equiv="refresh" content="0; url=/ssg">',
+    // The target of a 'Location' header is HTML escaped before it is written to the page.
+    'ssg-redirect-external/index.html':
+      '<meta http-equiv="refresh" content="0; url=https://example.com/docs?from=ssg&amp;next=/ssg">',
     'ssg-redirect-via-guard/index.html':
       '<meta http-equiv="refresh" content="0; url=/ssg?foo=bar">',
   };


### PR DESCRIPTION
#### Prevent HTML injection in static redirects 

Escape redirect targets before embedding them in generated meta refresh pages and fallback links.

Centralize WHATWG URL normalization in @angular/ssr for composed prerender paths, configured redirects, Location headers, and runtime redirects. Preserve documented catch-all parameter values, reject unsafe schemes and path forms, and cover validation failures with focused unit tests.

#### Safely serialize paths in the server manifest 

Serialize route-derived asset keys, base paths, hashes, and App Engine entry points before embedding them in executable ESM manifests.

Generate bounded ASCII asset chunk names with a path digest so filesystem-sensitive and URL-significant characters remain filename data without creating chunk-name collisions. Add focused manifest coverage and exercise an apostrophe-bearing prerender route end to end.