### PR TITLE
build: bump Angular framework and ng-packagr versions to 22.2.0-next.0

### DIFF
--- a/constants.bzl
+++ b/constants.bzl
@@ -3,10 +3,10 @@ RELEASE_ENGINES_NODE = "^22.22.3 || ^24.15.0 || >=26.0.0"
 RELEASE_ENGINES_NPM = "^6.11.0 || ^7.5.6 || >=8.0.0"
 RELEASE_ENGINES_YARN = ">= 1.13.0"
 
-NG_PACKAGR_VERSION = "^22.1.0-next.0"
-ANGULAR_FW_VERSION = "^22.1.0-next.0"
-ANGULAR_FW_PEER_DEP = "^22.0.0 || ^22.1.0-next.0"
-NG_PACKAGR_PEER_DEP = "^22.0.0 || ^22.1.0-next.0"
+NG_PACKAGR_VERSION = "^22.2.0-next.0"
+ANGULAR_FW_VERSION = "^22.2.0-next.0"
+ANGULAR_FW_PEER_DEP = "^22.0.0 || ^22.2.0-next.0"
+NG_PACKAGR_PEER_DEP = "^22.0.0 || ^22.2.0-next.0"
 
 # Baseline widely-available date in `YYYY-MM-DD` format which defines Angular's
 # browser support. This date serves as the source of truth for the Angular CLI's


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

`constants.bzl` specifies `^22.1.0-next.0` for Angular framework and `ng-packagr` versions.

Issue Number: N/A

## What is the new behavior?

Bumps Angular framework and `ng-packagr` versions and peer dependency ranges in `constants.bzl` to `^22.2.0-next.0` to match updated dependencies.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information