### PR TITLE
fix(@angular-devkit/build-angular): update http-proxy-middleware to 3.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "fast-glob": "3.3.3",
     "globals": "17.3.0",
     "http-proxy": "^1.18.1",
-    "http-proxy-middleware": "3.0.5",
+    "http-proxy-middleware": "3.0.7",
     "husky": "9.1.7",
     "jasmine": "~5.13.0",
     "jasmine-core": "~5.13.0",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -29,7 +29,7 @@
     "copy-webpack-plugin": "14.0.0",
     "css-loader": "7.1.3",
     "esbuild-wasm": "0.28.1",
-    "http-proxy-middleware": "3.0.5",
+    "http-proxy-middleware": "3.0.7",
     "istanbul-lib-instrument": "6.0.3",
     "jsonc-parser": "3.3.1",
     "karma-source-map-support": "1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,8 +210,8 @@ importers:
         specifier: ^1.18.1
         version: 1.18.1(debug@4.4.3)
       http-proxy-middleware:
-        specifier: 3.0.5
-        version: 3.0.5
+        specifier: 3.0.7
+        version: 3.0.7
       husky:
         specifier: 9.1.7
         version: 9.1.7
@@ -639,8 +639,8 @@ importers:
         specifier: 0.28.1
         version: 0.28.1
       http-proxy-middleware:
-        specifier: 3.0.5
-        version: 3.0.5
+        specifier: 3.0.7
+        version: 3.0.7
       istanbul-lib-instrument:
         specifier: 6.0.3
         version: 6.0.3
@@ -6443,9 +6443,9 @@ packages:
       '@types/express':
         optional: true
 
-  http-proxy-middleware@3.0.5:
-    resolution: {integrity: sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+  http-proxy-middleware@3.0.7:
+    resolution: {integrity: sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==}
+    engines: {node: ^14.18.0 || ^16.10.0 || >=18.0.0}
 
   http-proxy@1.18.1:
     resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
@@ -16263,7 +16263,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  http-proxy-middleware@3.0.5:
+  http-proxy-middleware@3.0.7:
     dependencies:
       '@types/http-proxy': 1.17.17
       debug: 4.4.3(supports-color@10.2.2)


### PR DESCRIPTION
This updates http-proxy-middleware to version 3.0.7 to address a security vulnerability.

CVE-2026-55603.

Fixes #33534