### PR TITLE
fix(@angular/ssr): prioritize options over environment variables in AngularNodeAppEngine (20.3.x)

### DIFF
--- a/packages/angular/ssr/node/src/app-engine.ts
+++ b/packages/angular/ssr/node/src/app-engine.ts
@@ -38,8 +38,8 @@ export class AngularNodeAppEngine {
   constructor(options?: AngularNodeAppEngineOptions) {
     const appEngineOptions: AngularAppEngineOptions = {
       ...options,
-      allowedHosts: getAllowedHostsFromEnv() ?? options?.allowedHosts,
-      trustProxyHeaders: getTrustProxyHeadersFromEnv() ?? options?.trustProxyHeaders,
+      allowedHosts: options?.allowedHosts ?? getAllowedHostsFromEnv(),
+      trustProxyHeaders: options?.trustProxyHeaders ?? getTrustProxyHeadersFromEnv(),
     };
 
     this.angularAppEngine = new AngularAppEngine(appEngineOptions);


### PR DESCRIPTION
Backport of #33352 to 20.3.x: Prioritize constructor options over environment variables when initializing the AngularNodeAppEngine. Previously, environment variables took priority and blindly overrode the constructor options if they were defined in the environment. Now, explicit constructor options act as the override, while the environment variables serve as a fallback.