### PR TITLE
fix(@angular/build): scope createRequire module resolution using paths to prevent parent paths

### DIFF
--- a/packages/angular/build/src/builders/application/options.ts
+++ b/packages/angular/build/src/builders/application/options.ts
@@ -25,6 +25,7 @@ import {
   loadPostcssConfiguration,
 } from '../../utils/postcss-configuration';
 import { getProjectRootPaths, normalizeDirectoryPath } from '../../utils/project-metadata';
+import { createProjectResolver } from '../../utils/resolve-project';
 import { addTrailingSlash, joinUrlParts, stripLeadingSlash } from '../../utils/url';
 import {
   Schema as ApplicationBuilderOptions,
@@ -728,9 +729,7 @@ function normalizeExternals(value: string[] | undefined): string[] | undefined {
 }
 
 async function findFrameworkVersion(projectRoot: string): Promise<string> {
-  // Create a custom require function for ESM compliance.
-  // NOTE: The trailing slash is significant.
-  const projectResolve = createRequire(projectRoot + '/').resolve;
+  const projectResolve = createProjectResolver(projectRoot);
 
   try {
     const manifestPath = projectResolve('@angular/core/package.json');

--- a/packages/angular/build/src/builders/karma/application_builder.ts
+++ b/packages/angular/build/src/builders/karma/application_builder.ts
@@ -15,6 +15,7 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import { ReadableStream } from 'node:stream/web';
 import { createVirtualModulePlugin } from '../../tools/esbuild/virtual-module-plugin';
+import { createProjectResolver } from '../../utils/resolve-project';
 import { writeTestFiles } from '../../utils/test-files';
 import { buildApplicationInternal } from '../application/index';
 import { ApplicationBuilderInternalOptions } from '../application/options';
@@ -202,8 +203,8 @@ async function runEsbuild(
   const usesZoneJS = buildOptions.polyfills?.includes('zone.js');
   let hasLocalize = false;
   try {
-    const projectRequire = createRequire(path.join(projectSourceRoot, 'package.json'));
-    projectRequire.resolve('@angular/localize');
+    const projectResolve = createProjectResolver(projectSourceRoot);
+    projectResolve('@angular/localize');
     hasLocalize = true;
   } catch {}
 

--- a/packages/angular/build/src/builders/unit-test/runners/dependency-checker.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/dependency-checker.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { createRequire } from 'node:module';
+import { createProjectResolver } from '../../../utils/resolve-project';
 
 /**
  * A custom error class to represent missing dependency errors.
@@ -26,7 +26,7 @@ export class DependencyChecker {
   private readonly missingDependencies = new Set<string>();
 
   constructor(projectSourceRoot: string) {
-    this.resolver = createRequire(projectSourceRoot + '/').resolve;
+    this.resolver = createProjectResolver(projectSourceRoot);
   }
 
   /**

--- a/packages/angular/build/src/builders/unit-test/runners/vitest/browser-provider.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/browser-provider.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { createRequire } from 'node:module';
 import type {
   BrowserBuiltinProvider,
   BrowserConfigOptions,
   BrowserProviderOption,
 } from 'vitest/node';
 import { assertIsError } from '../../../../utils/error';
+import { createProjectResolver } from '../../../../utils/resolve-project';
 
 export interface BrowserConfiguration {
   browser?: BrowserConfigOptions;
@@ -21,7 +21,7 @@ export interface BrowserConfiguration {
 }
 
 function findBrowserProvider(
-  projectResolver: NodeJS.RequireResolve,
+  projectResolver: (packageName: string) => string,
 ): BrowserBuiltinProvider | undefined {
   const requiresPreview = !!process.versions.webcontainer;
 
@@ -138,7 +138,7 @@ export async function setupBrowserConfiguration(
     return {};
   }
 
-  const projectResolver = createRequire(projectSourceRoot + '/').resolve;
+  const projectResolver = createProjectResolver(projectSourceRoot);
   let errors: string[] | undefined;
 
   const providerName = findBrowserProvider(projectResolver);

--- a/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
@@ -11,9 +11,9 @@
  * Provides Vitest-specific build options and virtual file contents for Angular unit testing.
  */
 
-import { createRequire } from 'node:module';
 import path from 'node:path';
 import { toPosixPath } from '../../../../utils/path';
+import { createProjectResolver } from '../../../../utils/resolve-project';
 import type { ApplicationBuilderInternalOptions } from '../../../application/options';
 import { OutputHashing } from '../../../application/schema';
 import { NormalizedUnitTestBuilderOptions } from '../../options';
@@ -169,8 +169,8 @@ function getZoneTestingStrategy(
   }
 
   try {
-    const projectRequire = createRequire(path.join(projectSourceRoot, 'package.json'));
-    projectRequire.resolve('zone.js');
+    const projectResolve = createProjectResolver(projectSourceRoot);
+    projectResolve('zone.js');
 
     // If polyfills is undefined (e.g. library build target), load zone.js dynamically.
     // If polyfills is defined but doesn't include zone.js (e.g. zoneless application), do NOT load zone.js.
@@ -268,8 +268,8 @@ export async function getVitestBuildOptions(
 
   let hasLocalize = false;
   try {
-    const projectRequire = createRequire(path.join(projectSourceRoot, 'package.json'));
-    projectRequire.resolve('@angular/localize');
+    const projectResolve = createProjectResolver(projectSourceRoot);
+    projectResolve('@angular/localize');
     hasLocalize = true;
   } catch {}
 

--- a/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
@@ -8,7 +8,6 @@
 
 import assert from 'node:assert';
 import { readFile } from 'node:fs/promises';
-import { createRequire } from 'node:module';
 import { platform } from 'node:os';
 import path from 'node:path';
 import type {
@@ -22,6 +21,7 @@ import type {
 } from 'vitest/node';
 import { createBuildAssetsMiddleware } from '../../../../tools/vite/middlewares/assets-middleware';
 import { toPosixPath } from '../../../../utils/path';
+import { createProjectResolver } from '../../../../utils/resolve-project';
 import type { ResultFile } from '../../../application/results';
 import type { NormalizedUnitTestBuilderOptions } from '../../options';
 import { normalizeBrowserName } from './browser-provider';
@@ -60,7 +60,7 @@ interface VitestConfigPluginOptions {
 }
 
 async function findTestEnvironment(
-  projectResolver: NodeJS.RequireResolve,
+  projectResolver: (packageName: string) => string,
 ): Promise<'jsdom' | 'happy-dom'> {
   try {
     projectResolver('happy-dom');
@@ -89,10 +89,10 @@ function determineCoverageProvider(
     if (hasNonChromium) {
       determinedProvider = 'istanbul';
     } else {
-      const projectRequire = createRequire(projectSourceRoot + '/');
+      const projectResolve = createProjectResolver(projectSourceRoot);
       const checkInstalled = (pkg: string) => {
         try {
-          projectRequire.resolve(pkg);
+          projectResolve(pkg);
 
           return true;
         } catch {
@@ -243,7 +243,7 @@ export async function createVitestConfigPlugin(
         validateBrowserCoverage(browser, testConfig?.browser, determinedProvider);
       }
 
-      const projectResolver = createRequire(projectSourceRoot + '/').resolve;
+      const projectResolver = createProjectResolver(projectSourceRoot);
 
       const projectDefaults: Vite.UserConfig & UserWorkspaceConfig = {
         test: {

--- a/packages/angular/build/src/utils/resolve-project.ts
+++ b/packages/angular/build/src/utils/resolve-project.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+
+/**
+ * Creates a module resolver function that is strictly scoped to the project root.
+ * This prevents module resolution from leaking the parent module context when executing inside virtual stores (like pnpm).
+ *
+ * @param projectRoot The root directory of the project.
+ * @returns A resolver function that takes a package name/path and returns its resolved path.
+ */
+export function createProjectResolver(projectRoot: string): (packageName: string) => string {
+  const projectRequire = createRequire(join(projectRoot, 'package.json'));
+
+  return (packageName: string) => projectRequire.resolve(packageName, { paths: [projectRoot] });
+}


### PR DESCRIPTION
Ensure that custom resolvers created via createRequire use the strict paths resolution option when checking for the presence of local packages (such as zone.js, @angular/localize, @angular/core, or vitest test environments). This prevents Node's resolver from using the parent module context (located inside the virtual store .pnpm) and falsely finding packages that are not direct dependencies of the project.