### PR TITLE
fix(@schematics/angular): safely comment out multiline statements in refactor-jasmine-vitest

### DIFF
--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-lifecycle.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-lifecycle.ts
@@ -15,7 +15,7 @@
 
 import ts from 'typescript';
 import { createPropertyAccess } from '../utils/ast-helpers';
-import { addTodoComment } from '../utils/comment-helpers';
+import { addCommentedNodeText, addTodoComment } from '../utils/comment-helpers';
 import { RefactorContext } from '../utils/refactor-context';
 
 const FOCUSED_SKIPPED_RENAMES = new Map<string, { newBase: string; newName: string }>([
@@ -77,7 +77,6 @@ export function transformPending(
     ) {
       hasPending = true;
       const replacement = ts.factory.createEmptyStatement();
-      const originalText = bodyNode.getFullText().trim();
 
       reporter.reportTransformation(
         sourceFile,
@@ -87,12 +86,7 @@ export function transformPending(
       const category = 'pending';
       reporter.recordTodo(category, sourceFile, bodyNode);
       addTodoComment(replacement, category);
-      ts.addSyntheticLeadingComment(
-        replacement,
-        ts.SyntaxKind.SingleLineCommentTrivia,
-        ` ${originalText}`,
-        true,
-      );
+      addCommentedNodeText(replacement, bodyNode);
 
       return replacement;
     }

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-matcher.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-matcher.ts
@@ -21,7 +21,7 @@ import {
   createPropertyAccess,
 } from '../utils/ast-helpers';
 import { getJasmineMethodName, isJasmineCallExpression } from '../utils/ast-validation';
-import { addTodoComment } from '../utils/comment-helpers';
+import { addCommentedNodeText, addTodoComment } from '../utils/comment-helpers';
 import { RefactorContext } from '../utils/refactor-context';
 
 const SUGAR_MATCHER_CHANGES = new Map<string, { newName: string; newArgs?: ts.Expression[] }>([
@@ -607,18 +607,12 @@ export function transformExpectNothing(
 
   // The statement is `expect().nothing()`, which can be removed.
   const replacement = ts.factory.createEmptyStatement();
-  const originalText = node.getFullText().trim();
 
   reporter.reportTransformation(sourceFile, node, 'Removed `expect().nothing()` statement.');
   const category = 'expect-nothing';
   reporter.recordTodo(category, sourceFile, node);
   addTodoComment(replacement, category);
-  ts.addSyntheticLeadingComment(
-    replacement,
-    ts.SyntaxKind.SingleLineCommentTrivia,
-    ` ${originalText}`,
-    true,
-  );
+  addCommentedNodeText(replacement, node);
 
   return replacement;
 }

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-misc.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-misc.ts
@@ -16,7 +16,7 @@
 import ts from 'typescript';
 import { addVitestValueImport } from '../utils/ast-helpers';
 import { getJasmineMethodName, isJasmineCallExpression } from '../utils/ast-validation';
-import { addTodoComment } from '../utils/comment-helpers';
+import { addCommentedNodeText, addTodoComment } from '../utils/comment-helpers';
 import { RefactorContext } from '../utils/refactor-context';
 import { createViCallExpression } from '../utils/refactor-helpers';
 import { TodoCategory } from '../utils/todo-notes';
@@ -143,7 +143,6 @@ export function transformJasmineMembers(node: ts.Node, refactorCtx: RefactorCont
         case 'MAX_PRETTY_PRINT_DEPTH':
         case 'MAX_PRETTY_PRINT_CHARS': {
           const replacement = ts.factory.createEmptyStatement();
-          const originalText = node.getFullText().trim();
 
           reporter.reportTransformation(
             sourceFile,
@@ -153,12 +152,7 @@ export function transformJasmineMembers(node: ts.Node, refactorCtx: RefactorCont
           const category = 'unsupported-jasmine-member';
           reporter.recordTodo(category, sourceFile, node);
           addTodoComment(replacement, category, { name: memberName });
-          ts.addSyntheticLeadingComment(
-            replacement,
-            ts.SyntaxKind.SingleLineCommentTrivia,
-            ` ${originalText}`,
-            true,
-          );
+          addCommentedNodeText(replacement, node);
 
           return replacement;
         }

--- a/packages/schematics/angular/refactor/jasmine-vitest/utils/comment-helpers.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/utils/comment-helpers.ts
@@ -70,3 +70,23 @@ export function addTodoComment(
     true,
   );
 }
+
+/**
+ * Safely comments out the full text of a node line-by-line and attaches
+ * it to a target node. This prevents multi-line statements from breaking
+ * syntax when converted to single-line comments.
+ * @param targetNode The node to which the comments will be added.
+ * @param nodeToComment The original node whose text will be commented out.
+ */
+export function addCommentedNodeText(targetNode: ts.Node, nodeToComment: ts.Node): void {
+  const originalText = nodeToComment.getFullText().trim();
+  const lines = originalText.split('\n');
+  for (const line of lines) {
+    ts.addSyntheticLeadingComment(
+      targetNode,
+      ts.SyntaxKind.SingleLineCommentTrivia,
+      ` ${line.trim()}`,
+      true,
+    );
+  }
+}

--- a/packages/schematics/angular/refactor/jasmine-vitest/utils/comment-helpers_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/utils/comment-helpers_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import ts from 'typescript';
-import { addTodoComment } from './comment-helpers';
+import { addCommentedNodeText, addTodoComment } from './comment-helpers';
 
 describe('addTodoComment', () => {
   function createTestHarness(sourceText: string) {
@@ -64,5 +64,20 @@ describe('addTodoComment', () => {
 
     expect(result.trim().startsWith('// TODO')).toBe(true);
     expect(result).toContain('const mySpy = jasmine.createSpy()');
+  });
+
+  describe('addCommentedNodeText', () => {
+    it('should comment out a multiline node line-by-line', () => {
+      const sourceText = `expect()\n  .nothing();`;
+      const sourceFile = ts.createSourceFile('test.ts', sourceText, ts.ScriptTarget.Latest, true);
+      const statement = sourceFile.statements[0];
+      const replacement = ts.factory.createEmptyStatement();
+      const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
+
+      addCommentedNodeText(replacement, statement);
+
+      const result = printer.printNode(ts.EmitHint.Unspecified, replacement, sourceFile);
+      expect(result).toContain('// expect()\n// .nothing();');
+    });
   });
 });


### PR DESCRIPTION
When refactoring unsupported or empty statements (such as `pending()`, `expect().nothing()`, and certain `jasmine` member assignments), the schematic previously commented out the code using a single-line comment prefix on the full text of the node. If the statement spanned multiple lines, only the first line was commented, leaving subsequent lines uncommented. This resulted in invalid syntax or unexpected compile errors.