### PR TITLE
fix(@angular/cli): fallback to deprecated versions when resolving ranges if no non-deprecated version is found (20.3.x)

### DIFF
--- a/packages/angular/cli/src/commands/update/cli.ts
+++ b/packages/angular/cli/src/commands/update/cli.ts
@@ -682,29 +682,30 @@ export default class UpdateCommandModule extends CommandModule<UpdateCommandArgs
         case 'version':
           manifest = metadata.versions[requestIdentifier.fetchSpec];
           break;
-        case 'range':
-          for (const potentialManifest of Object.values(metadata.versions)) {
-            // Ignore deprecated package versions
-            if (potentialManifest.deprecated) {
-              continue;
+        case 'range': {
+          const potentialManifests = Object.values(metadata.versions).filter((potentialManifest) =>
+            semver.satisfies(potentialManifest.version, requestIdentifier.fetchSpec, {
+              loose: true,
+            }),
+          );
+
+          const nonDeprecated = potentialManifests.filter((m) => !m.deprecated);
+          const deprecated = potentialManifests.filter((m) => !!m.deprecated);
+
+          const selectLatest = (manifests: PackageManifest[]) => {
+            let max: PackageManifest | undefined;
+            for (const m of manifests) {
+              if (!max || semver.gt(m.version, max.version, { loose: true })) {
+                max = m;
+              }
             }
-            // Only consider versions that are within the range
-            if (
-              !semver.satisfies(potentialManifest.version, requestIdentifier.fetchSpec, {
-                loose: true,
-              })
-            ) {
-              continue;
-            }
-            // Update the used manifest if current potential is newer than existing or there is not one yet
-            if (
-              !manifest ||
-              semver.gt(potentialManifest.version, manifest.version, { loose: true })
-            ) {
-              manifest = potentialManifest;
-            }
-          }
+
+            return max;
+          };
+
+          manifest = selectLatest(nonDeprecated) ?? selectLatest(deprecated);
           break;
+        }
       }
 
       if (!manifest) {

--- a/packages/angular/cli/src/commands/update/schematic/index.ts
+++ b/packages/angular/cli/src/commands/update/schematic/index.ts
@@ -704,7 +704,7 @@ function _addPackageGroup(
   if (Array.isArray(packageGroup) && !packageGroup.some((x) => typeof x != 'string')) {
     packageGroupNormalized = packageGroup.reduce(
       (acc, curr) => {
-        acc[curr] = maybePackage;
+        acc[curr] = version;
 
         return acc;
       },

--- a/tests/legacy-cli/e2e/assets/ssr-project-webpack/package.json
+++ b/tests/legacy-cli/e2e/assets/ssr-project-webpack/package.json
@@ -14,7 +14,6 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^20.0.0-next.0",
     "@angular/common": "^20.0.0-next.0",
     "@angular/compiler": "^20.0.0-next.0",
     "@angular/core": "^20.0.0-next.0",

--- a/tests/legacy-cli/e2e/tests/commands/add/version-specifier.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/version-specifier.ts
@@ -28,12 +28,13 @@ export default async function () {
     'Installation was not skipped',
   );
 
-  const output2 = await ng('add', '@angular/localize@latest', '--skip-confirmation');
-  assert.doesNotMatch(
-    output2.stdout,
-    /Skipping installation: Package already installed/,
-    'Installation should not have been skipped',
-  );
+  // Skipped as `@latest` installs a version that does not support the used Node.js version.
+  // const output2 = await ng('add', '@angular/localize@latest', '--skip-confirmation');
+  // assert.doesNotMatch(
+  //   output2.stdout,
+  //   /Skipping installation: Package already installed/,
+  //   'Installation should not have been skipped',
+  // );
 
   const output3 = await ng('add', '@angular/localize@19.1.0', '--skip-confirmation');
   assert.doesNotMatch(


### PR DESCRIPTION
When using `ng update` to resolve package version ranges on the command line in 20.3.x, we previously skipped deprecated package versions entirely during pre-validation. In cases where all versions satisfying the range are deprecated, this resulted in update failure. Now, we attempt to find a satisfying version from non-deprecated versions first, and fallback to deprecated versions if none are found. This aligns the CLI pre-validation with the update schematic resolution logic.