### PR TITLE
fix(@angular/cli): update MCP devserver tool names to conform to spec regex

### DIFF
--- a/packages/angular/cli/src/commands/mcp/tools/devserver/devserver-start.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/devserver/devserver-start.ts
@@ -93,29 +93,29 @@ export const DEVSERVER_START_TOOL: McpToolDeclaration<
   typeof devserverStartToolInputSchema.shape,
   typeof devserverStartToolOutputSchema.shape
 > = declareTool({
-  name: 'devserver.start',
+  name: 'devserver_start',
   title: 'Start Development Server',
   description: `
 <Purpose>
-Starts the Angular development server ("ng serve") as a background process. Follow this up with "devserver.wait_for_build" to wait until
+Starts the Angular development server ("ng serve") as a background process. Follow this up with "devserver_wait_for_build" to wait until
 the first build completes.
 </Purpose>
 <Use Cases>
 * **Starting the Server:** Use this tool to begin serving the application. The tool will return immediately while the server runs in the
   background.
-* **Get Initial Build Logs:** Once a dev server has started, use the "devserver.wait_for_build" tool to ensure it's alive. If there are any
-  build errors, "devserver.wait_for_build" would provide them back and you can give them to the user or rely on them to propose a fix.
-* **Get Updated Build Logs:** Important: as long as a devserver is alive (i.e. "devserver.stop" wasn't called), after every time you
-  make a change to the workspace, re-run "devserver.wait_for_build" to see whether the change was successfully built and wait for the
+* **Get Initial Build Logs:** Once a dev server has started, use the "devserver_wait_for_build" tool to ensure it's alive. If there are any
+  build errors, "devserver_wait_for_build" would provide them back and you can give them to the user or rely on them to propose a fix.
+* **Get Updated Build Logs:** Important: as long as a devserver is alive (i.e. "devserver_stop" wasn't called), after every time you
+  make a change to the workspace, re-run "devserver_wait_for_build" to see whether the change was successfully built and wait for the
   devserver to be updated.
 </Use Cases>
 <Operational Notes>
 * This tool manages development servers by itself. It maintains at most a single dev server instance for each project in the monorepo.
 * This is an asynchronous operation. Subsequent commands can be ran while the server is active.
-* Use 'devserver.stop' to gracefully shut down the server and access the full log output.
+* Use 'devserver_stop' to gracefully shut down the server and access the full log output.
 * **Keeping the Server Alive**: It is often better to keep the server alive between tool calls if you expect the user to request more
   changes or run more tests, as it saves time on restarts and maintains the file watcher state. You must still call
-  'devserver.wait_for_build' after every change to see whether the change was successfully built and be sure that that app was updated.
+  'devserver_wait_for_build' after every change to see whether the change was successfully built and be sure that the app was updated.
 * **Consistent Ports**: If making multiple calls, it is recommended to reuse the port you got from the first call for subsequent ones.
 </Operational Notes>
 `,

--- a/packages/angular/cli/src/commands/mcp/tools/devserver/devserver-stop.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/devserver/devserver-stop.ts
@@ -54,11 +54,11 @@ export const DEVSERVER_STOP_TOOL: McpToolDeclaration<
   typeof devserverStopToolInputSchema.shape,
   typeof devserverStopToolOutputSchema.shape
 > = declareTool({
-  name: 'devserver.stop',
+  name: 'devserver_stop',
   title: 'Stop Development Server',
   description: `
 <Purpose>
-Stops a running Angular development server ("ng serve") that was started with the "devserver.start" tool.
+Stops a running Angular development server ("ng serve") that was started with the "devserver_start" tool.
 </Purpose>
 <Use Cases>
 * **Stopping the Server:** Use this tool to terminate a running development server and retrieve the logs.

--- a/packages/angular/cli/src/commands/mcp/tools/devserver/devserver-wait-for-build.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/devserver/devserver-wait-for-build.ts
@@ -96,22 +96,22 @@ export const DEVSERVER_WAIT_FOR_BUILD_TOOL: McpToolDeclaration<
   typeof devserverWaitForBuildToolInputSchema.shape,
   typeof devserverWaitForBuildToolOutputSchema.shape
 > = declareTool({
-  name: 'devserver.wait_for_build',
+  name: 'devserver_wait_for_build',
   title: 'Wait for Devserver Build',
   description: `
 <Purpose>
-Waits for a dev server that was started with the "devserver.start" tool to complete its build, then reports the build logs from its most
+Waits for a dev server that was started with the "devserver_start" tool to complete its build, then reports the build logs from its most
 recent build.
 </Purpose>
 <Use Cases>
-* **Waiting for a build:** As long as a devserver is alive ("devserver.start" was called for this project and "devserver.stop" wasn't
+* **Waiting for a build:** As long as a devserver is alive ("devserver_start" was called for this project and "devserver_stop" wasn't
   called yet), then if you're making a file change and want to ensure it was successfully built, call this tool instead of any other build
   tool or command. When it retuns you'll get build logs back **and** you'll know the user's devserver is up-to-date with the latest changes.
 </Use Cases>
 <Operational Notes>
-* This tool expects that a dev server was launched on the same project with the "devserver.start" tool, otherwise the tool will fail.
+* This tool expects that a dev server was launched on the same project with the "devserver_start" tool, otherwise the tool will fail.
 * This tool will block until the build is complete or the timeout is reached. If you expect a long build process, consider increasing the
-  timeout. Timeouts on initial run (right after "devserver.start" calls) or after a big change are not necessarily indicative of an error.
+  timeout. Timeouts on initial run (right after "devserver_start" calls) or after a big change are not necessarily indicative of an error.
 * If you encountered a timeout and it might be reasonable, just call this tool again.
 * If the dev server is not building, it will return quickly, with the logs from the last build.
 </Operational Notes>

--- a/packages/angular/cli/src/commands/mcp/tools/run-target/generic-target-strategy.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/run-target/generic-target-strategy.ts
@@ -34,7 +34,7 @@ export class GenericTargetStrategy implements TargetStrategy {
     if (input.targetName === 'serve' || input.options?.['watch'] === true) {
       throw new Error(
         `Watch mode execution (serve target or watch option) is not yet supported by 'run_target'. ` +
-          `Please use the legacy 'devserver.start' / 'devserver.wait_for_build' tools instead.`,
+          `Please use the legacy 'devserver_start' / 'devserver_wait_for_build' tools instead.`,
       );
     }
 

--- a/packages/angular/cli/src/commands/mcp/tools/run-target/run-target.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/run-target/run-target.ts
@@ -66,7 +66,7 @@ This is the single, unified interface for executing all project tasks natively.
   and disables watch mode to guarantee clean execution.
 * Output Paths: For official builders, successful builds return the build directory in 'outputPath' under the extensions metadata.
 * Watch mode (serve target or watch options) is NOT yet supported in this version of run_target.
-  You MUST use the legacy 'devserver.*' tools for background server lifecycles.
+  You MUST use the legacy 'devserver_*' tools for background server lifecycles.
 </Operational Notes>`,
   isReadOnly: false,
   isLocalOnly: true,


### PR DESCRIPTION
MCP tool names must adhere to the regular expression ^[a-zA-Z0-9_-]+$. This commit updates devserver.start, devserver.stop, and devserver.wait_for_build to use underscores (devserver_start, devserver_stop, devserver_wait_for_build) and updates all corresponding tool references and documentation across the MCP command package.