### PR TITLE
fix(@angular/build): skip semantic diagnostics for declaration files

### DIFF
--- a/packages/angular/build/src/tools/angular/compilation/aot-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/aot-compilation.ts
@@ -234,6 +234,7 @@ export class AotCompilation extends AngularCompilation {
 
     const syntactic = modes & DiagnosticModes.Syntactic;
     const semantic = modes & DiagnosticModes.Semantic;
+    const skipLibCheck = typeScriptProgram.getCompilerOptions().skipLibCheck;
 
     // Collect program level diagnostics
     if (modes & DiagnosticModes.Option) {
@@ -265,13 +266,19 @@ export class AotCompilation extends AngularCompilation {
         continue;
       }
 
+      // When skipLibCheck is enabled (the default), declaration files are not
+      // type-checked, so getSemanticDiagnostics() would return nothing for them.
+      if (sourceFile.isDeclarationFile && skipLibCheck) {
+        continue;
+      }
+
       yield* profileSync(
         'NG_DIAGNOSTICS_SEMANTIC',
         () => typeScriptProgram.getSemanticDiagnostics(sourceFile),
         true,
       );
 
-      // Declaration files cannot have template diagnostics
+      // Declaration files cannot have template diagnostics.
       if (sourceFile.isDeclarationFile) {
         continue;
       }


### PR DESCRIPTION
Declaration files don't produce semantic or template diagnostics, so calling getSemanticDiagnostics() on them was just wasted work. Move the isDeclarationFile guard to before that call so .d.ts files are skipped entirely.