### PR TITLE
build: update BASELINE_DATE to 2026-05-07

### DIFF
--- a/constants.bzl
+++ b/constants.bzl
@@ -13,7 +13,7 @@ NG_PACKAGR_PEER_DEP = "^22.0.0"
 # default browser set used to determine what downleveling is necessary.
 #
 # See: https://web.dev/baseline
-BASELINE_DATE = "2025-10-20"
+BASELINE_DATE = "2026-05-07"
 
 SNAPSHOT_REPOS = {
     "@angular/cli": "angular/cli-builds",


### PR DESCRIPTION
Update baseline date.
Was already present on the main branch but missed the RC branch for 22.0.x.