### PR TITLE
fix(@angular/ssr): support server-side rendering configuration options

### DIFF
--- a/goldens/public-api/angular/ssr/index.api.md
+++ b/goldens/public-api/angular/ssr/index.api.md
@@ -42,6 +42,9 @@ export enum PrerenderFallback {
 export function provideServerRendering(...features: ServerRenderingFeature<ServerRenderingFeatureKind>[]): EnvironmentProviders;
 
 // @public
+export function provideServerRendering(options: ServerRenderingOptions, ...features: ServerRenderingFeature<ServerRenderingFeatureKind>[]): EnvironmentProviders;
+
+// @public
 export enum RenderMode {
     Client = 1,
     Prerender = 2,
@@ -50,6 +53,11 @@ export enum RenderMode {
 
 // @public
 export type RequestHandlerFunction = (request: Request) => Promise<Response | null> | null | Response;
+
+// @public
+export interface ServerRenderingOptions {
+    maxResponseBodySize: number;
+}
 
 // @public
 export type ServerRoute = ServerRouteClient | ServerRoutePrerender | ServerRoutePrerenderWithParams | ServerRouteServer;

--- a/packages/angular/ssr/public_api.ts
+++ b/packages/angular/ssr/public_api.ts
@@ -23,6 +23,7 @@ export {
   type ServerRoutePrerenderWithParams,
   type ServerRouteServer,
   type ServerRouteCommon,
+  type ServerRenderingOptions,
 } from './src/routes/route-config';
 
 export { IS_DISCOVERING_ROUTES } from './src/routes/ng-routes';

--- a/packages/angular/ssr/src/routes/route-config.ts
+++ b/packages/angular/ssr/src/routes/route-config.ts
@@ -342,6 +342,17 @@ export function withAppShell(
 }
 
 /**
+ * Options for configuring server-side rendering.
+ */
+export interface ServerRenderingOptions {
+  /**
+   * The maximum allowed response body size when using the Fetch API.
+   * @default 1MB
+   */
+  maxResponseBodySize: number;
+}
+
+/**
  * Configures server-side rendering for an Angular application.
  *
  * This function sets up the necessary providers for server-side rendering, including
@@ -379,10 +390,71 @@ export function withAppShell(
  */
 export function provideServerRendering(
   ...features: ServerRenderingFeature<ServerRenderingFeatureKind>[]
+): EnvironmentProviders;
+
+/**
+ * Configures server-side rendering for an Angular application with additional options.
+ *
+ * This function sets up the necessary providers for server-side rendering, including
+ * support for server routes and app shell. It combines features configured using
+ * `withRoutes` and `withAppShell` to provide a comprehensive server-side rendering setup.
+ *
+ * @param options - Configuration options for server-side rendering.
+ * @param features - Optional features to configure additional server rendering behaviors.
+ * @returns An `EnvironmentProviders` instance with the server-side rendering configuration.
+ *
+ * @example
+ * Basic example of how you can enable server-side rendering with options in your application
+ * when using the `bootstrapApplication` function:
+ *
+ * ```ts
+ * import { bootstrapApplication, BootstrapContext } from '@angular/platform-browser';
+ * import { provideServerRendering, withRoutes, withAppShell } from '@angular/ssr';
+ * import { AppComponent } from './app/app.component';
+ * import { SERVER_ROUTES } from './app/app.server.routes';
+ * import { AppShellComponent } from './app/app-shell.component';
+ *
+ * const bootstrap = (context: BootstrapContext) =>
+ *     bootstrapApplication(AppComponent, {
+ *       providers: [
+ *         provideServerRendering(
+ *           { maxResponseBodySize: 1024 * 1024 }, // 1MB limit
+ *           withRoutes(SERVER_ROUTES),
+ *           withAppShell(AppShellComponent),
+ *         ),
+ *       ],
+ *     }, context);
+ *
+ * export default bootstrap;
+ * ```
+ * @see {@link withRoutes} configures server-side routing
+ * @see {@link withAppShell} configures the application shell
+ */
+export function provideServerRendering(
+  options: ServerRenderingOptions,
+  ...features: ServerRenderingFeature<ServerRenderingFeatureKind>[]
+): EnvironmentProviders;
+export function provideServerRendering(
+  ...args:
+    | ServerRenderingFeature<ServerRenderingFeatureKind>[]
+    | [ServerRenderingOptions, ...ServerRenderingFeature<ServerRenderingFeatureKind>[]]
 ): EnvironmentProviders {
+  let options: ServerRenderingOptions | undefined;
+  let features: ServerRenderingFeature<ServerRenderingFeatureKind>[];
+  if (hasOptions(args)) {
+    const [first, ...rest] = args;
+    options = first;
+    features = rest;
+  } else {
+    features = args;
+  }
+
+  const providers: (Provider | EnvironmentProviders)[] = [
+    provideServerRenderingPlatformServer(options),
+  ];
+
   let hasAppShell = false;
   let hasServerRoutes = false;
-  const providers: (Provider | EnvironmentProviders)[] = [provideServerRenderingPlatformServer()];
 
   for (const { ɵkind, ɵproviders } of features) {
     hasAppShell ||= ɵkind === ServerRenderingFeatureKind.AppShell;
@@ -398,4 +470,17 @@ export function provideServerRendering(
   }
 
   return makeEnvironmentProviders(providers);
+}
+
+/**
+ * Checks if the first element of args is a `ServerRenderingOptions` object.
+ */
+function hasOptions(
+  args:
+    | ServerRenderingFeature<ServerRenderingFeatureKind>[]
+    | [ServerRenderingOptions, ...ServerRenderingFeature<ServerRenderingFeatureKind>[]],
+): args is [ServerRenderingOptions, ...ServerRenderingFeature<ServerRenderingFeatureKind>[]] {
+  const value = args[0];
+
+  return !!value && typeof value === 'object' && !('ɵkind' in value);
 }


### PR DESCRIPTION
Introduce the ServerRenderingOptions interface to support configuring options such as maxResponseBodySize for server-side rendering.

- Clean up overloads of provideServerRendering to use the ServerRenderingOptions interface instead of inline anonymous types.
- Add an array-level type guard hasOptions to check for options arguments at runtime, allowing TypeScript to narrow the arguments union type automatically without the need for manual type assertions (casts).
- Update the JSDocs for the provideServerRendering overloads to document parameter options and include clear examples.