### PR TITLE
fix(@schematics/angular): escape module specifier in insertImport

### DIFF
--- a/packages/schematics/angular/utility/ast-utils.ts
+++ b/packages/schematics/angular/utility/ast-utils.ts
@@ -77,7 +77,11 @@ export function insertImport(
   // if there are no imports or 'use strict' statement, insert import at beginning of file
   const insertAtBeginning = allImports.length === 0 && useStrict.length === 0;
   const separator = insertAtBeginning ? '' : `;${eol}`;
-  const escapedFileName = fileName.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+  const escapedFileName = fileName
+    .replace(/\\/g, '\\\\')
+    .replace(/'/g, "\\'")
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r');
   const toInsert =
     `${separator}import ${open}${importExpression}${close}` +
     ` from '${escapedFileName}'${insertAtBeginning ? `;${eol}` : ''}`;

--- a/packages/schematics/angular/utility/ast-utils.ts
+++ b/packages/schematics/angular/utility/ast-utils.ts
@@ -77,9 +77,10 @@ export function insertImport(
   // if there are no imports or 'use strict' statement, insert import at beginning of file
   const insertAtBeginning = allImports.length === 0 && useStrict.length === 0;
   const separator = insertAtBeginning ? '' : `;${eol}`;
+  const escapedFileName = fileName.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
   const toInsert =
     `${separator}import ${open}${importExpression}${close}` +
-    ` from '${fileName}'${insertAtBeginning ? `;${eol}` : ''}`;
+    ` from '${escapedFileName}'${insertAtBeginning ? `;${eol}` : ''}`;
 
   return insertAfterLastOccurrence(
     allImports,

--- a/packages/schematics/angular/utility/ast-utils_spec.ts
+++ b/packages/schematics/angular/utility/ast-utils_spec.ts
@@ -768,6 +768,24 @@ describe('ast utils', () => {
 
       expect(result).toBe(fileContent);
     });
+
+    it('should escape single quotes and backslashes in the module specifier', () => {
+      const fileContent = '';
+      const source = getTsSource(filePath, fileContent);
+      const change = insertImport(source, filePath, 'Component', "foo'bar\\baz");
+      const result = applyChanges(filePath, fileContent, [change]).trim();
+
+      expect(result).toBe("import { Component } from 'foo\\'bar\\\\baz';");
+    });
+
+    it('should escape newlines and carriage returns in the module specifier', () => {
+      const fileContent = '';
+      const source = getTsSource(filePath, fileContent);
+      const change = insertImport(source, filePath, 'Component', 'foo\nbar\rbaz');
+      const result = applyChanges(filePath, fileContent, [change]).trim();
+
+      expect(result).toBe(`import { Component } from 'foo\\nbar\\rbaz';`);
+    });
   });
 
   describe('hasTopLevelIdentifier', () => {


### PR DESCRIPTION
\`insertImport\` (\`packages/schematics/angular/utility/ast-utils.ts\`) builds an \`import ... from '<fileName>'\` statement by interpolating \`fileName\` directly between single quotes, with no escaping. A \`fileName\` containing a single quote breaks out of the string literal, so a caller that passes untrusted data as the module specifier ends up inserting attacker-controlled source into the target file instead of a plain import path.

This is reachable through \`addRootProvider\`'s \`external(symbolName, moduleName)\` (\`utility/standalone/code_block.ts\`), which calls \`insertImport\` with \`moduleName\` as \`fileName\` — any \`ng add\` schematic that calls \`external()\` with a module name sourced from project config rather than a hardcoded string inherits this. Confirmed with the real, unmodified \`insertImport\` against a \`fileName\` of \`\`x'; console.log('INJECTED'); const _y = 'y\`\`: the generated file contained the \`console.log(...)\` call as live top-level code rather than an unusual import path, and running the generated file executed it.

\`fileName\` is now escaped for backslashes and single quotes before being interpolated, matching the existing single-quote output format so the common case (a real module specifier, which never contains a quote or backslash) is byte-for-byte unchanged — verified against the existing \`insertImport\` describe block in \`ast-utils_spec.ts\` by hand, all of which assert exact single-quoted output.

Note on verification: this repo's test suite runs via Bazel (\`bazel test //packages/...\`), which wasn't feasible to run end-to-end in the environment this fix was developed in. The escaping logic was verified standalone against the existing test cases' expected output strings and against the malicious-input case described above; happy to have CI confirm on this PR.