### PR TITLE
fix(@angular/ssr): correct grammar in console warning for redirected location headers

### DIFF
--- a/packages/angular/ssr/src/utils/redirect.ts
+++ b/packages/angular/ssr/src/utils/redirect.ts
@@ -46,7 +46,7 @@ export function createRedirectResponse(
   if (ngDevMode && resHeaders.has('location')) {
     // eslint-disable-next-line no-console
     console.warn(
-      `Location header "${resHeaders.get('location')}" will ignored and set to "${location}".`,
+      `Location header "${resHeaders.get('location')}" will be ignored and set to "${location}".`,
     );
   }
 

--- a/packages/angular/ssr/test/utils/redirect_spec.ts
+++ b/packages/angular/ssr/test/utils/redirect_spec.ts
@@ -52,7 +52,7 @@ describe('Redirect Utils', () => {
       const warnSpy = spyOn(console, 'warn');
       createRedirectResponse('/home', 302, { 'Location': '/evil' });
       expect(warnSpy).toHaveBeenCalledWith(
-        'Location header "/evil" will ignored and set to "/home".',
+        'Location header "/evil" will be ignored and set to "/home".',
       );
     });
 


### PR DESCRIPTION

The console message had incorrect grammer.
