### PR TITLE
build(@schematics/angular): use genrule for best practices copy

### DIFF
--- a/packages/schematics/angular/BUILD.bazel
+++ b/packages/schematics/angular/BUILD.bazel
@@ -3,7 +3,6 @@
 # Use of this source code is governed by an MIT-style license that can be
 # found in the LICENSE file at https://angular.dev/license
 
-load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:defaults.bzl", "copy_to_bin", "jasmine_test", "npm_package", "ts_project")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
@@ -46,10 +45,11 @@ copy_to_bin(
     srcs = glob(["**/schema.json"]),
 )
 
-copy_file(
+genrule(
     name = "angular_best_practices",
-    src = "//:node_modules/@angular/core/resources/best-practices.md",
-    out = "ai-config/files/__bestPracticesName__.template",
+    srcs = ["//:node_modules/@angular/core/dir"],
+    outs = ["ai-config/files/__bestPracticesName__.template"],
+    cmd = "cp $(execpath //:node_modules/@angular/core/dir)/resources/best-practices.md $@",
 )
 
 RUNTIME_ASSETS = [


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

`packages/schematics/angular/BUILD.bazel` uses `copy_file` to copy `//:node_modules/@angular/core/resources/best-practices.md`. When `@angular/core` is linked as a directory tree artifact (`/dir`), referencing an internal file label directly without depending on the directory artifact causes Bazel's sandbox not to stage `@angular/core` into the sandbox, failing with `cp: cannot stat 'node_modules/@angular/core/resources/best-practices.md'`.

Issue Number: N/A

## What is the new behavior?

Replaces `copy_file` with `genrule` in `packages/schematics/angular/BUILD.bazel` to depend explicitly on `//:node_modules/@angular/core/dir` in `srcs`. This ensures Bazel stages the package directory into the sandbox for `copy_to_bin` / `npm_package_archive` builds.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information