### PR TITLE
perf(@angular/ssr): avoid buffering request body when sanitizing headers

### DIFF
--- a/packages/angular/ssr/src/utils/validation.ts
+++ b/packages/angular/ssr/src/utils/validation.ts
@@ -88,7 +88,7 @@ export function validateUrl(url: URL, allowedHosts: ReadonlySet<string>): void {
 
 /**
  * Sanitizes the proxy headers of a request by removing unallowed `X-Forwarded-*` headers.
- * If no headers need to be removed, the original request is returned without cloning.
+ * If no headers need to be removed, the original request is returned unchanged.
  *
  * @param request - The incoming `Request` object to sanitize.
  * @param trustProxyHeaders - A set of allowed proxy headers.
@@ -117,8 +117,7 @@ export function sanitizeRequestHeaders(
   }
 
   return headersDeleted
-    ? new Request(request.clone(), {
-        signal: request.signal,
+    ? new Request(request, {
         headers,
       })
     : request;

--- a/packages/angular/ssr/test/utils/validation_spec.ts
+++ b/packages/angular/ssr/test/utils/validation_spec.ts
@@ -494,12 +494,10 @@ describe('Validation Utils', () => {
       expect(secured.headers.get('forwarded')).toBe('host=proxy.com;proto=https');
     });
 
-    it('should not tee request body and should preserve abort signal when removing unallowed headers', async () => {
-      const controller = new AbortController();
+    it('should transfer request body without teeing when removing unallowed headers', async () => {
       const req = new Request('http://example.com', {
         method: 'POST',
         body: 'test body',
-        signal: controller.signal,
         headers: {
           'host': 'example.com',
           'x-forwarded-host': 'evil.com',
@@ -508,8 +506,24 @@ describe('Validation Utils', () => {
 
       const secured = sanitizeRequestHeaders(req, normalizeTrustProxyHeaders(undefined));
 
+      // In the Fetch specification, calling `request.clone()` tees the body stream and leaves
+      // `req.bodyUsed` as `false`. Passing `req` directly to `new Request(req, ...)` transfers the
+      // underlying stream without teeing, immediately marking `req.bodyUsed` as `true`.
       expect(req.bodyUsed).toBeTrue();
       expect(await secured.text()).toBe('test body');
+    });
+
+    it('should preserve abort signal when removing unallowed headers', () => {
+      const controller = new AbortController();
+      const req = new Request('http://example.com', {
+        signal: controller.signal,
+        headers: {
+          'host': 'example.com',
+          'x-forwarded-host': 'evil.com',
+        },
+      });
+
+      const secured = sanitizeRequestHeaders(req, normalizeTrustProxyHeaders(undefined));
 
       controller.abort();
       expect(secured.signal.aborted).toBeTrue();

--- a/packages/angular/ssr/test/utils/validation_spec.ts
+++ b/packages/angular/ssr/test/utils/validation_spec.ts
@@ -493,5 +493,26 @@ describe('Validation Utils', () => {
       expect(secured.headers.get('host')).toBe('example.com');
       expect(secured.headers.get('forwarded')).toBe('host=proxy.com;proto=https');
     });
+
+    it('should not tee request body and should preserve abort signal when removing unallowed headers', async () => {
+      const controller = new AbortController();
+      const req = new Request('http://example.com', {
+        method: 'POST',
+        body: 'test body',
+        signal: controller.signal,
+        headers: {
+          'host': 'example.com',
+          'x-forwarded-host': 'evil.com',
+        },
+      });
+
+      const secured = sanitizeRequestHeaders(req, normalizeTrustProxyHeaders(undefined));
+
+      expect(req.bodyUsed).toBeTrue();
+      expect(await secured.text()).toBe('test body');
+
+      controller.abort();
+      expect(secured.signal.aborted).toBeTrue();
+    });
   });
 });


### PR DESCRIPTION
Avoid teeing the incoming request body stream with `request.clone()` when removing untrusted `X-Forwarded-*` headers in `sanitizeRequestHeaders`.

Teeing the stream caused the unconsumed branch to buffer the uploaded body in memory. Passing `request` directly to `new Request(request, { headers })` transfers the stream without teeing or buffering.

Additionally, `request.signal` is automatically inherited by the new `Request` instance without needing to pass it explicitly.

Closes #33706