### PR TITLE
fix(@angular/cli): enforce MCP roots in get_best_practices tool

### DIFF
--- a/packages/angular/cli/src/commands/mcp/tools/best-practices.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/best-practices.ts
@@ -20,6 +20,7 @@ import { createRequire } from 'node:module';
 import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { z } from 'zod';
 import { VERSION } from '../../../utilities/version';
+import { isAllowedWorkspacePath } from '../workspace-utils';
 import { type McpToolContext, declareTool } from './tool-registry';
 
 const bestPracticesInputSchema = z.object({
@@ -86,13 +87,24 @@ async function getBundledBestPractices(): Promise<string> {
  *
  * @param workspacePath The absolute path to the user's `angular.json` file.
  * @param logger The MCP tool context logger for reporting warnings.
+ * @param server The MCP server context, used to enforce the client's declared roots.
  * @returns A promise that resolves to an object containing the guide's content and source,
  *     or `undefined` if the guide could not be resolved.
  */
 async function getVersionSpecificBestPractices(
   workspacePath: string,
   logger: McpToolContext['logger'],
+  server: McpToolContext['server'],
 ): Promise<{ content: string; source: string } | undefined> {
+  if (server && !(await isAllowedWorkspacePath(server, workspacePath))) {
+    logger.warn(
+      `Workspace path is outside the allowed MCP roots: ${workspacePath}. ` +
+        'Falling back to the bundled guide.',
+    );
+
+    return undefined;
+  }
+
   // 1. Resolve the path to package.json
   let pkgJsonPath: string;
   try {
@@ -175,7 +187,7 @@ async function getVersionSpecificBestPractices(
  * @param context The MCP tool context, containing the logger.
  * @returns An async function that serves as the tool's executor.
  */
-function createBestPracticesHandler({ logger }: McpToolContext) {
+function createBestPracticesHandler({ logger, server }: McpToolContext) {
   let bundledBestPractices: Promise<string>;
 
   return async (input: BestPracticesInput) => {
@@ -184,7 +196,11 @@ function createBestPracticesHandler({ logger }: McpToolContext) {
 
     // First, try to get the version-specific guide.
     if (input.workspacePath) {
-      const versionSpecific = await getVersionSpecificBestPractices(input.workspacePath, logger);
+      const versionSpecific = await getVersionSpecificBestPractices(
+        input.workspacePath,
+        logger,
+        server,
+      );
       if (versionSpecific) {
         content = versionSpecific.content;
         source = versionSpecific.source;

--- a/packages/angular/cli/src/commands/mcp/tools/best-practices.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/best-practices.ts
@@ -97,15 +97,9 @@ async function getVersionSpecificBestPractices(
   server: McpToolContext['server'],
 ): Promise<{ content: string; source: string } | undefined> {
   if (server) {
+    let isAllowed: boolean;
     try {
-      if (!(await isAllowedWorkspacePath(server, workspacePath))) {
-        logger.warn(
-          `Workspace path is outside the allowed MCP roots: ${workspacePath}. ` +
-            'Falling back to the bundled guide.',
-        );
-
-        return undefined;
-      }
+      isAllowed = await isAllowedWorkspacePath(server, workspacePath);
     } catch (e) {
       logger.warn(
         `Failed to verify workspace path '${workspacePath}': ` +
@@ -113,6 +107,13 @@ async function getVersionSpecificBestPractices(
       );
 
       return undefined;
+    }
+
+    if (!isAllowed) {
+      throw new Error(
+        `Workspace path is outside the allowed MCP roots: ${workspacePath}. ` +
+          "You can use 'list_projects' to find available workspaces.",
+      );
     }
   }
 

--- a/packages/angular/cli/src/commands/mcp/tools/best-practices.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/best-practices.ts
@@ -96,13 +96,24 @@ async function getVersionSpecificBestPractices(
   logger: McpToolContext['logger'],
   server: McpToolContext['server'],
 ): Promise<{ content: string; source: string } | undefined> {
-  if (server && !(await isAllowedWorkspacePath(server, workspacePath))) {
-    logger.warn(
-      `Workspace path is outside the allowed MCP roots: ${workspacePath}. ` +
-        'Falling back to the bundled guide.',
-    );
+  if (server) {
+    try {
+      if (!(await isAllowedWorkspacePath(server, workspacePath))) {
+        logger.warn(
+          `Workspace path is outside the allowed MCP roots: ${workspacePath}. ` +
+            'Falling back to the bundled guide.',
+        );
 
-    return undefined;
+        return undefined;
+      }
+    } catch (e) {
+      logger.warn(
+        `Failed to verify workspace path '${workspacePath}': ` +
+          `${e instanceof Error ? e.message : e}. Falling back to the bundled guide.`,
+      );
+
+      return undefined;
+    }
   }
 
   // 1. Resolve the path to package.json

--- a/packages/angular/cli/src/commands/mcp/workspace-utils.ts
+++ b/packages/angular/cli/src/commands/mcp/workspace-utils.ts
@@ -110,7 +110,7 @@ async function getAllowedWorkspaceRoots(server: McpToolContext['server']): Promi
     .filter((root): root is string => root !== null);
 }
 
-async function isAllowedWorkspacePath(
+export async function isAllowedWorkspacePath(
   server: McpToolContext['server'],
   workspacePath: string,
 ): Promise<boolean> {


### PR DESCRIPTION
\`getVersionSpecificBestPractices()\` resolves an npm package (and reads a file path declared in that package's \`package.json\`) starting from a caller-supplied \`workspacePath\`, without checking it against the client's declared MCP roots. Every other workspace-path-consuming MCP tool (\`run_target\`, \`devserver_start\`/\`stop\`/\`wait_for_build\`) validates this through \`resolveWorkspaceAndProject()\`'s \`isAllowedWorkspacePath()\` check; this tool never did.

Exports \`isAllowedWorkspacePath()\` from \`workspace-utils.ts\` and calls it in \`getVersionSpecificBestPractices()\` before resolving anything, falling back to the bundled guide when the path is outside the allowed roots, matching this file's existing fallback behavior for every other failure case in the function.