### PR TITLE
fix(@angular/cli): declare devserver_start/stop as isReadOnly:false

### DIFF
--- a/packages/angular/cli/src/commands/mcp/tools/devserver/devserver-start.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/devserver/devserver-start.ts
@@ -119,7 +119,7 @@ the first build completes.
 * **Consistent Ports**: If making multiple calls, it is recommended to reuse the port you got from the first call for subsequent ones.
 </Operational Notes>
 `,
-  isReadOnly: true,
+  isReadOnly: false,
   isLocalOnly: true,
   inputSchema: devserverStartToolInputSchema.shape,
   outputSchema: devserverStartToolOutputSchema.shape,

--- a/packages/angular/cli/src/commands/mcp/tools/devserver/devserver-stop.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/devserver/devserver-stop.ts
@@ -69,7 +69,7 @@ Stops a running Angular development server ("ng serve") that was started with th
   time after this is called. However note that this is not a blocker for starting a new devserver.
 </Operational Notes>
 `,
-  isReadOnly: true,
+  isReadOnly: false,
   isLocalOnly: true,
   inputSchema: devserverStopToolInputSchema.shape,
   outputSchema: devserverStopToolOutputSchema.shape,


### PR DESCRIPTION
## details
Reported via OSS VRP (Issue 539488941).

devserver_start and devserver_stop are declared isReadOnly:true, so they remain registered when the server is started with --read-only, and MCP host clients that use the readOnlyHint annotation to auto-approve tool calls without a confirmation prompt will call them without asking the user.

devserver_start spawns a background ng serve child process and binds a network port. devserver_stop sends SIGTERM to that process. Neither is a read-only operation.

devserver_wait_for_build only polls the status and logs of an already-running server, so it correctly stays isReadOnly:true and is unchanged here.

run_target.ts already declares isReadOnly:false for the same reason (it can trigger builds/tests), so this aligns the two devserver lifecycle tools with the existing pattern in the same module.