### PR TITLE
fix(@angular/build): exclude JSON imports from Vite dependency optimization

### DIFF
--- a/packages/angular/build/src/tools/vite/utils.ts
+++ b/packages/angular/build/src/tools/vite/utils.ts
@@ -140,8 +140,12 @@ export function updateExternalMetadata(
   }
 
   const { implicitBrowser, implicitServer, explicit } = result.detail['externalMetadata'];
-  const implicitServerFiltered = implicitServer.filter((m) => !isBuiltin(m) && !isAbsoluteUrl(m));
-  const implicitBrowserFiltered = implicitBrowser.filter((m) => !isAbsoluteUrl(m));
+  const implicitServerFiltered = implicitServer.filter(
+    (m) => !isBuiltin(m) && !isAbsoluteUrl(m) && !m.endsWith('.json'),
+  );
+  const implicitBrowserFiltered = implicitBrowser.filter(
+    (m) => !isAbsoluteUrl(m) && !m.endsWith('.json'),
+  );
   const explicitBrowserFiltered = explicitPackagesOnly
     ? explicit.filter((m) => !isAbsoluteUrl(m))
     : explicit;


### PR DESCRIPTION
Importing `.json` files (such as package.json files from third-party packages) causes Vite's dependency optimizer to throw errors and warnings during `ng serve`, as Vite is unable to optimize non-JS/TS modules:

`Cannot optimize dependency: @pkg-name/package.json, present in client 'optimizeDeps.include'`

This fix filters out any implicit dependencies ending in `.json` in the `updateExternalMetadata` utility, preventing them from being included in Vite's `optimizeDeps.include` array.

Closes #33280