### PR TITLE
fix(@angular/ssr): add support for configuring trusted proxy headers via environment variable

### DIFF
--- a/packages/angular/ssr/node/src/app-engine.ts
+++ b/packages/angular/ssr/node/src/app-engine.ts
@@ -10,7 +10,7 @@ import { AngularAppEngine } from '@angular/ssr';
 import type { IncomingMessage } from 'node:http';
 import type { Http2ServerRequest } from 'node:http2';
 import { AngularAppEngineOptions } from '../../src/app-engine';
-import { getAllowedHostsFromEnv } from './environment-options';
+import { getAllowedHostsFromEnv, getTrustProxyHeadersFromEnv } from './environment-options';
 import { createWebRequestFromNodeRequest } from './request';
 
 /**
@@ -37,11 +37,14 @@ export class AngularNodeAppEngine {
    * @param options Options for the Angular Node.js server application engine.
    */
   constructor(options?: AngularNodeAppEngineOptions) {
-    this.angularAppEngine = new AngularAppEngine({
+    const appEngineOptions: AngularAppEngineOptions = {
       ...options,
-      allowedHosts: [...getAllowedHostsFromEnv(), ...(options?.allowedHosts ?? [])],
-    });
-    this.trustProxyHeaders = options?.trustProxyHeaders;
+      allowedHosts: getAllowedHostsFromEnv() ?? options?.allowedHosts,
+      trustProxyHeaders: getTrustProxyHeadersFromEnv() ?? options?.trustProxyHeaders,
+    };
+
+    this.angularAppEngine = new AngularAppEngine(appEngineOptions);
+    this.trustProxyHeaders = appEngineOptions.trustProxyHeaders;
   }
 
   /**

--- a/packages/angular/ssr/node/src/common-engine/common-engine.ts
+++ b/packages/angular/ssr/node/src/common-engine/common-engine.ts
@@ -71,10 +71,7 @@ export class CommonEngine {
   private readonly allowedHosts: ReadonlySet<string>;
 
   constructor(private options?: CommonEngineOptions) {
-    this.allowedHosts = new Set([
-      ...getAllowedHostsFromEnv(),
-      ...(this.options?.allowedHosts ?? []),
-    ]);
+    this.allowedHosts = new Set(getAllowedHostsFromEnv() ?? this.options?.allowedHosts ?? []);
   }
 
   /**

--- a/packages/angular/ssr/node/src/environment-options.ts
+++ b/packages/angular/ssr/node/src/environment-options.ts
@@ -10,20 +10,31 @@
  * Retrieves the list of allowed hosts from the environment variable `NG_ALLOWED_HOSTS`.
  * @returns An array of allowed hosts.
  */
-export function getAllowedHostsFromEnv(): ReadonlyArray<string> {
-  const allowedHosts: string[] = [];
-  const envNgAllowedHosts = process.env['NG_ALLOWED_HOSTS'];
-  if (!envNgAllowedHosts) {
-    return allowedHosts;
+export function getAllowedHostsFromEnv(): ReadonlyArray<string> | undefined {
+  return getArrayFromEnv('NG_ALLOWED_HOSTS');
+}
+
+/**
+ * Retrieves the list of trusted proxy headers from the environment variable `NG_TRUST_PROXY_HEADERS`.
+ * @returns An array of trusted proxy headers.
+ */
+export function getTrustProxyHeadersFromEnv(): ReadonlyArray<string> | undefined {
+  return getArrayFromEnv('NG_TRUST_PROXY_HEADERS');
+}
+
+function getArrayFromEnv(envName: string): ReadonlyArray<string> | undefined {
+  const envValue = process.env[envName];
+  if (!envValue) {
+    return undefined;
   }
 
-  const hosts = envNgAllowedHosts.split(',');
-  for (const host of hosts) {
-    const trimmed = host.trim();
+  const values: string[] = [];
+  for (const value of envValue.split(',')) {
+    const trimmed = value.trim();
     if (trimmed.length > 0) {
-      allowedHosts.push(trimmed);
+      values.push(trimmed);
     }
   }
 
-  return allowedHosts;
+  return values;
 }


### PR DESCRIPTION
This is a v19 port of https://github.com/angular/angular-cli/pull/33056.

Adds support for configuring trusted proxy headers via the `NG_TRUST_PROXY_HEADERS` environment variable in `AngularNodeAppEngine`. This allows users to specify which proxy headers (such as `X-Forwarded-Host`) should be trusted when running the server-side application behind a reverse proxy, without needing to modify the application code. The environment variable accepts a comma-separated list of header names. If the `NG_TRUST_PROXY_HEADERS` environment variable is set and contains non-empty values, it will take precedence over the `trustProxyHeaders` option provided programmatically in the `AngularNodeAppEngine` constructor options.

(cherry picked from commit 126b19b9c74422211619aad0e523ef5f7e8eeabb)