### PR TITLE
fix(@schematics/angular): preserve Jasmine stub-by-default behavior f…

### DIFF
--- a/packages/schematics/angular/refactor/jasmine-vitest/index_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/index_spec.ts
@@ -59,7 +59,7 @@ describe('Jasmine to Vitest Schematic', () => {
     );
 
     const newContent = tree.readContent(specFilePath);
-    expect(newContent).toContain(`vi.spyOn(service, 'myMethod');`);
+    expect(newContent).toContain(`vi.spyOn(service, 'myMethod').mockReturnValue(undefined);`);
   });
 
   it('should only transform files matching the fileSuffix option', async () => {
@@ -94,7 +94,7 @@ describe('Jasmine to Vitest Schematic', () => {
     expect(unchangedContent).not.toContain(`vi.spyOn(window, 'alert');`);
 
     const changedContent = tree.readContent(testFilePath);
-    expect(changedContent).toContain(`vi.spyOn(window, 'confirm');`);
+    expect(changedContent).toContain(`vi.spyOn(window, 'confirm').mockReturnValue(undefined);`);
   });
 
   it('should print verbose logs when the verbose option is true', async () => {
@@ -120,7 +120,11 @@ describe('Jasmine to Vitest Schematic', () => {
 
     expect(logs).toContain('Detailed Transformation Log:');
     expect(logs).toContain(`Processing: /${specFilePath}`);
-    expect(logs.some((log) => log.includes('Transformed `spyOn` to `vi.spyOn`'))).toBe(true);
+    expect(
+      logs.some((log) =>
+        log.includes('Transformed `spyOn` to `vi.spyOn(...).mockReturnValue(undefined)`'),
+      ),
+    ).toBe(true);
   });
 
   describe('with `include` option', () => {
@@ -144,7 +148,7 @@ describe('Jasmine to Vitest Schematic', () => {
       );
 
       const changedContent = tree.readContent('projects/bar/src/app/nested/nested.spec.ts');
-      expect(changedContent).toContain(`vi.spyOn(window, 'confirm');`);
+      expect(changedContent).toContain(`vi.spyOn(window, 'confirm').mockReturnValue(undefined);`);
 
       const unchangedContent = tree.readContent('projects/bar/src/app/app.spec.ts');
       expect(unchangedContent).toContain(`spyOn(window, 'alert');`);
@@ -158,7 +162,7 @@ describe('Jasmine to Vitest Schematic', () => {
       );
 
       const changedContent = tree.readContent('projects/bar/src/app/nested/nested.spec.ts');
-      expect(changedContent).toContain(`vi.spyOn(window, 'confirm');`);
+      expect(changedContent).toContain(`vi.spyOn(window, 'confirm').mockReturnValue(undefined);`);
 
       const unchangedContent = tree.readContent('projects/bar/src/app/app.spec.ts');
       expect(unchangedContent).toContain(`spyOn(window, 'alert');`);
@@ -177,10 +181,12 @@ describe('Jasmine to Vitest Schematic', () => {
       );
 
       const changedAppContent = tree.readContent('projects/bar/src/app/app.spec.ts');
-      expect(changedAppContent).toContain(`vi.spyOn(window, 'alert');`);
+      expect(changedAppContent).toContain(`vi.spyOn(window, 'alert').mockReturnValue(undefined);`);
 
       const changedNestedContent = tree.readContent('projects/bar/src/app/nested/nested.spec.ts');
-      expect(changedNestedContent).toContain(`vi.spyOn(window, 'confirm');`);
+      expect(changedNestedContent).toContain(
+        `vi.spyOn(window, 'confirm').mockReturnValue(undefined);`,
+      );
 
       const unchangedContent = tree.readContent('projects/bar/src/other/other.spec.ts');
       expect(unchangedContent).toContain(`spyOn(window, 'close');`);
@@ -194,10 +200,12 @@ describe('Jasmine to Vitest Schematic', () => {
       );
 
       const changedAppContent = tree.readContent('projects/bar/src/app/app.spec.ts');
-      expect(changedAppContent).toContain(`vi.spyOn(window, 'alert');`);
+      expect(changedAppContent).toContain(`vi.spyOn(window, 'alert').mockReturnValue(undefined);`);
 
       const changedNestedContent = tree.readContent('projects/bar/src/app/nested/nested.spec.ts');
-      expect(changedNestedContent).toContain(`vi.spyOn(window, 'confirm');`);
+      expect(changedNestedContent).toContain(
+        `vi.spyOn(window, 'confirm').mockReturnValue(undefined);`,
+      );
     });
 
     it('should throw if the include path does not exist', async () => {

--- a/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.integration_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.integration_spec.ts
@@ -109,7 +109,7 @@ describe('Jasmine to Vitest Transformer - Integration Tests', () => {
         });
 
         it('should handle user click', () => {
-          vi.spyOn(window, 'alert');
+          vi.spyOn(window, 'alert').mockReturnValue(undefined);
           const button = fixture.nativeElement.querySelector('button');
           button.click();
           fixture.detectChanges();

--- a/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer_add-imports_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer_add-imports_spec.ts
@@ -13,7 +13,7 @@ describe('Jasmine to Vitest Transformer - addImports option', () => {
     const input = `spyOn(foo, 'bar');`;
     const expected = `
         import { vi } from 'vitest';
-        vi.spyOn(foo, 'bar');
+        vi.spyOn(foo, 'bar').mockReturnValue(undefined);
       `;
     await expectTransformation(input, expected, true);
   });
@@ -27,7 +27,7 @@ describe('Jasmine to Vitest Transformer - addImports option', () => {
         import { type Mock, vi } from 'vitest';
 
         let mySpy: Mock;
-        vi.spyOn(foo, 'bar');
+        vi.spyOn(foo, 'bar').mockReturnValue(undefined);
       `;
     await expectTransformation(input, expected, true);
   });
@@ -41,7 +41,7 @@ describe('Jasmine to Vitest Transformer - addImports option', () => {
         import type { Mock } from 'vitest';
 
         let mySpy: Mock;
-        vi.spyOn(foo, 'bar');
+        vi.spyOn(foo, 'bar').mockReturnValue(undefined);
       `;
     await expectTransformation(input, expected, false);
   });

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-spy.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-spy.ts
@@ -34,19 +34,7 @@ export function transformSpies(node: ts.Node, refactorCtx: RefactorContext): ts.
     ts.isIdentifier(node.expression) &&
     (node.expression.text === 'spyOn' || node.expression.text === 'spyOnProperty')
   ) {
-    addVitestValueImport(pendingVitestValueImports, 'vi');
-    reporter.reportTransformation(
-      sourceFile,
-      node,
-      `Transformed \`${node.expression.text}\` to \`vi.spyOn\`.`,
-    );
-
-    return ts.factory.updateCallExpression(
-      node,
-      createPropertyAccess('vi', 'spyOn'),
-      node.typeArguments,
-      node.arguments,
-    );
+    return transformSpyExpression(node, refactorCtx);
   }
 
   if (ts.isPropertyAccessExpression(node.expression)) {
@@ -93,8 +81,8 @@ export function transformSpies(node: ts.Node, refactorCtx: RefactorContext): ts.
             );
             const returnValues = node.arguments;
             if (returnValues.length === 0) {
-              // No values, so it's a no-op. Just transform the spyOn call.
-              return transformSpies(spyCall, refactorCtx);
+              // No values, preserve Jasmine's stub-by-default behavior.
+              return transformSpyExpression(spyCall, refactorCtx, true);
             }
             // spy.and.returnValues(a, b) -> spy.mockReturnValueOnce(a).mockReturnValueOnce(b)
             let chainedCall: ts.Expression = spyCall;
@@ -119,7 +107,8 @@ export function transformSpies(node: ts.Node, refactorCtx: RefactorContext): ts.
               'Removed redundant `.and.callThrough()` call.',
             );
 
-            return transformSpies(spyCall, refactorCtx); // .and.callThrough() is redundant, just transform spyOn.
+            // .and.callThrough() is redundant, just transform spyOn.
+            return transformSpyExpression(spyCall, refactorCtx, false);
           case 'stub': {
             reporter.reportTransformation(
               sourceFile,
@@ -214,6 +203,67 @@ export function transformSpies(node: ts.Node, refactorCtx: RefactorContext): ts.
     addTodoComment(node, category);
 
     return node;
+  }
+
+  return node;
+}
+
+function transformSpyExpression(
+  node: ts.Expression,
+  refactorCtx: RefactorContext,
+  forceStubBehavior?: boolean,
+): ts.Expression {
+  const { sourceFile, reporter, pendingVitestValueImports } = refactorCtx;
+
+  if (
+    ts.isCallExpression(node) &&
+    ts.isIdentifier(node.expression) &&
+    (node.expression.text === 'spyOn' || node.expression.text === 'spyOnProperty')
+  ) {
+    const spyFnName = node.expression.text;
+    addVitestValueImport(pendingVitestValueImports, 'vi');
+
+    const viSpyOnCall = ts.factory.updateCallExpression(
+      node,
+      createPropertyAccess('vi', 'spyOn'),
+      node.typeArguments,
+      node.arguments,
+    );
+
+    const shouldStub = forceStubBehavior ?? shouldStubBareSpyOn(node);
+
+    if (shouldStub) {
+      reporter.reportTransformation(
+        sourceFile,
+        node,
+        `Transformed \`${spyFnName}\` to \`vi.spyOn(...).mockReturnValue(undefined)\` ` +
+          `to preserve Jasmine's stub-by-default behavior.`,
+      );
+
+      return ts.factory.createCallExpression(
+        createPropertyAccess(viSpyOnCall, 'mockReturnValue'),
+        undefined,
+        [ts.factory.createIdentifier('undefined')],
+      );
+    }
+
+    reporter.reportTransformation(
+      sourceFile,
+      node,
+      `Transformed \`${spyFnName}\` to \`vi.spyOn\`.`,
+    );
+
+    return viSpyOnCall;
+  }
+
+  // Variable reference (e.g. `spy` from `spy.and.returnValues()`).
+  // There is no spyOn call to transform — only stub-wrapping is relevant here.
+  if (forceStubBehavior) {
+    return ts.factory.createCallExpression(
+      createPropertyAccess(node, 'mockReturnValue'),
+      undefined,
+      [ts.factory.createIdentifier('undefined')],
+    );
   }
 
   return node;
@@ -393,6 +443,32 @@ export function transformSpyReset(
   }
 
   return node;
+}
+
+function shouldStubBareSpyOn(node: ts.CallExpression): boolean {
+  if (
+    ts.isIdentifier(node.expression) &&
+    node.expression.text === 'spyOnProperty' &&
+    node.arguments.length >= 3
+  ) {
+    const accessType = node.arguments[2];
+    if (ts.isStringLiteralLike(accessType) && accessType.text === 'set') {
+      return false;
+    }
+  }
+
+  const parent = node.parent;
+  if (
+    parent &&
+    ts.isPropertyAccessExpression(parent) &&
+    parent.expression === node &&
+    ts.isIdentifier(parent.name) &&
+    parent.name.text === 'and'
+  ) {
+    return false;
+  }
+
+  return true;
 }
 
 function getSpyIdentifierFromCalls(node: ts.PropertyAccessExpression): ts.Expression | undefined {

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-spy_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-spy_spec.ts
@@ -11,9 +11,10 @@ import { expectTransformation } from '../test-helpers';
 describe('Jasmine to Vitest Transformer - transformSpies', () => {
   const testCases = [
     {
-      description: 'should transform spyOn(object, "method") to vi.spyOn(object, "method")',
+      description:
+        'should transform bare spyOn to vi.spyOn(...).mockReturnValue(undefined) to preserve Jasmine stub-by-default semantics',
       input: `spyOn(service, 'myMethod');`,
-      expected: `vi.spyOn(service, 'myMethod');`,
+      expected: `vi.spyOn(service, 'myMethod').mockReturnValue(undefined);`,
     },
     {
       description: 'should transform .and.returnValue(...) to .mockReturnValue(...)',
@@ -58,9 +59,10 @@ describe('Jasmine to Vitest Transformer - transformSpies', () => {
       expected: `const mySpy = vi.fn(() => 'foo').mockName('mySpy');`,
     },
     {
-      description: 'should transform spyOnProperty(object, "prop") to vi.spyOn(object, "prop")',
+      description:
+        'should transform bare spyOnProperty to vi.spyOn(...).mockReturnValue(undefined) to preserve Jasmine stub-by-default semantics',
       input: `spyOnProperty(service, 'myProp');`,
-      expected: `vi.spyOn(service, 'myProp');`,
+      expected: `vi.spyOn(service, 'myProp').mockReturnValue(undefined);`,
     },
     {
       description: 'should transform .and.stub() to .mockImplementation(() => {})',
@@ -80,9 +82,11 @@ describe('Jasmine to Vitest Transformer - transformSpies', () => {
       expected: `const mySpy = vi.fn().mockName('mySpy').mockReturnValue(true);`,
     },
     {
-      description: 'should handle .and.returnValues() with no arguments',
+      description:
+        'should transform .and.returnValues() with no args to vi.spyOn(...).mockReturnValue(undefined) ' +
+        'because Jasmine reverts to stub-by-default',
       input: `spyOn(service, 'myMethod').and.returnValues();`,
-      expected: `vi.spyOn(service, 'myMethod');`,
+      expected: `vi.spyOn(service, 'myMethod').mockReturnValue(undefined);`,
     },
     {
       description:
@@ -116,6 +120,46 @@ describe('Jasmine to Vitest Transformer - transformSpies', () => {
       input: `spyOn(service, 'myMethod').and.unknownStrategy();`,
       expected: `// TODO: vitest-migration: Unsupported spy strategy ".and.unknownStrategy()" found. Please migrate this manually. See: https://vitest.dev/api/mocked.html#mock
 vi.spyOn(service, 'myMethod').and.unknownStrategy();`,
+    },
+    {
+      description: 'should preserve stub-by-default semantics for spyOn assigned to a variable',
+      input: `const spy = spyOn(service, 'myMethod');`,
+      expected: `const spy = vi.spyOn(service, 'myMethod').mockReturnValue(undefined);`,
+    },
+    {
+      description:
+        'should wrap spyOnProperty with explicit "get" access type to preserve stub-by-default semantics',
+      input: `spyOnProperty(service, 'myProp', 'get');`,
+      expected: `vi.spyOn(service, 'myProp', 'get').mockReturnValue(undefined);`,
+    },
+    {
+      description:
+        'should NOT wrap spyOnProperty with "set" access type because setter semantics already match',
+      input: `spyOnProperty(service, 'myProp', 'set');`,
+      expected: `vi.spyOn(service, 'myProp', 'set');`,
+    },
+    {
+      description:
+        'should wrap spyOn used as an expression argument to preserve stub-by-default semantics',
+      input: `expect(spyOn(service, 'myMethod')).toBeDefined();`,
+      expected: `expect(vi.spyOn(service, 'myMethod').mockReturnValue(undefined)).toBeDefined();`,
+    },
+    {
+      description:
+        'should wrap a spy variable with .and.returnValues() with no args to preserve stub-by-default semantics',
+      input: `spy.and.returnValues();`,
+      expected: `spy.mockReturnValue(undefined);`,
+    },
+    {
+      description: 'should remove .and.callThrough() on a spy variable',
+      input: `spy.and.callThrough();`,
+      expected: `spy;`,
+    },
+    {
+      description:
+        'should preserve stub-by-default on spyOn with .calls.reset() chained (not an .and accessor)',
+      input: `spyOn(service, 'myMethod').calls.reset();`,
+      expected: `vi.spyOn(service, 'myMethod').mockReturnValue(undefined).mockClear();`,
     },
   ];
 


### PR DESCRIPTION
…or bare spyOn calls

Bare `spyOn`/`spyOnProperty` calls in Jasmine create stubs that return `undefined` by default. Vitest's `vi.spyOn` passes through to the real implementation instead, changing observable behavior of migrated tests. Wrap bare spy calls with `.mockReturnValue(undefined)` to preserve the Jasmine semantics, except for `spyOnProperty(obj, prop, 'set')` where setter semantics already match.

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The jasmine-to-vitest schematic transforms bare `spyOn(obj, 'method')` and `spyOnProperty(obj, 'prop')` calls to `vi.spyOn(obj, 'method')` directly. However, Jasmine's `spyOn` creates a stub that returns `undefined` by default (it does NOT call through to the real implementation), while Vitest's `vi.spyOn` passes through to the real implementation by default. This means the migration changes the observable behavior of tests.

Issue Number: #33253

## What is the new behavior?

<!-- Please describe the new behavior that. -->
Bare `spyOn`/`spyOnProperty` calls (with no `.and.*` chain, or with `.and.returnValues()` and no arguments) are now wrapped with `.mockReturnValue(undefined)` to preserve Jasmine's stub-by-default semantics:

```typescript
// Before (incorrect)
spyOn(service, 'myMethod');
// → vi.spyOn(service, 'myMethod');
// After (correct)
spyOn(service, 'myMethod');
// → vi.spyOn(service, 'myMethod').mockReturnValue(undefined);
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

The output of the migration schematic changes - projects migrated with the old schematic that depended on bare spies passing through to real implementations will need re-migration, though this fix corrects the previous incorrect behavior that silently altered test semantics.

## Other information
