### PR TITLE
docs: mention Vitest instead of Karma in README template of schematic…

### DIFF
--- a/packages/schematics/angular/library/files/README.md.template
+++ b/packages/schematics/angular/library/files/README.md.template
@@ -43,7 +43,7 @@ Once the project is built, you can publish your library by following these steps
 
 ## Running unit tests
 
-To execute unit tests with the [Karma](https://karma-runner.github.io) test runner, use the following command:
+To execute unit tests with the [Vitest](https://vitest.dev/) test runner, use the following command:
 
 ```bash
 ng test


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfils the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Since version Angular 21, Vitest is the default test runner.

Issue Number: N/A

## What is the new behavior?

Mention Vitest instead of Karma.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
Found a similar change in #31916, but it seems this part in the schematic/library files was forgotten to change as well.