### PR TITLE
fix(@angular/cli): remove forceAuth and unscoped credential parsing

### DIFF
--- a/packages/angular/cli/src/utilities/package-metadata.ts
+++ b/packages/angular/cli/src/utilities/package-metadata.ts
@@ -52,9 +52,7 @@ export interface PackageManifest extends Manifest, NgPackageManifestProperties {
   peerDependenciesMeta?: Record<string, { optional?: boolean }>;
 }
 
-interface PackageManagerOptions extends Record<string, unknown> {
-  forceAuth?: Record<string, unknown>;
-}
+type PackageManagerOptions = Record<string, unknown>;
 
 let npmrc: PackageManagerOptions;
 const npmPackageJsonCache = new Map<string, Promise<Partial<NpmRepositoryPackageJson>>>();
@@ -175,19 +173,6 @@ function normalizeOptions(
     }
 
     switch (key) {
-      // Unless auth options are scope with the registry url it appears that npm-registry-fetch ignores them,
-      // even though they are documented.
-      // https://github.com/npm/npm-registry-fetch/blob/8954f61d8d703e5eb7f3d93c9b40488f8b1b62ac/README.md
-      // https://github.com/npm/npm-registry-fetch/blob/8954f61d8d703e5eb7f3d93c9b40488f8b1b62ac/auth.js#L45-L91
-      case '_authToken':
-      case 'token':
-      case 'username':
-      case 'password':
-      case '_auth':
-      case 'auth':
-        options['forceAuth'] ??= {};
-        options['forceAuth'][key] = substitutedValue;
-        break;
       case 'noproxy':
       case 'no-proxy':
         options['noProxy'] = substitutedValue;

--- a/tests/e2e/tests/commands/add/secure-registry.ts
+++ b/tests/e2e/tests/commands/add/secure-registry.ts
@@ -1,5 +1,5 @@
-import { expectFileNotToExist, expectFileToExist, rimraf } from '../../../utils/fs';
-import { getActivePackageManager, installWorkspacePackages } from '../../../utils/packages';
+import { expectFileNotToExist, expectFileToExist } from '../../../utils/fs';
+import { installWorkspacePackages } from '../../../utils/packages';
 import { git, ng } from '../../../utils/process';
 import { createNpmConfigForAuthentication } from '../../../utils/registry';
 import { expectToFail } from '../../../utils/utils';
@@ -9,37 +9,17 @@ export default async function () {
   try {
     // The environment variable has priority over the .npmrc
     delete process.env['NPM_CONFIG_REGISTRY'];
-    const packageManager = getActivePackageManager();
-    const supportsUnscopedAuth = packageManager === 'yarn';
     const command = ['add', '@angular/pwa', '--skip-confirmation'];
-
-    // Works with unscoped registry authentication details
-    if (supportsUnscopedAuth) {
-      // Some package managers such as Bun and NPM do not support unscoped auth.
-      await createNpmConfigForAuthentication(false);
-
-      await expectFileNotToExist('public/manifest.webmanifest');
-
-      await ng(...command);
-      await expectFileToExist('public/manifest.webmanifest');
-      await git('clean', '-dxf');
-    }
 
     // Works with scoped registry authentication details
     await expectFileNotToExist('public/manifest.webmanifest');
 
-    await createNpmConfigForAuthentication(true);
+    await createNpmConfigForAuthentication();
     await ng(...command);
     await expectFileToExist('public/manifest.webmanifest');
     await git('clean', '-dxf');
 
     // Invalid authentication token
-    if (supportsUnscopedAuth) {
-      // Some package managers such as Bun and NPM do not support unscoped auth.
-      await createNpmConfigForAuthentication(false, true);
-      await expectToFail(() => ng(...command));
-    }
-
     await createNpmConfigForAuthentication(true, true);
     await expectToFail(() => ng(...command));
   } finally {

--- a/tests/e2e/tests/update/update-secure-registry.ts
+++ b/tests/e2e/tests/update/update-secure-registry.ts
@@ -6,9 +6,6 @@ import { getActivePackageManager } from '../../utils/packages';
 import assert from 'node:assert';
 
 export default async function () {
-  const packageManager = getActivePackageManager();
-  const supportsUnscopedAuth = packageManager === 'yarn';
-
   // The environment variable has priority over the .npmrc
   delete process.env['NPM_CONFIG_REGISTRY'];
   const worksMessage = 'We analyzed your package.json';
@@ -20,26 +17,13 @@ export default async function () {
 
   // Valid authentication token
 
-  if (supportsUnscopedAuth) {
-    await createNpmConfigForAuthentication(false);
-    const { stdout: stdout1 } = await ng('update', ...extraArgs);
-    if (!stdout1.includes(worksMessage)) {
-      throw new Error(`Expected stdout to contain "${worksMessage}"`);
-    }
-  }
-
-  await createNpmConfigForAuthentication(true);
+  await createNpmConfigForAuthentication();
   const { stdout: stdout2 } = await ng('update', ...extraArgs);
   if (!stdout2.includes(worksMessage)) {
     throw new Error(`Expected stdout to contain "${worksMessage}"`);
   }
 
   // Invalid authentication token
-
-  if (supportsUnscopedAuth) {
-    await createNpmConfigForAuthentication(false, true);
-    await expectToFail(() => ng('update', ...extraArgs));
-  }
 
   await createNpmConfigForAuthentication(true, true);
   await expectToFail(() => ng('update', ...extraArgs));

--- a/tests/e2e/utils/registry.ts
+++ b/tests/e2e/utils/registry.ts
@@ -63,7 +63,7 @@ export async function createNpmConfigForAuthentication(
    * _auth="dGVzdGluZzpzM2NyZXQ="`
    * ```
    */
-  scopedAuthentication: boolean,
+  scopedAuthentication = true,
   /** When true, an incorrect token is used. Use this to validate authentication failures. */
   invalidToken = false,
 ): Promise<void> {


### PR DESCRIPTION
Remove the non-standard forceAuth option and custom parsing for unscoped registry credentials (token, username, password, auth) in package-metadata.ts.

Since the npm CLI does not support unscoped credentials and ignores them by default, this aligning removes the unnecessary parsing complexity. Unscoped credentials will now behave identically to any other standard configuration property, falling through to default configuration parsing.