### PR TITLE
fix(@angular/build): favor istanbul coverage provider when browser testing is enabled

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
@@ -102,7 +102,9 @@ function determineCoverageProvider(
       const hasIstanbul = checkInstalled('@vitest/coverage-istanbul');
       const hasV8 = checkInstalled('@vitest/coverage-v8');
 
-      if (hasIstanbul && !hasV8) {
+      // Favor istanbul when browser testing is enabled (to avoid slow CDP V8 HTTP sourcemap remapping)
+      // or when only istanbul is installed.
+      if (hasIstanbul && (browsersToCheck.length > 0 || !hasV8)) {
         determinedProvider = 'istanbul';
       } else {
         determinedProvider = 'v8';


### PR DESCRIPTION
When browser testing is enabled (`browsers` option configured), using V8 coverage in Chromium requires fetching and remapping source maps over CDP/HTTP for every script loaded in the browser window, causing multi-minute delays during report generation on large projects.

This change updates `determineCoverageProvider` to favor `@vitest/coverage-istanbul` when browser mode is active and `@vitest/coverage-istanbul` is installed in `node_modules`. Istanbul instruments code at build time, allowing instant coverage extraction from `window.__coverage__` without CDP sourcemap resolution overhead. Explicit `coverage.provider` settings in user configuration remain fully respected.

Relates to #31724