### PR TITLE
fix(@schematics/angular): remove unused app tsconfig outDir

### DIFF
--- a/packages/schematics/angular/application/files/common-files/tsconfig.app.json.template
+++ b/packages/schematics/angular/application/files/common-files/tsconfig.app.json.template
@@ -3,7 +3,6 @@
 {
   "extends": "<%= relativePathToWorkspaceRoot %>/tsconfig.json",
   "compilerOptions": {
-    "outDir": "<%= relativePathToWorkspaceRoot %>/out-tsc/app",
     "types": []
   },
   "include": [

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -94,10 +94,12 @@ describe('Application Schematic', () => {
     const tree = await schematicRunner.runSchematic('application', defaultOptions, workspaceTree);
 
     const {
+      compilerOptions,
       include,
       exclude,
       extends: _extends,
     } = readJsonFile(tree, '/projects/foo/tsconfig.app.json');
+    expect(compilerOptions.outDir).toBeUndefined();
     expect(include).toEqual(['src/**/*.ts']);
     expect(exclude).toEqual(['src/**/*.spec.ts']);
     expect(_extends).toBe('../../tsconfig.json');


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

New applications generated by the application schematic include an `outDir` entry in `tsconfig.app.json`. This can cause a TypeScript configuration lint warning for projects generated by `ng new`.

Issue Number: Fixes #33360

## What is the new behavior?

Generated application `tsconfig.app.json` files no longer include the unused `outDir` compiler option.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Docs are not updated because this only removes an unused generated TypeScript compiler option.

Verification:
- `pnpm exec bazelisk test //packages/schematics/angular:test --test_output=errors`
- `git diff --check`
