### PR TITLE
refactor(@angular/build): use envDir instead of deprecated envFile option in Vite configuration

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite/server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite/server.ts
@@ -165,7 +165,7 @@ export async function setupServer(
 
   const configuration: Vite.InlineConfig = {
     configFile: false,
-    envFile: false,
+    envDir: false,
     cacheDir,
     root: virtualProjectRoot,
     publicDir: false,


### PR DESCRIPTION
The 'envFile' option in Vite inline config is deprecated. This updates the Vite dev server configuration to use 'envDir: false' instead.