### PR TITLE
fix(@angular/cli): support resolving subproject dependencies in pnpm workspaces

### DIFF
--- a/packages/angular/cli/src/package-managers/parsers.ts
+++ b/packages/angular/cli/src/package-managers/parsers.ts
@@ -79,6 +79,13 @@ interface NpmListDependency {
  * @param logger An optional logger instance.
  * @returns A map of package names to their installed package details.
  */
+interface NpmListProject {
+  name?: string;
+  dependencies?: Record<string, NpmListDependency>;
+  devDependencies?: Record<string, NpmListDependency>;
+  unsavedDependencies?: Record<string, NpmListDependency>;
+}
+
 export function parseNpmLikeDependencies(
   stdout: string,
   logger?: Logger,
@@ -94,26 +101,55 @@ export function parseNpmLikeDependencies(
     return dependencies;
   }
 
-  let data = JSON.parse(stdout);
+  const data = JSON.parse(stdout);
+  const workspacePackageName = options?.workspacePackageName;
+
+  let rootProject: NpmListProject | undefined;
+  let subProject: NpmListProject | undefined;
+
   if (Array.isArray(data)) {
-    // pnpm returns an array of projects.
-    data = data[0];
+    rootProject = data[0];
+    if (workspacePackageName) {
+      subProject = data.find(
+        (project) => (project as NpmListProject | undefined)?.name === workspacePackageName,
+      );
+    }
+  } else {
+    rootProject = data;
   }
 
-  const dependencyMaps = [data.dependencies, data.devDependencies, data.unsavedDependencies].filter(
-    (d) => !!d,
-  );
-
-  if (dependencyMaps.length === 0) {
-    logger?.debug('  `dependencies` property not found. No dependencies found.');
-
+  if (!rootProject || typeof rootProject !== 'object') {
     return dependencies;
   }
 
-  const workspacePackageName = options?.workspacePackageName;
+  // 1. Extract subproject dependencies first to prioritize them
+  if (subProject) {
+    const subprojectMaps = [
+      subProject.dependencies,
+      subProject.devDependencies,
+      subProject.unsavedDependencies,
+    ].filter((d) => !!d) as Record<string, NpmListDependency>[];
 
-  if (workspacePackageName) {
-    for (const dependencyMap of dependencyMaps) {
+    for (const subprojectMap of subprojectMaps) {
+      for (const [name, info] of Object.entries(subprojectMap)) {
+        if (info && typeof info === 'object' && info.version) {
+          dependencies.set(name, {
+            name,
+            version: info.version,
+            path: info.path,
+          });
+        }
+      }
+    }
+  } else if (workspacePackageName) {
+    // Fallback to npm-like nested lookup inside the root project
+    const rootDependencyMaps = [
+      rootProject.dependencies,
+      rootProject.devDependencies,
+      rootProject.unsavedDependencies,
+    ].filter((d) => !!d) as Record<string, NpmListDependency>[];
+
+    for (const dependencyMap of rootDependencyMaps) {
       const info = dependencyMap[workspacePackageName];
       if (info && typeof info === 'object') {
         const nestedMaps = [
@@ -137,11 +173,15 @@ export function parseNpmLikeDependencies(
     }
   }
 
-  // Extract top-level dependencies (root), without overwriting subproject dependencies
-  for (const dependencyMap of dependencyMaps) {
-    for (const [name, info] of Object.entries(
-      dependencyMap as Record<string, NpmListDependency & { resolved?: string }>,
-    )) {
+  // 2. Supplement with hoisted/root dependencies (without overwriting subproject dependencies)
+  const rootDependencyMaps = [
+    rootProject.dependencies,
+    rootProject.devDependencies,
+    rootProject.unsavedDependencies,
+  ].filter((d) => !!d) as Record<string, NpmListDependency & { resolved?: string }>[];
+
+  for (const dependencyMap of rootDependencyMaps) {
+    for (const [name, info] of Object.entries(dependencyMap)) {
       if (!info || typeof info !== 'object') {
         continue;
       }

--- a/packages/angular/cli/src/package-managers/parsers_spec.ts
+++ b/packages/angular/cli/src/package-managers/parsers_spec.ts
@@ -64,6 +64,113 @@ describe('parsers', () => {
         path: undefined,
       });
     });
+
+    it('should parse dependencies from array when workspacePackageName matches a project', () => {
+      const stdout = JSON.stringify([
+        {
+          name: 'monorepo-root',
+          version: '1.0.0',
+          path: '/workspace',
+          dependencies: {
+            typescript: {
+              version: '5.9.3',
+            },
+          },
+        },
+        {
+          name: 'app',
+          version: '1.0.0',
+          path: '/workspace/apps/test-app',
+          dependencies: {
+            rxjs: {
+              version: '7.8.2',
+            },
+          },
+        },
+      ]);
+
+      const deps = parseNpmLikeDependencies(stdout, undefined, { workspacePackageName: 'app' });
+      expect(deps.size).toBe(2);
+      expect(deps.get('rxjs')).toEqual({ name: 'rxjs', version: '7.8.2', path: undefined });
+      expect(deps.get('typescript')).toEqual({
+        name: 'typescript',
+        version: '5.9.3',
+        path: undefined,
+      });
+    });
+
+    it('should parse dependencies from array when workspacePackageName matches the root project', () => {
+      const stdout = JSON.stringify([
+        {
+          name: 'monorepo-root',
+          version: '1.0.0',
+          path: '/workspace',
+          dependencies: {
+            typescript: {
+              version: '5.9.3',
+            },
+          },
+        },
+        {
+          name: 'other-app',
+          version: '1.0.0',
+          path: '/workspace/apps/other-app',
+          dependencies: {
+            rxjs: {
+              version: '7.8.2',
+            },
+          },
+        },
+      ]);
+
+      const deps = parseNpmLikeDependencies(stdout, undefined, {
+        workspacePackageName: 'monorepo-root',
+      });
+      expect(deps.size).toBe(1);
+      expect(deps.get('typescript')).toEqual({
+        name: 'typescript',
+        version: '5.9.3',
+        path: undefined,
+      });
+    });
+
+    it('should parse nested dependencies and supplement with hoisted root dependencies in npm workspaces', () => {
+      const stdout = JSON.stringify({
+        name: 'monorepo-root',
+        version: '1.0.0',
+        dependencies: {
+          app: {
+            version: '1.0.0',
+            resolved: 'file:apps/test-app',
+            dependencies: {
+              rxjs: {
+                version: '7.8.2',
+              },
+            },
+          },
+          typescript: {
+            version: '5.9.3',
+          },
+        },
+      });
+
+      const deps = parseNpmLikeDependencies(stdout, undefined, {
+        workspacePackageName: 'app',
+      });
+      expect(deps.size).toBe(2);
+      expect(deps.get('rxjs')).toEqual({ name: 'rxjs', version: '7.8.2', path: undefined });
+      expect(deps.get('typescript')).toEqual({
+        name: 'typescript',
+        version: '5.9.3',
+        path: undefined,
+      });
+    });
+
+    it('should return empty map and not throw on empty array or non-object json', () => {
+      expect(parseNpmLikeDependencies('[]').size).toBe(0);
+      expect(parseNpmLikeDependencies('null').size).toBe(0);
+      expect(parseNpmLikeDependencies('"not-an-object"').size).toBe(0);
+    });
   });
 
   describe('parseNpmLikeError', () => {


### PR DESCRIPTION
When running dependency listing commands (like `pnpm list --depth=0 --json`) in a workspace subproject, the package manager resolves the workspace layout and runs in the context of the workspace root, returning an array of project objects representing all workspace members.

Previously, `parseNpmLikeDependencies` blindly selected the first item in the array (`data[0]`), which corresponds to the workspace root package. Since the root package typically does not declare workspace member dependencies (like `@angular/core`), `ng update` failed with "Package X is not a dependency" errors.

This updates `parseNpmLikeDependencies` to search the array for the project matching `workspacePackageName` if it is provided. If the selected project is the workspace member itself, it bypasses the nested workspace dependency lookup block, allowing its direct dependencies to be parsed correctly.