### PR TITLE
fix(@angular/build): escape hostname in host-validation 403 error page

### DIFF
--- a/packages/angular/build/src/tools/vite/middlewares/host-check-middleware.ts
+++ b/packages/angular/build/src/tools/vite/middlewares/host-check-middleware.ts
@@ -42,7 +42,17 @@ export function patchHostValidationMiddleware(middlewares: Connect.Server): void
   };
 }
 
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 function html403(hostname: string): string {
+  const safeHostname = escapeHtml(hostname);
+
   return `<!doctype html>
 <html>
   <head>
@@ -61,12 +71,12 @@ function html403(hostname: string): string {
   </head>
   <body>
     <main>
-      <h1>Blocked request. This host ("${hostname}") is not allowed.</h1>
+      <h1>Blocked request. This host ("${safeHostname}") is not allowed.</h1>
       <p>To allow this host, add it to <code>allowedHosts</code> under the <code>serve</code> target in <code>angular.json</code>.</p>
       <pre><code>{
   "serve": {
     "options": {
-      "allowedHosts": ["${hostname}"]
+      "allowedHosts": ["${safeHostname}"]
     }
   }
 }</code></pre>


### PR DESCRIPTION
## Problem

The `html403()` function in `host-check-middleware.ts` interpolates `req.headers.host` directly into an HTML response without entity encoding:

```typescript
const hostname = req.headers.host?.toLowerCase().split(':')[0] ?? '';
res.end(html403(hostname));
// ...
`<h1>Blocked request. This host ("${hostname}") is not allowed.</h1>`
```

The response is served with `Content-Type: text/html`. A raw HTTP request with HTML metacharacters in the `Host` header reflects unescaped content.

## Reproduction

```bash
ng serve --host 0.0.0.0 --port 4200
curl -s -H 'Host: <img src=x onerror=alert(document.domain)>' http://127.0.0.1:4200/
```

Response body contains the unescaped payload in a `text/html` response.

## Fix

Add `escapeHtml()` to encode `&`, `<`, `>`, and `"` before interpolation into the HTML template.