### PR TITLE
perf(@angular/build): dispose builder result context early in non-watch mode

### DIFF
--- a/packages/angular/build/src/builders/application/build-action.ts
+++ b/packages/angular/build/src/builders/application/build-action.ts
@@ -148,7 +148,13 @@ export async function* runEsBuildBuildAction(
     // Output the first build results after setting up the watcher to ensure that any code executed
     // higher in the iterator call stack will trigger the watcher. This is particularly relevant for
     // unit tests which execute the builder and modify the file system programmatically.
-    yield* emitOutputResults(result, outputOptions);
+    const outputResults = [...emitOutputResults(result, outputOptions)];
+    if (!watch) {
+      await result.dispose();
+      // Set to true to prevent double-disposal of the result context in the finally block on generator exit
+      watchLoopStarted = true;
+    }
+    yield* outputResults;
 
     // Finish if watch mode is not enabled
     if (!watcher) {


### PR DESCRIPTION
Evaluates and extracts final output results into a list before calling result.dispose() in non-watch mode. This ensures all compiler worker processes (retaining the TypeScript program structures and cache) are terminated and reclaimed before yielding results to the caller for disk writing.
