### PR TITLE
fix(@angular/cli): revert package.json changes if installation tasks fail during update

### DIFF
--- a/packages/angular/cli/src/commands/update/cli.ts
+++ b/packages/angular/cli/src/commands/update/cli.ts
@@ -541,6 +541,14 @@ export default class UpdateCommandModule extends CommandModule<UpdateCommandArgs
       return 1;
     }
 
+    const packageJsonPath = path.join(this.context.root, 'package.json');
+    let originalPackageJsonContent: string | undefined;
+    try {
+      originalPackageJsonContent = await fs.readFile(packageJsonPath, 'utf8');
+    } catch {
+      // Ignore backup errors.
+    }
+
     try {
       await applyUpdatePlan(this.context.root, plan, logger);
     } catch (error) {
@@ -596,6 +604,16 @@ export default class UpdateCommandModule extends CommandModule<UpdateCommandArgs
         Module._pathCache = Object.create(null);
       }
     } catch (e) {
+      if (originalPackageJsonContent !== undefined) {
+        try {
+          await fs.writeFile(packageJsonPath, originalPackageJsonContent, 'utf8');
+          logger.info('Restored package.json to its original state.');
+        } catch (restoreError) {
+          assertIsError(restoreError);
+          logger.error(`Failed to restore package.json: ${restoreError.message}`);
+        }
+      }
+
       if (e instanceof CommandError) {
         return 1;
       }

--- a/packages/angular/cli/src/commands/update/cli.ts
+++ b/packages/angular/cli/src/commands/update/cli.ts
@@ -567,6 +567,11 @@ export default class UpdateCommandModule extends CommandModule<UpdateCommandArgs
     const tasks = new Listr([
       {
         title: 'Cleaning node modules directory',
+        skip() {
+          return packageManager.name !== 'npm'
+            ? 'Cleaning not required for this package manager.'
+            : false;
+        },
         async task(_, task) {
           try {
             await fs.rm(path.join(commandRoot, 'node_modules'), {


### PR DESCRIPTION
When running the update command, if package manager installation fails (e.g., due to peer dependency conflicts or network issues), the project's package.json is left in an updated state but node_modules is missing or inconsistent.

To prevent leaving the workspace in a broken state, backup the original package.json before applying the update plan, and restore it from the backup if the installation tasks throw an error.

Closes #22162