### PR TITLE
fix(@angular/build): prevent unit-test vitest runner from hanging after tests complete

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
@@ -205,7 +205,16 @@ export class VitestExecutor implements TestExecutor {
 
   async [Symbol.asyncDispose](): Promise<void> {
     this.debugLog(DebugLogLevel.Info, 'Disposing VitestExecutor: Closing Vitest instance.');
-    await this.vitest?.close();
+    if (this.vitest && !this.options.watch) {
+      // In run (non-watch) mode, mirror the `vitest run` CLI by using `exit()`, which arms an
+      // unref'd `teardownTimeout` safety net (`process.exit()`) before closing. `close()` alone
+      // can wait indefinitely when a worker or service keeps the event loop alive, leaving the
+      // process hanging after all tests have completed.
+      // See https://github.com/angular/angular-cli/issues/32832
+      await this.vitest.exit();
+    } else {
+      await this.vitest?.close();
+    }
     this.debugLog(DebugLogLevel.Info, 'Vitest instance closed.');
   }
 


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## What is the current behavior?

In non-watch mode, `ng test` with the vitest runner hangs indefinitely after all tests
complete and results are printed. The executor disposes the Vitest instance with
`close()`, which has no teardown timeout. Whether the hang occurs depends on the size
of the TypeScript program of the spec tsconfig (full analysis in the linked issue) —
freshly generated projects exit cleanly while larger real-world projects hang on every
run, leaving orphaned node/esbuild processes in CI.

Issue Number: #32832 (likely also #33317)

## What is the new behavior?

When not in watch mode, the executor calls `vitest.exit()` instead of `vitest.close()`,
mirroring what the `vitest run` CLI does: `exit()` arms an unref'd `teardownTimeout`
safety net (`process.exit()` after 10s by default) before closing. When teardown
completes normally nothing changes; when something keeps the event loop alive, vitest
reports it and force-exits:

    close timed out after 10000ms
    Tests closed successfully but something prevents the main process from exiting

Watch mode still uses `close()` and is unaffected.

Validated on a project that reproduces the hang on 100% of runs (315 tests, 19 spec files):
- run mode, passing tests: process now exits on its own, exit code 0
- run mode, failing tests: exit code 1 preserved
- watch mode: process stays alive, re-runs on change
- no orphaned node/esbuild processes after the run

## Does this PR introduce a breaking change?

- [x] No

## Other information

No test added: asserting "the process exits" requires a real hanging handle, which the
builder test harness does not reproduce (small programs tear down cleanly — that is the
bug's timing dependency). Happy to add one if there is a suitable seam.
