### PR TITLE
fix(@angular/build): allow disabling Vitest isolation from builder

### DIFF
--- a/packages/angular/build/src/builders/unit-test/options.ts
+++ b/packages/angular/build/src/builders/unit-test/options.ts
@@ -126,7 +126,7 @@ export async function normalizeOptions(
     watch,
     debug: options.debug ?? false,
     ui: process.env['CI'] ? false : ui,
-    isolate: isolate ?? false,
+    isolate,
     quiet: options.quiet ?? (process.env['CI'] ? false : true),
     providersFile: options.providersFile && path.join(workspaceRoot, options.providersFile),
     setupFiles: options.setupFiles

--- a/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
@@ -54,7 +54,7 @@ interface VitestConfigPluginOptions {
   include: string[];
   optimizeDepsInclude: string[];
   watch: boolean;
-  isolate: boolean;
+  isolate: boolean | undefined;
 }
 
 async function findTestEnvironment(
@@ -268,8 +268,8 @@ export async function createVitestConfigPlugin(
           include,
           // CLI provider browser options override, if present
           ...(browser ? { browser } : {}),
-          // Only override if the user explicitly enabled it via CLI
-          ...(options.isolate ? { isolate: true } : {}),
+          // Only override if the user explicitly set it via CLI
+          ...(options.isolate !== undefined ? { isolate: options.isolate } : {}),
           // If the user has not specified an environment, use a smart default.
           ...(!testConfig?.environment
             ? { environment: await findTestEnvironment(projectResolver) }

--- a/packages/angular/build/src/builders/unit-test/tests/options/isolate_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/isolate_spec.ts
@@ -54,5 +54,59 @@ describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
       const { result } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
     });
+
+    it('should override isolate from the Vitest config file when set to false', async () => {
+      harness.writeFile(
+        'vitest-base.config.ts',
+        `
+          import { defineConfig } from 'vitest/config';
+
+          export default defineConfig({
+            test: {
+              fileParallelism: false,
+              isolate: true,
+              setupFiles: ['./src/setup.ts'],
+            },
+          });
+        `,
+      );
+
+      harness.writeFile(
+        'src/setup.ts',
+        `
+          const global = globalThis as typeof globalThis & { setupCount?: number };
+          global.setupCount = (global.setupCount ?? 0) + 1;
+        `,
+      );
+
+      harness.writeFile(
+        'src/app/first.spec.ts',
+        `
+          it('runs first', () => {
+            expect(true).toBe(true);
+          });
+        `,
+      );
+
+      harness.writeFile(
+        'src/app/second.spec.ts',
+        `
+          it('shares the test environment with the first spec file', () => {
+            const global = globalThis as typeof globalThis & { setupCount?: number };
+            expect(global.setupCount).toBeGreaterThan(1);
+          });
+        `,
+      );
+
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        runner: 'vitest' as any,
+        runnerConfig: true,
+        isolate: false,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+    });
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Previously, `ng test --isolate` worked because true was forwarded as an override, but `ng test --no-isolate` was normalized to false and then treated the same as an omitted option. As a result, `test.isolate: true` in `vitest-base.config.ts` stayed active.

## What is the new behavior?

Keep the isolate builder option undefined when it is omitted so a Vitest runner config can provide its own value.

Forward explicit false values to the Vitest project config so `--no-isolate` can override runnerConfig while the default still aligns with the Karma/Jasmine experience.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
