### PR TITLE
fix(@angular/build): add host validation to internal SSR middleware

### DIFF
--- a/packages/angular/build/src/tools/vite/middlewares/ssr-middleware.ts
+++ b/packages/angular/build/src/tools/vite/middlewares/ssr-middleware.ts
@@ -23,6 +23,9 @@ export function createAngularSsrInternalMiddleware(
 ): Connect.NextHandleFunction {
   let cachedAngularServerApp: ReturnType<typeof getOrCreateAngularServerApp> | undefined;
 
+  const { allowedHosts } = server.config.server;
+  const disableAllowedHostsCheck = allowedHosts === true;
+
   return function angularSsrMiddleware(
     req: Connect.IncomingMessage,
     res: ServerResponse,
@@ -62,6 +65,20 @@ export function createAngularSsrInternalMiddleware(
       const webReq = new Request(createWebRequestFromNodeRequest(req), {
         signal: AbortSignal.timeout(30_000),
       });
+
+      if (!disableAllowedHostsCheck && Array.isArray(allowedHosts) && allowedHosts.length > 0) {
+        const { hostname } = new URL(webReq.url);
+        const isAllowed = allowedHosts.some(
+          (host) => hostname === host || hostname.endsWith(`.${host}`),
+        );
+        if (!isAllowed) {
+          res.statusCode = 400;
+          res.end('Bad Request: Host not allowed.');
+
+          return;
+        }
+      }
+
       const webRes = await angularServerApp.handle(webReq);
       if (!webRes) {
         return next();


### PR DESCRIPTION
## Problem

`createAngularSsrInternalMiddleware` calls `AngularServerApp.handle()` directly without validating the request hostname against the configured `allowedHosts`.

The external middleware correctly propagates the check:
```typescript
AngularAppEngine.ɵdisableAllowedHostsCheck = disableAllowedHostsCheck;
```

But the internal middleware has **no equivalent validation**. When `allowedHosts` is configured as an array (not `true`), the internal SSR path still processes requests with arbitrary `Host` headers.

## Impact

With `host: "0.0.0.0"` + `allowedHosts: ["myapp.com"]`, a DNS rebinding attack can set `Host: attacker.com` and the internal SSR middleware will:
1. Construct the request URL from the attacker-controlled Host header
2. Resolve all relative `HttpClient` requests against `attacker.com`
3. Send credentials/cookies to the attacker's server

This is the same SSRF class as GHSA-rfh7-fxqc-q52v but in the dev server's internal middleware path.

## Reproduction

```bash
# angular.json: "serve": { "options": { "host": "0.0.0.0", "allowedHosts": ["myapp.com"] } }
ng serve

# Attacker sends request with spoofed Host:
curl -H 'Host: attacker.com' http://VICTIM:4200/
# SSR engine resolves relative HttpClient URLs against attacker.com
```

## Fix

Validate the request URL hostname against `allowedHosts` before calling `angularServerApp.handle()`, consistent with the external middleware's behavior.