### PR TITLE
fix(@schematics/angular): remove default workspace vscode mcp.json configuration

### DIFF
--- a/packages/schematics/angular/workspace/files/__dot__vscode/mcp.json.template
+++ b/packages/schematics/angular/workspace/files/__dot__vscode/mcp.json.template
@@ -1,9 +1,0 @@
-{
-  // For more information, visit: https://angular.dev/ai/mcp
-  "servers": {
-    "angular-cli": {
-      "command": "npx",
-      "args": ["-y", "@angular/cli", "mcp"]
-    }
-  }
-}

--- a/packages/schematics/angular/workspace/index_spec.ts
+++ b/packages/schematics/angular/workspace/index_spec.ts
@@ -29,7 +29,6 @@ describe('Workspace Schematic', () => {
       jasmine.arrayContaining([
         '/.vscode/extensions.json',
         '/.vscode/launch.json',
-        '/.vscode/mcp.json',
         '/.vscode/tasks.json',
         '/.editorconfig',
         '/angular.json',
@@ -71,7 +70,6 @@ describe('Workspace Schematic', () => {
       jasmine.arrayContaining([
         '/.vscode/extensions.json',
         '/.vscode/launch.json',
-        '/.vscode/mcp.json',
         '/.vscode/tasks.json',
         '/angular.json',
         '/.gitignore',


### PR DESCRIPTION
The workspace schematic previously generated a default `.vscode/mcp.json` file when initializing a new workspace. However, this configuration is now managed and optionally generated via the `ai-config` schematic (either during `ng new` tool setup or through direct schematic invocation).