### PR TITLE
fix(@angular/cli): serialize configuration as a single argv token in run_target strategies

### DIFF
--- a/packages/angular/cli/src/commands/mcp/tools/run-target/build-target-strategy.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/run-target/build-target-strategy.ts
@@ -29,7 +29,7 @@ export class BuildTargetStrategy implements TargetStrategy {
   ): Promise<RunTargetOutput> {
     const args = ['build', input.projectName];
     if (input.configuration) {
-      args.push('-c', input.configuration);
+      args.push(`--configuration=${input.configuration}`);
     }
 
     args.push(...serializeOptions(input.options));

--- a/packages/angular/cli/src/commands/mcp/tools/run-target/generic-target-strategy.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/run-target/generic-target-strategy.ts
@@ -46,7 +46,7 @@ export class GenericTargetStrategy implements TargetStrategy {
     }
 
     if (input.configuration) {
-      args.push('-c', input.configuration);
+      args.push(`--configuration=${input.configuration}`);
     }
 
     let options = input.options;

--- a/packages/angular/cli/src/commands/mcp/tools/run-target/run-target_spec.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/run-target/run-target_spec.ts
@@ -42,7 +42,7 @@ describe('Run Target Tool', () => {
     mockContext.workspace.extensions['defaultProject'] = 'my-app';
     await runTarget({ target: 'build', configuration: 'production' }, mockContext);
     expect(mockHost.executeNgCommand).toHaveBeenCalledWith(
-      ['build', 'my-app', '-c', 'production'],
+      ['build', 'my-app', '--configuration=production'],
       {
         cwd: '/test',
       },
@@ -53,7 +53,7 @@ describe('Run Target Tool', () => {
     mockContext.workspace.extensions['defaultProject'] = 'my-app';
     await runTarget({ target: 'storybook', configuration: 'docs' }, mockContext);
     expect(mockHost.executeNgCommand).toHaveBeenCalledWith(
-      ['run', 'my-app:storybook', '-c', 'docs'],
+      ['run', 'my-app:storybook', '--configuration=docs'],
       { cwd: '/test' },
     );
   });

--- a/packages/angular/cli/src/commands/mcp/tools/run-target/unit-test-strategy.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/run-target/unit-test-strategy.ts
@@ -28,7 +28,7 @@ export class UnitTestTargetStrategy implements TargetStrategy {
   ): Promise<RunTargetOutput> {
     const args = ['test', input.projectName];
     if (input.configuration) {
-      args.push('-c', input.configuration);
+      args.push(`--configuration=${input.configuration}`);
     }
 
     const builder = input.targetDefinition?.builder;

--- a/packages/angular/cli/src/commands/mcp/tools/run-target/unit-test-strategy_spec.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/run-target/unit-test-strategy_spec.ts
@@ -65,7 +65,15 @@ describe('UnitTestTargetStrategy', () => {
       );
 
       expect(mockHost.executeNgCommand).toHaveBeenCalledWith(
-        ['test', 'my-app', '--configuration=ci', '--browsers', 'ChromeHeadless', '--watch', 'false'],
+        [
+          'test',
+          'my-app',
+          '--configuration=ci',
+          '--browsers',
+          'ChromeHeadless',
+          '--watch',
+          'false',
+        ],
         { cwd: '/test' },
       );
     });

--- a/packages/angular/cli/src/commands/mcp/tools/run-target/unit-test-strategy_spec.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/run-target/unit-test-strategy_spec.ts
@@ -65,7 +65,7 @@ describe('UnitTestTargetStrategy', () => {
       );
 
       expect(mockHost.executeNgCommand).toHaveBeenCalledWith(
-        ['test', 'my-app', '-c', 'ci', '--browsers', 'ChromeHeadless', '--watch', 'false'],
+        ['test', 'my-app', '--configuration=ci', '--browsers', 'ChromeHeadless', '--watch', 'false'],
         { cwd: '/test' },
       );
     });


### PR DESCRIPTION
build-target-strategy.ts, generic-target-strategy.ts, and unit-test-strategy.ts all pushed the configuration value as a separate argv element after '-c'. Since the ng CLI's argument parser does not consume a following token as the value of a string option when that token itself starts with a dash, a configuration value crafted to look like a flag (e.g. "--outputPath=...") is instead parsed as an independent, legitimately-declared option of the target's builder, silently overriding it.

Serialize configuration as a single '--configuration=value' token, matching the format serializeOptions() already uses for every other option, which is not affected by this because the value is bound to the key within one argv element.

Updated the two existing spec assertions that checked the old argv shape.