### PR TITLE
fix(@angular-devkit/build-angular): update http-proxy-middleware to 3.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "fast-glob": "3.3.3",
     "globals": "16.3.0",
     "http-proxy": "^1.18.1",
-    "http-proxy-middleware": "3.0.5",
+    "http-proxy-middleware": "3.0.7",
     "husky": "9.1.7",
     "jasmine": "~5.9.0",
     "jasmine-core": "~5.9.0",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -30,7 +30,7 @@
     "css-loader": "7.1.2",
     "esbuild-wasm": "0.28.1",
     "fast-glob": "3.3.3",
-    "http-proxy-middleware": "3.0.5",
+    "http-proxy-middleware": "3.0.7",
     "istanbul-lib-instrument": "6.0.3",
     "jsonc-parser": "3.3.1",
     "karma-source-map-support": "1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,8 +212,8 @@ importers:
         specifier: ^1.18.1
         version: 1.18.1(debug@4.4.3)
       http-proxy-middleware:
-        specifier: 3.0.5
-        version: 3.0.5
+        specifier: 3.0.7
+        version: 3.0.7
       husky:
         specifier: 9.1.7
         version: 9.1.7
@@ -660,8 +660,8 @@ importers:
         specifier: 3.3.3
         version: 3.3.3
       http-proxy-middleware:
-        specifier: 3.0.5
-        version: 3.0.5
+        specifier: 3.0.7
+        version: 3.0.7
       istanbul-lib-instrument:
         specifier: 6.0.3
         version: 6.0.3
@@ -6248,9 +6248,9 @@ packages:
       '@types/express':
         optional: true
 
-  http-proxy-middleware@3.0.5:
-    resolution: {integrity: sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+  http-proxy-middleware@3.0.7:
+    resolution: {integrity: sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==}
+    engines: {node: ^14.18.0 || ^16.10.0 || >=18.0.0}
 
   http-proxy@1.18.1:
     resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
@@ -15981,7 +15981,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  http-proxy-middleware@3.0.5:
+  http-proxy-middleware@3.0.7:
     dependencies:
       '@types/http-proxy': 1.17.16
       debug: 4.4.3(supports-color@10.2.2)


### PR DESCRIPTION
This updates http-proxy-middleware to version 3.0.7 to address a security vulnerability.

CVE-2026-55603.

Fixes #33534