### PR TITLE
fix(@schematics/angular): use null objects and callbacks in karma-to-vitest migration

### DIFF
--- a/packages/schematics/angular/migrations/migrate-karma-to-vitest/karma-config-analyzer.ts
+++ b/packages/schematics/angular/migrations/migrate-karma-to-vitest/karma-config-analyzer.ts
@@ -142,7 +142,7 @@ export function analyzeKarmaConfig(content: string): KarmaConfigAnalysis {
       case ts.SyntaxKind.ArrayLiteralExpression:
         return (node as ts.ArrayLiteralExpression).elements.map(extractValue);
       case ts.SyntaxKind.ObjectLiteralExpression: {
-        const obj: { [key: string]: KarmaConfigValue } = {};
+        const obj: { [key: string]: KarmaConfigValue } = Object.create(null);
         for (const prop of (node as ts.ObjectLiteralExpression).properties) {
           if (isSupportedPropertyAssignment(prop)) {
             // Recursively extract values for nested objects.

--- a/packages/schematics/angular/migrations/migrate-karma-to-vitest/karma-config-comparer.ts
+++ b/packages/schematics/angular/migrations/migrate-karma-to-vitest/karma-config-comparer.ts
@@ -46,11 +46,10 @@ export async function generateDefaultKarmaConfig(
 
   // TODO: Replace this with the actual schematic templating logic.
   template = template
-    .replace(
-      /<%= relativePathToWorkspaceRoot %>/g,
+    .replace(/<%= relativePathToWorkspaceRoot %>/g, () =>
       path.normalize(relativePathToWorkspaceRoot).replace(/\\/g, '/'),
     )
-    .replace(/<%= folderName %>/g, projectName);
+    .replace(/<%= folderName %>/g, () => projectName);
 
   const devkitPluginRegex = /<% if \(needDevkitPlugin\) { %>(.*?)<% } %>/gs;
   const replacement = needDevkitPlugin ? '$1' : '';

--- a/packages/schematics/angular/migrations/migrate-karma-to-vitest/migration.ts
+++ b/packages/schematics/angular/migrations/migrate-karma-to-vitest/migration.ts
@@ -32,6 +32,7 @@ async function processTestTargetOptions(
   let needsIstanbul = false;
   for (const [configName, options] of allTargetOptions(testTarget, false)) {
     const configKey = configName || '';
+
     if (!customBuildOptions[configKey]) {
       // Match Karma behavior where AOT was disabled by default
       customBuildOptions[configKey] = {
@@ -276,7 +277,10 @@ function updateProjects(tree: Tree, context: SchematicContext): Rule {
       tsConfigsToUpdate.add(join(project.root, 'tsconfig.spec.json'));
 
       // Store custom build options to move to a new build configuration if needed
-      const customBuildOptions: Record<string, Record<string, json.JsonValue | undefined>> = {};
+      const customBuildOptions: Record<
+        string,
+        Record<string, json.JsonValue | undefined>
+      > = Object.create(null);
 
       const projectCoverageInfo = await processTestTargetOptions(
         testTarget,


### PR DESCRIPTION
The karma-to-vitest migration schematic previously used plain JavaScript objects as dictionaries when processing custom build options and analyzing Karma AST configurations. In environments where the input workspace files contain custom keys such as `__proto__` these assignments would leak properties onto the global Object prototype.