### PR TITLE
fix(@angular/cli): expand package groups for newly added peer dependencies in update schematic

### DIFF
--- a/packages/angular/cli/src/commands/update/schematic/index.ts
+++ b/packages/angular/cli/src/commands/update/schematic/index.ts
@@ -884,14 +884,16 @@ export default function (options: UpdateSchema): Rule {
     let lastPackagesSize;
     do {
       lastPackagesSize = packages.size;
-      npmPackageJsonMap.forEach((npmPackageJson) => {
-        _addPackageGroup(tree, packages, npmDeps, npmPackageJson, logger);
-      });
-    } while (packages.size > lastPackagesSize);
 
-    // This is done in seperate loop to ensure that package groups are added before peer dependencies.
-    do {
-      lastPackagesSize = packages.size;
+      let lastGroupSize;
+      do {
+        lastGroupSize = packages.size;
+        npmPackageJsonMap.forEach((npmPackageJson) => {
+          _addPackageGroup(tree, packages, npmDeps, npmPackageJson, logger);
+        });
+      } while (packages.size > lastGroupSize);
+
+      // This is done in seperate loop to ensure that package groups are added before peer dependencies.
       npmPackageJsonMap.forEach((npmPackageJson) => {
         _addPeerDependencies(tree, packages, npmDeps, npmPackageJson, npmPackageJsonMap, logger);
       });


### PR DESCRIPTION

Previously, the package group stabilization loop (`_addPackageGroup`) ran completely before the peer dependencies resolution loop (`_addPeerDependencies`). If a peer dependency was newly added during the peer dependencies loop (such as `@angular/core` when updating `@angular/build`), its corresponding package group members (such as `@angular/router` and `@angular/common`) were never expanded, leaving them outdated.

Now, we wrap the package group and peer dependencies stabilization logic in a single outer loop so that newly added peer dependencies also get their package groups correctly stabilized and expanded.
