### PR TITLE
feat(@angular/cli): add support for the nub package manager

### DIFF
--- a/packages/angular/cli/lib/config/workspace-schema.json
+++ b/packages/angular/cli/lib/config/workspace-schema.json
@@ -47,7 +47,7 @@
         "packageManager": {
           "description": "Specify which package manager tool to use.",
           "type": "string",
-          "enum": ["npm", "yarn", "pnpm", "bun"]
+          "enum": ["npm", "yarn", "pnpm", "bun", "nub"]
         },
         "warnings": {
           "description": "Control CLI specific console warnings",
@@ -101,7 +101,7 @@
         "packageManager": {
           "description": "Specify which package manager tool to use.",
           "type": "string",
-          "enum": ["npm", "yarn", "pnpm", "bun"]
+          "enum": ["npm", "yarn", "pnpm", "bun", "nub"]
         },
         "warnings": {
           "description": "Control CLI specific console warnings",

--- a/packages/angular/cli/src/package-managers/package-manager-descriptor.ts
+++ b/packages/angular/cli/src/package-managers/package-manager-descriptor.ts
@@ -281,6 +281,37 @@ export const SUPPORTED_PACKAGE_MANAGERS = {
     },
     isNotFound: isKnownNotFound,
   },
+  nub: {
+    // nub is pnpm-CLI-compatible, so its descriptor mirrors pnpm's aside from
+    // the binary name and the pnpm-v9-format lockfile it writes (`nub.lock`).
+    binary: 'nub',
+    lockfiles: ['nub.lock'],
+    addCommand: 'add',
+    installCommand: ['install'],
+    forceFlag: '--force',
+    saveExactFlag: '--save-exact',
+    saveTildeFlag: '--save-tilde',
+    saveDevFlag: '--save-dev',
+    noLockfileFlag: '--no-lockfile',
+    ignoreScriptsFlag: '--ignore-scripts',
+    ignorePeerDependenciesFlag: '--strict-peer-dependencies=false',
+    configFiles: ['.npmrc'],
+    getRegistryOptions: (registry: string) => ({ args: ['--registry', registry] }),
+    versionCommand: ['--version'],
+    listDependenciesCommand: ['list', '--depth=0', '--json'],
+    getReleaseAgeConfigCommand: ['config', 'get', 'minimum-release-age'],
+    getPackageNameCommand: ['pkg', 'get', 'name'],
+    getManifestCommand: ['view', '--json'],
+    viewCommandFieldArgFormatter: (fields) => [...fields],
+    outputParsers: {
+      listDependencies: parseNpmLikeDependencies,
+      getRegistryManifest: parseNpmLikeManifest,
+      getRegistryMetadata: parseNpmLikeMetadata,
+      getError: parseNpmLikeError,
+      getReleaseAge: parsePnpmReleaseAge,
+    },
+    isNotFound: isKnownNotFound,
+  },
   bun: {
     binary: 'bun',
     lockfiles: ['bun.lockb', 'bun.lock'],
@@ -346,6 +377,7 @@ export const SUPPORTED_PACKAGE_MANAGERS = {
  */
 export const PACKAGE_MANAGER_PRECEDENCE: readonly PackageManagerName[] = [
   'pnpm',
+  'nub',
   'yarn',
   'bun',
   'npm',

--- a/packages/angular/create/src/index.ts
+++ b/packages/angular/create/src/index.ts
@@ -17,7 +17,7 @@ const hasPackageManagerArg = args.some((a) => a.startsWith('--package-manager'))
 if (!hasPackageManagerArg) {
   // Ex: yarn/1.22.18 npm/? node/v16.15.1 linux x64
   const packageManager = process.env['npm_config_user_agent']?.split('/')[0];
-  if (packageManager && ['npm', 'pnpm', 'yarn', 'bun'].includes(packageManager)) {
+  if (packageManager && ['npm', 'pnpm', 'yarn', 'bun', 'nub'].includes(packageManager)) {
     args.push('--package-manager', packageManager);
   }
 }

--- a/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
+++ b/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
@@ -45,6 +45,12 @@ const packageManagers: { [name: string]: PackageManagerProfile } = {
       installPackage: 'install',
     },
   },
+  'nub': {
+    commands: {
+      installAll: 'install',
+      installPackage: 'add',
+    },
+  },
 };
 
 export class UnknownPackageManagerException extends BaseException {

--- a/packages/angular_devkit/schematics_cli/blank/schema.json
+++ b/packages/angular_devkit/schematics_cli/blank/schema.json
@@ -15,7 +15,7 @@
     "packageManager": {
       "description": "The package manager used to install dependencies.",
       "type": "string",
-      "enum": ["npm", "yarn", "pnpm", "bun"],
+      "enum": ["npm", "yarn", "pnpm", "bun", "nub"],
       "default": "npm"
     },
     "author": {

--- a/packages/angular_devkit/schematics_cli/schematic/schema.json
+++ b/packages/angular_devkit/schematics_cli/schematic/schema.json
@@ -15,7 +15,7 @@
     "packageManager": {
       "description": "The package manager used to install dependencies.",
       "type": "string",
-      "enum": ["npm", "yarn", "pnpm", "bun"],
+      "enum": ["npm", "yarn", "pnpm", "bun", "nub"],
       "default": "npm"
     }
   },

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -132,7 +132,7 @@
     "packageManager": {
       "description": "The package manager used to install dependencies.",
       "type": "string",
-      "enum": ["npm", "yarn", "pnpm", "bun"]
+      "enum": ["npm", "yarn", "pnpm", "bun", "nub"]
     },
     "standalone": {
       "description": "Creates an application based upon the standalone API, without NgModules.",

--- a/packages/schematics/angular/workspace/schema.json
+++ b/packages/schematics/angular/workspace/schema.json
@@ -40,7 +40,7 @@
     "packageManager": {
       "description": "The package manager to use for installing dependencies.",
       "type": "string",
-      "enum": ["npm", "yarn", "pnpm", "bun"],
+      "enum": ["npm", "yarn", "pnpm", "bun", "nub"],
       "$default": {
         "$source": "packageManager"
       }


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The CLI does not recognize [nub](https://nubjs.com) as a package manager. It is rejected or silently defaulted to npm at every allowlist site: lockfile discovery ignores `nub.lock`, the schematics executor throws `UnknownPackageManagerException`, and the `packageManager` schema enums plus the `npm create @angular` user-agent allowlist exclude it.

Issue Number: N/A

## What is the new behavior?

nub is recognized wherever the other package managers are. nub is pnpm-CLI-compatible and writes a pnpm-v9-format lockfile (`nub.lock`), so its handling mirrors pnpm throughout.

- **`packages/angular/cli/src/package-managers/package-manager-descriptor.ts`** — adds a `nub` descriptor to `SUPPORTED_PACKAGE_MANAGERS`, cloned from the pnpm descriptor with `binary: 'nub'` and `lockfiles: ['nub.lock']`, and adds `nub` to `PACKAGE_MANAGER_PRECEDENCE`. Lockfile discovery (`discovery.ts`) is data-driven off the descriptor's `lockfiles`, so `nub.lock` is now detected automatically — no separate change needed there.
- **`packages/angular_devkit/schematics/tasks/package-manager/executor.ts`** — adds a `nub` entry to the executor map (`installAll: 'install'`, `installPackage: 'add'`), which previously threw `UnknownPackageManagerException`.
- **`packageManager` schema enums** — adds `"nub"` to `packages/schematics/angular/ng-new/schema.json`, `packages/schematics/angular/workspace/schema.json`, `packages/angular/cli/lib/config/workspace-schema.json` (both occurrences), and `packages/angular_devkit/schematics_cli/{schematic,blank}/schema.json`.
- **`packages/angular/create/src/index.ts`** — adds `'nub'` to the user-agent allowlist in the `npm create @angular` shim. nub's user agent is `nub/<ver> …`, which the shim parses as `nub` via `split('/')[0]`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The nub descriptor mirrors pnpm because nub implements the pnpm CLI grammar and lockfile format; no nub-specific parsing was required. A signed Google CLA is still pending on my side.
