### PR TITLE
fix(@angular-devkit/schematics): prevent schematic writes from escaping the workspace via symlinks

### DIFF
--- a/packages/angular_devkit/schematics/tools/workflow/node-workflow.ts
+++ b/packages/angular_devkit/schematics/tools/workflow/node-workflow.ts
@@ -8,6 +8,9 @@
 
 import { Path, getSystemPath, normalize, schema, virtualFs } from '@angular-devkit/core';
 import { NodeJsSyncHost } from '@angular-devkit/core/node';
+import { realpathSync } from 'node:fs';
+import { dirname, isAbsolute, relative, resolve as resolveSystemPath, sep } from 'node:path';
+import { Observable } from 'rxjs';
 import { workflow } from '../../src';
 import { BuiltinTaskExecutor } from '../../tasks/node';
 import { FileSystemEngine } from '../description';
@@ -29,6 +32,72 @@ export interface NodeWorkflowOptions {
 }
 
 /**
+ * A {@link virtualFs.ScopedHost} that additionally rejects any write/delete/rename whose real
+ * (symlink-resolved) location escapes the workspace root.
+ *
+ * The lexical containment of `ScopedHost` (and the schematics `Tree`, which rejects `..`) does not
+ * resolve symlinks, so a workspace that contains a symlinked directory could otherwise route a
+ * schematic/migration write to a file outside the workspace. This mirrors the realpath-based root
+ * restriction already used by the MCP host (`createRootRestrictedHost`).
+ */
+class WorkspaceRootHost<T extends object> extends virtualFs.ScopedHost<T> {
+  private readonly _systemRoot: string;
+
+  constructor(delegate: virtualFs.Host<T>, root: Path) {
+    super(delegate, root);
+    this._systemRoot = realpathSync(getSystemPath(root));
+  }
+
+  private _assertWithinRoot(path: Path): void {
+    // Resolve the real path, walking up to the first existing ancestor for not-yet-created files.
+    let current = resolveSystemPath(getSystemPath(this._resolve(path)));
+    let real: string;
+    for (;;) {
+      try {
+        real = realpathSync(current);
+        break;
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+          throw e;
+        }
+        const parent = dirname(current);
+        if (parent === current) {
+          throw e;
+        }
+        current = parent;
+      }
+    }
+
+    const rel = relative(this._systemRoot, real);
+    if (rel === '..' || rel.startsWith('..' + sep) || isAbsolute(rel)) {
+      throw new Error(
+        `Schematic attempted to access a path outside of the workspace root: ` +
+          getSystemPath(this._resolve(path)),
+      );
+    }
+  }
+
+  override write(path: Path, content: virtualFs.FileBuffer): Observable<void> {
+    this._assertWithinRoot(path);
+
+    return super.write(path, content);
+  }
+
+  override delete(path: Path): Observable<void> {
+    this._assertWithinRoot(path);
+
+    return super.delete(path);
+  }
+
+  override rename(from: Path, to: Path): Observable<void> {
+    this._assertWithinRoot(from);
+    this._assertWithinRoot(to);
+
+    return super.rename(from, to);
+  }
+}
+
+/**
  * A workflow specifically for Node tools.
  */
 export class NodeWorkflow extends workflow.BaseWorkflow {
@@ -41,7 +110,7 @@ export class NodeWorkflow extends workflow.BaseWorkflow {
     let root;
     if (typeof hostOrRoot === 'string') {
       root = normalize(hostOrRoot);
-      host = new virtualFs.ScopedHost(new NodeJsSyncHost(), root);
+      host = new WorkspaceRootHost(new NodeJsSyncHost(), root);
     } else {
       host = hostOrRoot;
       root = options.root;

--- a/packages/angular_devkit/schematics/tools/workflow/node-workflow.ts
+++ b/packages/angular_devkit/schematics/tools/workflow/node-workflow.ts
@@ -9,7 +9,7 @@
 import { Path, getSystemPath, normalize, schema, virtualFs } from '@angular-devkit/core';
 import { NodeJsSyncHost } from '@angular-devkit/core/node';
 import { realpathSync } from 'node:fs';
-import { dirname, isAbsolute, relative, resolve as resolveSystemPath, sep } from 'node:path';
+import { basename, dirname, isAbsolute, relative, resolve as resolveSystemPath, sep } from 'node:path';
 import { Observable } from 'rxjs';
 import { workflow } from '../../src';
 import { BuiltinTaskExecutor } from '../../tasks/node';
@@ -32,6 +32,34 @@ export interface NodeWorkflowOptions {
 }
 
 /**
+ * Resolves the real path of a system path, walking up to the first existing ancestor if the path or
+ * its descendants do not exist, and preserving the non-existent trailing segments. This keeps the
+ * containment check working for not-yet-created files and for a workspace root that does not exist
+ * yet (e.g. during `ng new`), where `realpathSync` would otherwise throw `ENOENT`.
+ */
+function resolveRealPath(systemPath: string): string {
+  let current = resolveSystemPath(systemPath);
+  const segments: string[] = [];
+  for (;;) {
+    try {
+      const real = realpathSync(current);
+
+      return resolveSystemPath(real, ...segments.reverse());
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw e;
+      }
+      const parent = dirname(current);
+      if (parent === current) {
+        throw e;
+      }
+      segments.push(basename(current));
+      current = parent;
+    }
+  }
+}
+
+/**
  * A {@link virtualFs.ScopedHost} that additionally rejects any write/delete/rename whose real
  * (symlink-resolved) location escapes the workspace root.
  *
@@ -45,28 +73,11 @@ class WorkspaceRootHost<T extends object> extends virtualFs.ScopedHost<T> {
 
   constructor(delegate: virtualFs.Host<T>, root: Path) {
     super(delegate, root);
-    this._systemRoot = realpathSync(getSystemPath(root));
+    this._systemRoot = resolveRealPath(getSystemPath(root));
   }
 
   private _assertWithinRoot(path: Path): void {
-    // Resolve the real path, walking up to the first existing ancestor for not-yet-created files.
-    let current = resolveSystemPath(getSystemPath(this._resolve(path)));
-    let real: string;
-    for (;;) {
-      try {
-        real = realpathSync(current);
-        break;
-      } catch (e) {
-        if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
-          throw e;
-        }
-        const parent = dirname(current);
-        if (parent === current) {
-          throw e;
-        }
-        current = parent;
-      }
-    }
+    const real = resolveRealPath(getSystemPath(this._resolve(path)));
 
     const rel = relative(this._systemRoot, real);
     if (rel === '..' || rel.startsWith('..' + sep) || isAbsolute(rel)) {


### PR DESCRIPTION
Reopens #33325 (the previous PR was accidentally closed; this is the same single-file fix rebased cleanly onto current `main`).

A schematic / migration write can escape the workspace root via a **symlinked directory inside the workspace**. The schematics `NodeWorkflow` writes through `virtualFs.ScopedHost`, whose containment is **lexical** (it joins the path under the root but does not resolve symlinks), and the schematics `Tree` only rejects `..`. So a workspace that contains a symlinked directory can route a `write`/`delete`/`rename` to a file **outside** the workspace.

## Fix
`WorkspaceRootHost extends virtualFs.ScopedHost` resolves the **real** (symlink-collapsed) path with `realpathSync` (walking up to the first existing ancestor for not-yet-created files) and rejects any `write`/`delete`/`rename` whose real location is outside the workspace root (`rel === ".." || rel.startsWith(".." + sep) || isAbsolute(rel)`). This mirrors the realpath-based root restriction already used by the MCP host (`createRootRestrictedHost`). No change for legitimate in-workspace paths.

Single file changed: `packages/angular_devkit/schematics/tools/workflow/node-workflow.ts` (+70 −1).