### PR TITLE
fix(@angular/ssr): avoid caching non-SSG page lookups

### DIFF
--- a/packages/angular/ssr/node/src/common-engine/common-engine.ts
+++ b/packages/angular/ssr/node/src/common-engine/common-engine.ts
@@ -175,9 +175,11 @@ export class CommonEngine {
     const isSSG = SSG_MARKER_REGEXP.test(content);
     if (isSSG) {
       this.pageIsSSG.set(pagePath, true);
+
+      return content;
     }
 
-    return isSSG ? content : undefined;
+    return undefined;
   }
 
   private async renderApplication(opts: CommonEngineRenderOptions): Promise<string> {

--- a/packages/angular/ssr/node/src/common-engine/common-engine.ts
+++ b/packages/angular/ssr/node/src/common-engine/common-engine.ts
@@ -167,15 +167,15 @@ export class CommonEngine {
 
     if (pagePath === resolve(documentFilePath) || !(await exists(pagePath))) {
       // View matches with prerender path or file does not exist.
-      this.pageIsSSG.set(pagePath, false);
-
       return undefined;
     }
 
     // Static file exists.
     const content = await fs.promises.readFile(pagePath, 'utf-8');
     const isSSG = SSG_MARKER_REGEXP.test(content);
-    this.pageIsSSG.set(pagePath, isSSG);
+    if (isSSG) {
+      this.pageIsSSG.set(pagePath, true);
+    }
 
     return isSSG ? content : undefined;
   }


### PR DESCRIPTION
Only cache CommonEngine SSG lookup results after the target file is confirmed to be a prerendered SSG page.

Missing pages and static files without the SSG marker can be derived from request URLs, so retaining those negative results allows attacker-controlled paths to grow the process cache without bound. Over time, this can lead to unbounded memory growth and a denial of service.
