### PR TITLE
fix(@angular/cli): batch Prettier invocations during migration formatting

### DIFF
--- a/packages/angular/cli/src/utilities/prettier.ts
+++ b/packages/angular/cli/src/utilities/prettier.ts
@@ -16,6 +16,50 @@ const execFileAsync = promisify(execFile);
 let prettierCliPath: string | null | undefined;
 
 /**
+ * Conservative upper bound for the length of a single spawned command line.
+ * Windows caps `CreateProcess` command lines at 32,767 characters; POSIX `ARG_MAX`
+ * is larger. Staying below this budget avoids `E2BIG`/`ENAMETOOLONG` when a large
+ * migration changes thousands of files.
+ */
+const MAX_COMMAND_LINE_LENGTH = 32_000;
+
+/**
+ * Groups files into batches whose combined argument length (including `baseLength`
+ * for the fixed leading arguments) stays under `maxLength`. A file longer on its own
+ * than the budget still gets its own batch, so files are never dropped.
+ */
+export function batchFilesByArgumentLength(
+  files: Iterable<string>,
+  baseLength: number,
+  maxLength: number,
+): string[][] {
+  const batches: string[][] = [];
+  let batch: string[] = [];
+  let length = baseLength;
+
+  for (const file of files) {
+    // Account for the separator between arguments, plus the surrounding quotes the OS
+    // adds to paths containing spaces when they are spawned.
+    const fileLength = file.length + (file.includes(' ') ? 3 : 1);
+
+    if (batch.length > 0 && length + fileLength > maxLength) {
+      batches.push(batch);
+      batch = [];
+      length = baseLength;
+    }
+
+    batch.push(file);
+    length += fileLength;
+  }
+
+  if (batch.length > 0) {
+    batches.push(batch);
+  }
+
+  return batches;
+}
+
+/**
  * Formats files using Prettier.
  * @param cwd The current working directory.
  * @param files The files to format.
@@ -42,12 +86,37 @@ export async function formatFiles(cwd: string, files: Set<string>): Promise<void
     return;
   }
 
-  await execFileAsync(
-    process.execPath,
-    [prettierCliPath, '--write', '--no-error-on-unmatched-pattern', '--ignore-unknown', ...files],
-    {
-      cwd,
-      shell: false,
-    },
+  const baseArgs = [
+    prettierCliPath,
+    '--write',
+    '--no-error-on-unmatched-pattern',
+    '--ignore-unknown',
+  ];
+  // `process.execPath` is spawned as the first argument and also counts toward the
+  // command-line limit; it and `prettierCliPath` are absolute paths that may contain
+  // spaces and therefore be quoted.
+  const baseLength = [process.execPath, ...baseArgs].reduce(
+    (total, arg) => total + arg.length + (arg.includes(' ') ? 3 : 1),
+    0,
   );
+
+  // Spawn Prettier once per batch so repositories with many changed files do not
+  // overflow the OS command-line length limit. A failure in one batch (e.g. a file
+  // Prettier cannot parse) must not stop the remaining batches, matching the previous
+  // single-invocation behavior, so errors are collected and reported together.
+  const errors: string[] = [];
+  for (const batch of batchFilesByArgumentLength(files, baseLength, MAX_COMMAND_LINE_LENGTH)) {
+    try {
+      await execFileAsync(process.execPath, [...baseArgs, ...batch], {
+        cwd,
+        shell: false,
+      });
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(errors.join('\n'));
+  }
 }

--- a/packages/angular/cli/src/utilities/prettier_spec.ts
+++ b/packages/angular/cli/src/utilities/prettier_spec.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { batchFilesByArgumentLength } from './prettier';
+
+describe('batchFilesByArgumentLength', () => {
+  it('returns no batches when there are no files', () => {
+    expect(batchFilesByArgumentLength([], 10, 100)).toEqual([]);
+  });
+
+  it('keeps files that fit the budget in a single batch', () => {
+    const files = ['a.ts', 'b.ts', 'c.ts'];
+
+    expect(batchFilesByArgumentLength(files, 0, 1000)).toEqual([files]);
+  });
+
+  it('splits files into multiple batches when the budget is exceeded', () => {
+    // Each file contributes `length + 1` => 5; a budget of 12 fits two files per batch.
+    expect(batchFilesByArgumentLength(['aaaa', 'bbbb', 'cccc', 'dddd'], 0, 12)).toEqual([
+      ['aaaa', 'bbbb'],
+      ['cccc', 'dddd'],
+    ]);
+  });
+
+  it('reserves the base argument length in every batch', () => {
+    // base 8, each file => 5: 8 + 5 fits, 8 + 5 + 5 > 15 so the second file starts a new batch.
+    expect(batchFilesByArgumentLength(['aaaa', 'bbbb'], 8, 15)).toEqual([['aaaa'], ['bbbb']]);
+  });
+
+  it('reserves extra length for files that contain spaces (quoted when spawned)', () => {
+    // 'a a' contains a space => length + 3 = 6; the others => length + 1 = 2. Budget 10:
+    // 6 + 2 + 2 fits, adding the fourth file (12) exceeds it.
+    expect(batchFilesByArgumentLength(['a a', 'b', 'c', 'd'], 0, 10)).toEqual([
+      ['a a', 'b', 'c'],
+      ['d'],
+    ]);
+  });
+
+  it('never drops a file that is longer than the budget on its own', () => {
+    const files = ['short', 'a-very-long-single-file-name-well-over-budget', 'tiny'];
+
+    const batches = batchFilesByArgumentLength(files, 0, 10);
+
+    expect(batches.flat()).toEqual(files);
+    expect(batches).toContain(['a-very-long-single-file-name-well-over-budget']);
+  });
+
+  it('keeps multi-file batches within the budget for a large file set', () => {
+    const files = Array.from({ length: 5000 }, (_, index) => `path/to/file-${index}.component.ts`);
+    const baseLength = 40;
+    const maxLength = 2000;
+
+    for (const batch of batchFilesByArgumentLength(files, baseLength, maxLength)) {
+      const length = batch.reduce((total, file) => total + file.length + 1, baseLength);
+
+      // A batch may exceed the budget only when it is a single unavoidable oversized file.
+      if (batch.length > 1) {
+        expect(length).toBeLessThanOrEqual(maxLength);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Fixes #33597

## Problem

`formatFiles` (`packages/angular/cli/src/utilities/prettier.ts`) passes **every** changed file to Prettier as a single `execFile` argument list:

```ts
await execFileAsync(
  process.execPath,
  [prettierCliPath, '--write', '--no-error-on-unmatched-pattern', '--ignore-unknown', ...files],
  { cwd, shell: false },
);
```

On large repositories (Nx monorepos, migrations touching thousands of files) the combined command line exceeds the OS limit and the spawn is rejected:

- Windows → `spawn ENAMETOOLONG` (`CreateProcess` command line capped at 32,767 chars)
- Linux / macOS → `spawn E2BIG` (`argv`+`envp` over `ARG_MAX`)

The error is caught and only logged, so `ng update` prints `WARNING: Formatting of files failed with the following error: spawn ENAMETOOLONG` and silently skips formatting — on exactly the large repos where the migration formatting step is most useful.

Reproduced on Node 26 / macOS (`ARG_MAX` 1 MiB): 25,000 changed paths ≈ 2 MB of argv → `spawn E2BIG`.

## Fix

Split the file list into batches whose combined argument length stays under a conservative cross-platform budget (`32_000`, below the Windows 32,767 limit and far below POSIX `ARG_MAX`), and invoke Prettier once per batch. A single file longer than the budget still gets its own batch, so no file is ever dropped.

The batching logic is extracted into a small pure helper (`batchFilesByArgumentLength`) so it can be unit-tested deterministically without spawning a process.

## Tests

Added `prettier_spec.ts` covering: empty input, single batch, splitting when the budget is exceeded, reserving the base-argument length in every batch, never dropping an oversized file, and keeping multi-file batches within budget for a 5,000-file set.

## Notes

Related but different (already-fixed) code path: angular/angular#57978 (`ng build` `spawn ENAMETOOLONG` from many uncommitted files, in `compiler-cli`).