### PR TITLE
fix(@angular/build): auto-inject localize/init in library unit tests

### DIFF
--- a/packages/angular/build/src/builders/karma/application_builder.ts
+++ b/packages/angular/build/src/builders/karma/application_builder.ts
@@ -11,6 +11,7 @@ import type { Config, ConfigOptions, FilePattern, InlinePluginDef, Server } from
 import { randomUUID } from 'node:crypto';
 import { rmSync } from 'node:fs';
 import * as fs from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { ReadableStream } from 'node:stream/web';
 import { createVirtualModulePlugin } from '../../tools/esbuild/virtual-module-plugin';
@@ -199,10 +200,18 @@ async function runEsbuild(
   projectSourceRoot: string,
 ): Promise<[Result & { kind: ResultKind.Full }, AsyncIterator<Result> | null]> {
   const usesZoneJS = buildOptions.polyfills?.includes('zone.js');
+  let hasLocalize = false;
+  try {
+    const projectRequire = createRequire(path.join(projectSourceRoot, 'package.json'));
+    projectRequire.resolve('@angular/localize');
+    hasLocalize = true;
+  } catch {}
+
   const virtualTestBedInit = createVirtualModulePlugin({
     namespace: 'angular:test-bed-init',
     loadContent: async () => {
       const contents: string[] = [
+        ...(hasLocalize ? [`import '@angular/localize/init';`] : []),
         // Initialize the Angular testing environment
         `import { NgModule${usesZoneJS ? ', provideZoneChangeDetection' : ''} } from '@angular/core';`,
         `import { getTestBed } from '@angular/core/testing';`,

--- a/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
@@ -34,6 +34,7 @@ function createTestBedInitVirtualFile(
   projectSourceRoot: string,
   teardown: boolean,
   zoneTestingStrategy: 'none' | 'static' | 'dynamic',
+  hasLocalize: boolean,
 ): string {
   let providersImport = 'const providers = [];';
   if (providersFile) {
@@ -58,6 +59,7 @@ function createTestBedInitVirtualFile(
   // when running Vitest in non-isolated mode with JSDOM. It looks up the
   // document dynamically on every operation instead of caching it.
   return `
+    ${hasLocalize ? "import '@angular/localize/init';" : ''}
     // Initialize the Angular testing environment
     import { NgModule, provideZoneChangeDetection } from '@angular/core';
     import { getTestBed, ɵgetCleanupHook as getCleanupHook, TestComponentRenderer } from '@angular/core/testing';
@@ -254,11 +256,19 @@ export async function getVitestBuildOptions(
   // Inject the zone.js testing polyfill if Zone.js is installed.
   const zoneTestingStrategy = getZoneTestingStrategy(buildOptions, projectSourceRoot);
 
+  let hasLocalize = false;
+  try {
+    const projectRequire = createRequire(path.join(projectSourceRoot, 'package.json'));
+    projectRequire.resolve('@angular/localize');
+    hasLocalize = true;
+  } catch {}
+
   const testBedInitContents = createTestBedInitVirtualFile(
     providersFile,
     projectSourceRoot,
     !options.debug,
     zoneTestingStrategy,
+    hasLocalize,
   );
 
   const mockPatchContents = `

--- a/packages/angular/build/src/tools/esbuild/angular-localize-init-warning-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/angular-localize-init-warning-plugin.ts
@@ -26,6 +26,10 @@ export function createAngularLocalizeInitWarningPlugin(): Plugin {
           return null;
         }
 
+        if (args.namespace?.startsWith('angular:')) {
+          return null;
+        }
+
         const { importer, kind, resolveDir, namespace, pluginData = {} } = args;
         pluginData[NG_LOCALIZE_RESOLUTION] = true;
 


### PR DESCRIPTION
Injects '@angular/localize/init' at the top of the internal virtual initialization file (angular:test-bed-init) if '@angular/localize' is installed in the workspace. This prevents ReferenceErrors when testing libraries that consume localization APIs.

Also updates the warning plugin to skip internal imports originating from the 'angular:' namespace.