### PR TITLE
fix(@schematics/angular): remove unused spec tsconfig outDir

### DIFF
--- a/packages/schematics/angular/application/files/common-files/tsconfig.spec.json.template
+++ b/packages/schematics/angular/application/files/common-files/tsconfig.spec.json.template
@@ -3,7 +3,6 @@
 {
   "extends": "<%= relativePathToWorkspaceRoot %>/tsconfig.json",
   "compilerOptions": {
-    "outDir": "<%= relativePathToWorkspaceRoot %>/out-tsc/spec",
     "types": [
       "<%= testRunner === 'vitest' ? 'vitest/globals' : 'jasmine' %>"
     ]

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -108,7 +108,11 @@ describe('Application Schematic', () => {
   it('should set the right paths in the tsconfig.spec.json', async () => {
     const tree = await schematicRunner.runSchematic('application', defaultOptions, workspaceTree);
 
-    const { extends: _extends } = readJsonFile(tree, '/projects/foo/tsconfig.spec.json');
+    const { compilerOptions, extends: _extends } = readJsonFile(
+      tree,
+      '/projects/foo/tsconfig.spec.json',
+    );
+    expect(compilerOptions.outDir).toBeUndefined();
     expect(_extends).toBe('../../tsconfig.json');
   });
 


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

New applications generated by the application schematic include an `outDir` entry in `tsconfig.spec.json`. This can cause a TypeScript configuration lint warning for projects generated by `ng new`.

Issue Number: https://github.com/angular/angular-cli/issues/33360

## What is the new behavior?

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Similar with PR #33366, but remove from `tsconfig.spec.json`