### PR TITLE
fix(@angular/build): strip all vite id prefixes from minified code wi…

### DIFF
--- a/packages/angular/build/src/tools/vite/plugins/id-prefix-plugin.ts
+++ b/packages/angular/build/src/tools/vite/plugins/id-prefix-plugin.ts
@@ -29,17 +29,7 @@ export function createRemoveIdPrefixPlugin(externals: string[]): Plugin {
         return;
       }
 
-      // The path suffix is bounded so that a match can never extend past the end of an
-      // import specifier string literal. With a greedy `.+`, minified (single-line) code
-      // would let the first match consume the remainder of the line, leaving all later
-      // `/@id/` occurrences on that line unstripped.
-      const escapedExternals = externals.map(
-        (e) => escapeRegexSpecialChars(e) + '(?:/[^\'"`\\s]+)?',
-      );
-      const prefixedExternalRegex = new RegExp(
-        `${resolvedConfig.base}${VITE_ID_PREFIX}(${escapedExternals.join('|')})`,
-        'g',
-      );
+      const transformFn = createTransformer(resolvedConfig.base, externals);
 
       // @ts-expect-error: Property 'push' does not exist on type 'readonly Plugin<any>[]'
       // Reasoning:
@@ -48,15 +38,34 @@ export function createRemoveIdPrefixPlugin(externals: string[]): Plugin {
       //  AFTER the import-analysis.
       resolvedConfig.plugins.push({
         name: 'angular-plugin-remove-id-prefix-transform',
-        transform: (code: string) => {
-          // don't do anything when code does not contain the Vite prefix
-          if (!code.includes(VITE_ID_PREFIX)) {
-            return code;
-          }
-
-          return code.replace(prefixedExternalRegex, (_, externalName) => externalName);
-        },
+        transform: transformFn,
       });
     },
+  };
+}
+
+/**
+ * Creates a transform function that removes the Vite ID prefix from externals.
+ * @param base The base path of the application.
+ * @param externals The external package names.
+ * @returns A function that transforms code by removing the Vite ID prefix.
+ */
+export function createTransformer(base: string, externals: string[]): (code: string) => string {
+  // The path suffix is bounded so that a match can never extend past the end of an
+  // import specifier string literal. With a greedy `.+`, minified (single-line) code
+  // would let the first match consume the remainder of the line, leaving all later
+  // `/@id/` occurrences on that line unstripped.
+  const escapedExternals = externals.map((e) => escapeRegexSpecialChars(e) + '(?:/[^\'"`\\s]+)?');
+
+  const prefixedExternalRegex = new RegExp(
+    `${base}${VITE_ID_PREFIX}(${escapedExternals.join('|')})`,
+    'g',
+  );
+
+  return (code: string) => {
+    return code.includes(VITE_ID_PREFIX)
+      ? code.replace(prefixedExternalRegex, (_, externalName) => externalName)
+      : // don't do anything when code does not contain the Vite prefix
+        code;
   };
 }

--- a/packages/angular/build/src/tools/vite/plugins/id-prefix-plugin.ts
+++ b/packages/angular/build/src/tools/vite/plugins/id-prefix-plugin.ts
@@ -29,7 +29,13 @@ export function createRemoveIdPrefixPlugin(externals: string[]): Plugin {
         return;
       }
 
-      const escapedExternals = externals.map((e) => escapeRegexSpecialChars(e) + '(?:/.+)?');
+      // The path suffix is bounded so that a match can never extend past the end of an
+      // import specifier string literal. With a greedy `.+`, minified (single-line) code
+      // would let the first match consume the remainder of the line, leaving all later
+      // `/@id/` occurrences on that line unstripped.
+      const escapedExternals = externals.map(
+        (e) => escapeRegexSpecialChars(e) + '(?:/[^\'"`\\s]+)?',
+      );
       const prefixedExternalRegex = new RegExp(
         `${resolvedConfig.base}${VITE_ID_PREFIX}(${escapedExternals.join('|')})`,
         'g',

--- a/packages/angular/build/src/tools/vite/plugins/id-prefix-plugin_spec.ts
+++ b/packages/angular/build/src/tools/vite/plugins/id-prefix-plugin_spec.ts
@@ -6,34 +6,16 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { createRemoveIdPrefixPlugin } from './id-prefix-plugin';
+import { createTransformer } from './id-prefix-plugin';
 
-/**
- * Runs the plugin's `configResolved` hook against a minimal fake resolved
- * configuration and returns the transform function of the plugin it registers.
- */
-function getTransform(externals: string[], base: string): (code: string) => string {
-  const plugin = createRemoveIdPrefixPlugin(externals);
-  const resolvedConfig = {
-    base,
-    plugins: [] as { name: string; transform?: (code: string) => string }[],
-  };
-
-  (plugin.configResolved as (config: unknown) => void)(resolvedConfig);
-
-  const pushedPlugin = resolvedConfig.plugins[0];
-  expect(pushedPlugin?.transform).toBeDefined();
-
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return pushedPlugin.transform!;
-}
-
-describe('createRemoveIdPrefixPlugin', () => {
+describe('createTransformer', () => {
   it('should strip the prefix from every occurrence on a single (minified) line', () => {
-    const transform = getTransform(
-      ['@angular/common', '@angular/common/http', '@angular/core', '@angular/router'],
-      '/',
-    );
+    const transform = createTransformer('/', [
+      '@angular/common',
+      '@angular/common/http',
+      '@angular/core',
+      '@angular/router',
+    ]);
 
     const minified =
       'import{a}from"/@id/@angular/common/http";' +
@@ -48,7 +30,7 @@ describe('createRemoveIdPrefixPlugin', () => {
   });
 
   it('should strip the prefix from an external with a deep import path', () => {
-    const transform = getTransform(['@angular/common'], '/');
+    const transform = createTransformer('/', ['@angular/common']);
 
     expect(transform('import{h}from"/@id/@angular/common/http";')).toBe(
       'import{h}from"@angular/common/http";',
@@ -56,7 +38,7 @@ describe('createRemoveIdPrefixPlugin', () => {
   });
 
   it('should strip the prefix when a non-root base is configured', () => {
-    const transform = getTransform(['@angular/router'], '/app/');
+    const transform = createTransformer('/app/', ['@angular/router']);
 
     expect(transform('import{r}from"/app/@id/@angular/router";')).toBe(
       'import{r}from"@angular/router";',
@@ -64,7 +46,7 @@ describe('createRemoveIdPrefixPlugin', () => {
   });
 
   it('should strip the prefix from multi-line (unminified) code', () => {
-    const transform = getTransform(['@angular/common', '@angular/router'], '/');
+    const transform = createTransformer('/', ['@angular/common', '@angular/router']);
 
     const code =
       'import { CommonModule } from "/@id/@angular/common";\n' +
@@ -77,18 +59,9 @@ describe('createRemoveIdPrefixPlugin', () => {
   });
 
   it('should not modify imports that are not configured externals', () => {
-    const transform = getTransform(['@angular/router'], '/');
+    const transform = createTransformer('/', ['@angular/router']);
 
     const code = 'import{x}from"/@id/some-other-package";';
     expect(transform(code)).toBe(code);
-  });
-
-  it('should not register a transform when there are no externals', () => {
-    const plugin = createRemoveIdPrefixPlugin([]);
-    const resolvedConfig = { base: '/', plugins: [] };
-
-    (plugin.configResolved as (config: unknown) => void)(resolvedConfig);
-
-    expect(resolvedConfig.plugins).toHaveSize(0);
   });
 });

--- a/packages/angular/build/src/tools/vite/plugins/id-prefix-plugin_spec.ts
+++ b/packages/angular/build/src/tools/vite/plugins/id-prefix-plugin_spec.ts
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { createRemoveIdPrefixPlugin } from './id-prefix-plugin';
+
+/**
+ * Runs the plugin's `configResolved` hook against a minimal fake resolved
+ * configuration and returns the transform function of the plugin it registers.
+ */
+function getTransform(externals: string[], base: string): (code: string) => string {
+  const plugin = createRemoveIdPrefixPlugin(externals);
+  const resolvedConfig = {
+    base,
+    plugins: [] as { name: string; transform?: (code: string) => string }[],
+  };
+
+  (plugin.configResolved as (config: unknown) => void)(resolvedConfig);
+
+  const pushedPlugin = resolvedConfig.plugins[0];
+  expect(pushedPlugin?.transform).toBeDefined();
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return pushedPlugin.transform!;
+}
+
+describe('createRemoveIdPrefixPlugin', () => {
+  it('should strip the prefix from every occurrence on a single (minified) line', () => {
+    const transform = getTransform(
+      ['@angular/common', '@angular/common/http', '@angular/core', '@angular/router'],
+      '/',
+    );
+
+    const minified =
+      'import{a}from"/@id/@angular/common/http";' +
+      'import{b}from"/@id/@angular/router";' +
+      'import{c}from"/@id/@angular/core";';
+
+    expect(transform(minified)).toBe(
+      'import{a}from"@angular/common/http";' +
+        'import{b}from"@angular/router";' +
+        'import{c}from"@angular/core";',
+    );
+  });
+
+  it('should strip the prefix from an external with a deep import path', () => {
+    const transform = getTransform(['@angular/common'], '/');
+
+    expect(transform('import{h}from"/@id/@angular/common/http";')).toBe(
+      'import{h}from"@angular/common/http";',
+    );
+  });
+
+  it('should strip the prefix when a non-root base is configured', () => {
+    const transform = getTransform(['@angular/router'], '/app/');
+
+    expect(transform('import{r}from"/app/@id/@angular/router";')).toBe(
+      'import{r}from"@angular/router";',
+    );
+  });
+
+  it('should strip the prefix from multi-line (unminified) code', () => {
+    const transform = getTransform(['@angular/common', '@angular/router'], '/');
+
+    const code =
+      'import { CommonModule } from "/@id/@angular/common";\n' +
+      'import { Router } from "/@id/@angular/router";\n';
+
+    expect(transform(code)).toBe(
+      'import { CommonModule } from "@angular/common";\n' +
+        'import { Router } from "@angular/router";\n',
+    );
+  });
+
+  it('should not modify imports that are not configured externals', () => {
+    const transform = getTransform(['@angular/router'], '/');
+
+    const code = 'import{x}from"/@id/some-other-package";';
+    expect(transform(code)).toBe(code);
+  });
+
+  it('should not register a transform when there are no externals', () => {
+    const plugin = createRemoveIdPrefixPlugin([]);
+    const resolvedConfig = { base: '/', plugins: [] };
+
+    (plugin.configResolved as (config: unknown) => void)(resolvedConfig);
+
+    expect(resolvedConfig.plugins).toHaveSize(0);
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #33524

When the dev server serves an optimized/minified build and `externalDependencies` are in
effect, the `angular-plugin-remove-id-prefix` transform strips Vite's `/@id/` prefix only from
the first external import per line. Its regex appends a greedy `(?:/.+)?` to each external
name, so on minified single-line output the first match on an external with a deep import path
(e.g. `@angular/common/http`) consumes the remainder of the line into the capture group, and
every later `/@id/` occurrence on that line is never matched. The browser then requests e.g.
`http://localhost:4200/@id/@angular/router`, receives the `index.html` fallback, and module
loading fails:

```
Error: Unsupported Content-Type "text/html" loading http://localhost:4200/@id/@angular/router
Modules must be served with a valid MIME type like application/javascript.
```

Deterministic repro of the defect:

```js
const escapeRegexSpecialChars = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
const externals = ['@angular/common', '@angular/common/http', '@angular/core', '@angular/router'].sort();
const escaped = externals.map((e) => escapeRegexSpecialChars(e) + '(?:/.+)?');
const reg = new RegExp('/@id/(' + escaped.join('|') + ')', 'g');

const code =
  'import{a}from"/@id/@angular/common/http";import{b}from"/@id/@angular/router";import{c}from"/@id/@angular/core";';

console.log(code.replace(reg, (_, name) => name));
// Actual:   import{a}from"@angular/common/http";import{b}from"/@id/@angular/router";import{c}from"/@id/@angular/core";
// Expected: import{a}from"@angular/common/http";import{b}from"@angular/router";import{c}from"@angular/core";
```

## What is the new behavior?

The path suffix in the regex is bounded (`(?:/[^'"\`\s]+)?`) so a match can never extend past
the end of an import specifier string literal. Every `/@id/` occurrence is stripped — including
on minified single-line bundles — while deep import paths are still fully captured and
multi-line (unminified) behavior is unchanged.

A regression spec (`id-prefix-plugin_spec.ts`) is added covering: the minified single-line
case, deep import paths, non-root `base`, multi-line code, non-external `@id/` imports
(untouched), and the empty-externals no-op. The new spec fails against the previous
implementation and passes with this change (`pnpm bazel test //packages/angular/build:test`).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The fix was also verified end-to-end against `@angular/build` 21.2.0 by patching
`node_modules` in a real application that previously failed to bootstrap under an optimized
`ng serve` — it starts correctly with the bounded regex.

#30642 reported the same symptom earlier and was closed as not reproducible — a default
(unoptimized) `ng serve` never triggers the bug; `optimization` must be enabled so the output
is single-line.
