### PR TITLE
fix(@angular/ssr): preserve response headers during redirect

### DIFF
--- a/packages/angular/ssr/src/app.ts
+++ b/packages/angular/ssr/src/app.ts
@@ -353,7 +353,7 @@ export class AngularServerApp {
     }
 
     if (result.redirectTo) {
-      return createRedirectResponse(result.redirectTo, responseInit.status, headers);
+      return createRedirectResponse(result.redirectTo, responseInit.status, responseInit.headers);
     }
 
     if (renderMode === RenderMode.Prerender) {

--- a/packages/angular/ssr/src/utils/redirect.ts
+++ b/packages/angular/ssr/src/utils/redirect.ts
@@ -9,7 +9,9 @@
 /**
  * An set of HTTP status codes that are considered valid for redirect responses.
  */
-export const VALID_REDIRECT_RESPONSE_CODES: Set<number> = new Set([301, 302, 303, 307, 308]);
+export const VALID_REDIRECT_RESPONSE_CODES: ReadonlySet<number> = new Set([
+  301, 302, 303, 307, 308,
+]);
 
 /**
  * Checks if the given HTTP status code is a valid redirect response code.
@@ -33,7 +35,7 @@ export function isValidRedirectResponseCode(code: number): boolean {
 export function createRedirectResponse(
   location: string,
   status = 302,
-  headers?: Record<string, string>,
+  headers?: Record<string, string> | Headers,
 ): Response {
   if (ngDevMode && !isValidRedirectResponseCode(status)) {
     throw new Error(
@@ -42,7 +44,7 @@ export function createRedirectResponse(
     );
   }
 
-  const resHeaders = new Headers(headers);
+  const resHeaders = headers instanceof Headers ? headers : new Headers(headers);
   if (ngDevMode && resHeaders.has('location')) {
     // eslint-disable-next-line no-console
     console.warn(

--- a/packages/angular/ssr/test/app_spec.ts
+++ b/packages/angular/ssr/test/app_spec.ts
@@ -42,6 +42,10 @@ describe('AngularServerApp', () => {
         const responseInit = inject(RESPONSE_INIT);
         if (responseInit) {
           responseInit.status = 308;
+          const headers = responseInit.headers;
+          if (headers) {
+            (headers as Headers).set('X-Redirect-Header', 'custom-value');
+          }
         }
 
         void inject(Router).navigate([], {
@@ -326,6 +330,7 @@ describe('AngularServerApp', () => {
         const response = await app.handle(new Request('http://localhost/redirect-via-navigate'));
         expect(response?.headers.get('location')).toBe('/redirect-via-navigate?filter=test');
         expect(response?.status).toBe(308);
+        expect(response?.headers.get('X-Redirect-Header')).toBe('custom-value');
       });
 
       it('returns a 302 status and redirects to the correct location when `urlTree` is updated in a guard', async () => {


### PR DESCRIPTION
Previously, when a redirect was triggered, any custom headers (such as cookies or cache control) configured on the RESPONSE_INIT object by components or guards were lost because the redirect response was created with the default headers only.

Closes #33473
