### PR TITLE
fix(@angular/cli): respect release age policy in update bootstrapping logic

### DIFF
--- a/packages/angular/cli/src/commands/update/utilities/cli-version.ts
+++ b/packages/angular/cli/src/commands/update/utilities/cli-version.ts
@@ -70,7 +70,7 @@ export async function checkCLIVersion(
 
   const version = manifest.version;
 
-  return VERSION.full === version ? null : version;
+  return VERSION.full === version ? null : String(runnerVersion);
 }
 
 /**


### PR DESCRIPTION
Querying version target returns the resolved range/tag specifier instead of the resolved specific version number if the installed CLI version is outdated. This allows the package manager to natively enforce release-age policies (like pnpm's `minimum-release-age` or yarn's `npmMinimalAgeGate`) and select an appropriate older version during temporary installation rather than crashing.
