### PR TITLE
fix(@angular/build): fallback to build target preserveSymlinks option  in karma runner

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/karma/executor.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/karma/executor.ts
@@ -91,7 +91,7 @@ export class KarmaExecutor implements TestExecutor {
       progress: unitTestOptions.buildProgress ?? buildTargetOptions.progress,
       watch: unitTestOptions.watch,
       poll: buildTargetOptions.poll,
-      preserveSymlinks: unitTestOptions.preserveSymlinks,
+      preserveSymlinks: unitTestOptions.preserveSymlinks ?? buildTargetOptions.preserveSymlinks,
       browsers: unitTestOptions.browsers?.join(','),
       codeCoverage: unitTestOptions.coverage.enabled,
       codeCoverageExclude: unitTestOptions.coverage.exclude,


### PR DESCRIPTION


When running unit tests with karma, the `preserveSymlinks` option was only read from the unit test builder options which is always undefined, as `unitTestOptions.preserveSymlinks` is only configured for non standalone runners.
