### PR TITLE
fix(@angular-devkit/build-angular): remove unconditional CORS wildcard from webpack dev-server

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/headers_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/headers_spec.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { executeDevServer } from '../../index';
+import { executeOnceAndFetch } from '../execute-fetch';
+import { describeServeBuilder } from '../jasmine-helpers';
+import { BASE_OPTIONS, DEV_SERVER_BUILDER_INFO } from '../setup';
+
+describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupTarget) => {
+  describe('option: "headers"', () => {
+    beforeEach(async () => {
+      setupTarget(harness, {
+        styles: ['src/styles.css'],
+      });
+
+      // Application code is not needed for these tests
+      await harness.writeFile('src/main.ts', '');
+      await harness.writeFile('src/styles.css', '');
+    });
+
+    it('index response headers should include configured header', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+        headers: {
+          'x-custom': 'foo',
+        },
+      });
+
+      const { result, response } = await executeOnceAndFetch(harness, '/');
+
+      expect(result?.success).toBeTrue();
+      expect(await response?.headers.get('x-custom')).toBe('foo');
+    });
+
+    it('should include configured Access-Control-Allow-Origin header', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+        headers: {
+          'Access-Control-Allow-Origin': 'http://example.com',
+        },
+      });
+
+      const { result, response } = await executeOnceAndFetch(harness, '/main.js');
+
+      expect(result?.success).toBeTrue();
+      expect(await response?.headers.get('access-control-allow-origin')).toBe('http://example.com');
+    });
+
+    it('should not include Access-Control-Allow-Origin header by default', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result, response } = await executeOnceAndFetch(harness, '/main.js');
+
+      expect(result?.success).toBeTrue();
+      expect(await response?.headers.has('access-control-allow-origin')).toBeFalse();
+    });
+  });
+});

--- a/packages/angular_devkit/build_angular/src/tools/webpack/configs/dev-server.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/configs/dev-server.ts
@@ -60,10 +60,7 @@ export async function getDevServerConfig(
     devServer: {
       host,
       port,
-      headers: {
-        'Access-Control-Allow-Origin': '*',
-        ...headers,
-      },
+      headers,
       historyApiFallback: !!index && {
         index: posix.join(servePath, getIndexOutputFile(index)),
         disableDotRule: true,


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Security hardening (aligning legacy webpack dev-server defaults with the modern `@angular/build` builder)

## What is the current behavior?

The legacy webpack-based dev-server bundled with `@angular-devkit/build-angular:dev-server` unconditionally sets `Access-Control-Allow-Origin: *` on every response in `packages/angular_devkit/build_angular/src/tools/webpack/configs/dev-server.ts`. This overrides webpack-dev-server cross-origin protections (added in 5.2.1 to address CVE-2025-30359 / CVE-2025-30360) and allows any web page a developer visits to read the full content of the local dev server cross-origin.

Background and ecosystem retrospective: https://green.sapphi.red/blog/addressing-source-code-leaks-across-the-ecosystem-a-retrospective

Issue Number: N/A

## What is the new behavior?

The unconditional `Access-Control-Allow-Origin: *` header is removed. Developers who relied on the previous behavior can opt back in explicitly via the existing `headers` option in `angular.json`:

```json
"serve": {
  "options": {
    "headers": { "Access-Control-Allow-Origin": "*" }
  }
}
```

### Alignment with the modern builder

The newer `@angular/build` dev-server (Vite-based) **already** does not set `Access-Control-Allow-Origin` by default. Its existing test contract asserts this explicitly in `packages/angular/build/src/builders/dev-server/tests/options/headers_spec.ts`:

```ts
it('should not include Access-Control-Allow-Origin header by default', async () => {
  harness.useTarget('serve', { ...BASE_OPTIONS });
  const { result, response } = await executeOnceAndFetch(harness, '/main.js');
  expect(result?.success).toBeTrue();
  expect(await response?.headers.has('access-control-allow-origin')).toBeFalse();
});
```
### Changes

- `packages/angular_devkit/build_angular/src/tools/webpack/configs/dev-server.ts` — remove the unconditional `'Access-Control-Allow-Origin': '*'` entry; pass user-provided `headers` through unchanged.
- `packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/headers_spec.ts` — new test file mirroring the contract in `@angular/build`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information