### PR TITLE
docs(@angular/ssr): add SSRF security note to createNodeRequestHandle…

### DIFF
--- a/packages/angular/ssr/node/src/handler.ts
+++ b/packages/angular/ssr/node/src/handler.ts
@@ -55,6 +55,14 @@ export type NodeRequestHandlerFunction = (
  * });
  * ```
  *
+ * @remarks
+ * **Security note:** `createWebRequestFromNodeRequest()` builds the request URL directly from the
+ * `Host` and `X-Forwarded-*` headers and does not validate them. When integrating with a
+ * third-party framework as shown above, configure `allowedHosts` (and, if needed,
+ * `trustProxyHeaders`) via `AngularNodeAppEngine`, or otherwise validate these headers yourself,
+ * to prevent Server-Side Request Forgery (SSRF). For more information, see
+ * https://angular.dev/best-practices/security#preventing-server-side-request-forgery-ssrf.
+ *
  * @example
  * Usage in a Fastify application:
  * ```ts


### PR DESCRIPTION
The Hono example in `handler.ts` uses `createWebRequestFromNodeRequest()` directly, which builds `request.url` from `Host`/`X-Forwarded-*` headers without host validation. Unlike `AngularNodeAppEngine` which documents `allowedHosts` and links to the SSRF security guide, this example carries no security guidance. This PR adds a @remarks note directing users to the existing SSRF documentation.

Reference: https://angular.dev/best-practices/security#preventing-server-side-request-forgery-ssrf