### PR TITLE
test: allow hyphens in hash for server routes preload links

### DIFF
--- a/packages/angular/build/src/builders/application/chunk-optimizer.ts
+++ b/packages/angular/build/src/builders/application/chunk-optimizer.ts
@@ -302,7 +302,7 @@ export async function optimizeChunks(
         minify: { mangle: false, compress: false },
         sourcemap,
         chunkFileNames: (chunkInfo) =>
-          `${chunkInfo.name.replace(/-[a-zA-Z0-9]{8}$/, '')}-[hash].js`,
+          `${chunkInfo.name.replace(/-[a-zA-Z0-9_-]{8}$/, '')}-[hash].js`,
       });
       optimizedOutput = result.output;
     } else {
@@ -324,7 +324,7 @@ export async function optimizeChunks(
         compact: true,
         sourcemap,
         chunkFileNames: (chunkInfo) =>
-          `${chunkInfo.name.replace(/-[a-zA-Z0-9]{8}$/, '')}-[hash].js`,
+          `${chunkInfo.name.replace(/-[a-zA-Z0-9_-]{8}$/, '')}-[hash].js`,
       });
       optimizedOutput = result.output;
     }

--- a/tests/e2e/tests/build/server-rendering/server-routes-preload-links.ts
+++ b/tests/e2e/tests/build/server-rendering/server-routes-preload-links.ts
@@ -137,36 +137,36 @@ const RESPONSE_EXPECTS: Record<
   }
 > = {
   '/': {
-    matches: [/<link rel="modulepreload" href="(home-[a-zA-Z0-9_]{8}\.js)">/],
+    matches: [/<link rel="modulepreload" href="(home-[a-zA-Z0-9_-]{8}\.js)">/],
     notMatches: [/ssg\-component/, /ssr/, /csr/, /cross-dep-/],
   },
   '/ssg': {
     matches: [
-      /<link rel="modulepreload" href="(ssg\.routes-[a-zA-Z0-9_]{8}\.js)">/,
-      /<link rel="modulepreload" href="(ssg-component-[a-zA-Z0-9_]{8}\.js)">/,
+      /<link rel="modulepreload" href="(ssg\.routes-[a-zA-Z0-9_-]{8}\.js)">/,
+      /<link rel="modulepreload" href="(ssg-component-[a-zA-Z0-9_-]{8}\.js)">/,
     ],
     notMatches: [/home/, /ssr/, /csr/, /ssg-one/, /ssg-two/, /cross-dep-/],
   },
   '/ssg/one': {
     matches: [
-      /<link rel="modulepreload" href="(ssg\.routes-[a-zA-Z0-9_]{8}\.js)">/,
-      /<link rel="modulepreload" href="(ssg-one-[a-zA-Z0-9_]{8}\.js)">/,
+      /<link rel="modulepreload" href="(ssg\.routes-[a-zA-Z0-9_-]{8}\.js)">/,
+      /<link rel="modulepreload" href="(ssg-one-[a-zA-Z0-9_-]{8}\.js)">/,
     ],
     notMatches: [/home/, /ssr/, /csr/, /ssg-two/, /ssg\-component/, /cross-dep-/],
   },
   '/ssg/two': {
     matches: [
-      /<link rel="modulepreload" href="(ssg\.routes-[a-zA-Z0-9_]{8}\.js)">/,
-      /<link rel="modulepreload" href="(ssg-two-[a-zA-Z0-9_]{8}\.js)">/,
+      /<link rel="modulepreload" href="(ssg\.routes-[a-zA-Z0-9_-]{8}\.js)">/,
+      /<link rel="modulepreload" href="(ssg-two-[a-zA-Z0-9_-]{8}\.js)">/,
     ],
     notMatches: [/home/, /ssr/, /csr/, /ssg-one/, /ssg\-component/, /cross-dep-/],
   },
   '/ssr': {
-    matches: [/<link rel="modulepreload" href="(ssr-[a-zA-Z0-9_]{8}\.js)">/],
+    matches: [/<link rel="modulepreload" href="(ssr-[a-zA-Z0-9_-]{8}\.js)">/],
     notMatches: [/home/, /ssg\-component/, /csr/],
   },
   '/csr': {
-    matches: [/<link rel="modulepreload" href="(csr-[a-zA-Z0-9_]{8}\.js)">/],
+    matches: [/<link rel="modulepreload" href="(csr-[a-zA-Z0-9_-]{8}\.js)">/],
     notMatches: [/home/, /ssg\-component/, /ssr/, /cross-dep-/],
   },
 };


### PR DESCRIPTION

Simplifies character class [a-zA-Z0-9_-] to [\w-] in server-routes-preload-links.ts and chunk-optimizer.ts for cleaner, more readable regular expressions.