### PR TITLE
fix(@angular/cli): correctly report available package updates during bare ng update

### DIFF
--- a/packages/angular/cli/src/commands/update/update-resolver.ts
+++ b/packages/angular/cli/src/commands/update/update-resolver.ts
@@ -942,11 +942,7 @@ export async function resolveUserUpdatePlan(
   };
 
   if (packages.size === 0) {
-    await Promise.all(
-      Array.from(npmDeps.keys()).map(async (depName) => {
-        await getOrFetchPackageMetadata(depName);
-      }),
-    );
+    await Promise.all(Array.from(npmDeps.keys(), (depName) => getOrFetchPackageMetadata(depName)));
   } else {
     let lastPackagesSize;
     do {
@@ -999,12 +995,13 @@ export async function resolveUserUpdatePlan(
     } while (packages.size > lastPackagesSize);
   }
 
+  const isListingUpdates = packages.size === 0;
   const packageInfoEntries = await Promise.all(
     Array.from(npmDeps.keys(), async (depName) => {
       const isUpdating = packages.has(depName);
       const localPkgJson = getInstalledPackageJson(depName, workspaceRoot);
 
-      if (isUpdating || !localPkgJson) {
+      if (isListingUpdates || isUpdating || !localPkgJson) {
         const metadata = await getOrFetchPackageMetadata(depName);
         if (metadata) {
           const info = await _buildPackageInfo(

--- a/packages/angular/cli/src/commands/update/update-resolver_spec.ts
+++ b/packages/angular/cli/src/commands/update/update-resolver_spec.ts
@@ -289,6 +289,29 @@ describe('UpdateResolver', () => {
     expect(plan.packagesToUpdate.size).toBe(0);
   });
 
+  it('includes registry metadata when listing updates with locked dependency versions in package.json', async () => {
+    createMockWorkspace(
+      {
+        name: 'blah',
+        dependencies: {
+          '@angular-devkit-tests/update-base': '1.0.0',
+        },
+      },
+      {
+        '@angular-devkit-tests/update-base': { version: '1.0.0' },
+      },
+    );
+
+    const plan = await resolvePlan({
+      packages: [],
+      workspaceRoot: tempRoot,
+    });
+
+    const info = plan.packageInfoMap.get('@angular-devkit-tests/update-base');
+    expect(info?.npmPackageJson['dist-tags']?.['latest']).toBe('1.1.0');
+    expect(info?.npmPackageJson.versions).toContain('1.1.0');
+  });
+
   it('should not error with yarn 2.0 protocols', async () => {
     createMockWorkspace(
       {


### PR DESCRIPTION
In v22.0.1, a performance optimization (4510dae) was introduced to fetch registry metadata lazily during `ng update`, only querying the registry for packages actively being updated or uninstalled. However, during a bare `ng update` to list available workspace updates (where `packages.size === 0`), `isUpdating` is false for every dependency. For installed dependencies with locked versions in package.json (no carets/tildes), localPkgJson exists, causing the resolver to fall back to local mock package info without registry versions or dist-tags.

This commit updates the registry metadata check in `resolveUserUpdatePlan` to include listing mode (`packages.size === 0`), ensuring cached registry metadata is used to list available package updates.

Closes #33712
