### PR TITLE
fix(@schematics/angular): fix browserMode option mapping in refactor-jasmine-vitest

### DIFF
--- a/packages/schematics/angular/refactor/jasmine-vitest/index.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/index.ts
@@ -121,7 +121,7 @@ export default function (options: Schema): Rule {
       const content = tree.readText(file);
       const newContent = transformJasmineToVitest(file, content, reporter, {
         addImports: !!options.addImports,
-        browserMode: !!options.browerMode,
+        browserMode: !!options.browserMode,
         fakeAsync: !!options.fakeAsync,
       });
 

--- a/packages/schematics/angular/refactor/jasmine-vitest/index_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/index_spec.ts
@@ -238,4 +238,46 @@ describe('Jasmine to Vitest Schematic', () => {
     expect(logs).toContain('- 1 TODO(s) added for manual review:');
     expect(logs).toContain('  - 1x spyOnAllFunctions');
   });
+
+  it('should not transform toHaveClass when browserMode is true', async () => {
+    const specFilePath = 'projects/bar/src/app/app.spec.ts';
+    const content = `
+      describe('AppComponent', () => {
+        it('should check class', () => {
+          expect(element).toHaveClass('active');
+        });
+      });
+    `;
+    appTree.overwrite(specFilePath, content);
+
+    const tree = await schematicRunner.runSchematic(
+      'refactor-jasmine-vitest',
+      { project: 'bar', browserMode: true },
+      appTree,
+    );
+
+    const result = tree.readContent(specFilePath);
+    expect(result).toContain("expect(element).toHaveClass('active');");
+  });
+
+  it('should transform toHaveClass when browserMode is false', async () => {
+    const specFilePath = 'projects/bar/src/app/app.spec.ts';
+    const content = `
+      describe('AppComponent', () => {
+        it('should check class', () => {
+          expect(element).toHaveClass('active');
+        });
+      });
+    `;
+    appTree.overwrite(specFilePath, content);
+
+    const tree = await schematicRunner.runSchematic(
+      'refactor-jasmine-vitest',
+      { project: 'bar', browserMode: false },
+      appTree,
+    );
+
+    const result = tree.readContent(specFilePath);
+    expect(result).toContain("expect(element.classList.contains('active')).toBe(true);");
+  });
 });


### PR DESCRIPTION
The jasmine-vitest refactor schematic previously mapped the `browserMode` option to `options.browerMode` (with a spelling typo). Because of the index signature `[property: string]: any` in the generated options Schema type, the compiler did not emit any error, which resulted in the option silently resolving to `undefined` at runtime and disabling browser-mode transformations.
