### PR TITLE
ci: use W3C-compliant Sauce Labs tunnelName and remove deprecated tunnelIdentifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,7 @@ jobs:
           google_credential: ${{ secrets.RBE_TRUSTED_BUILDS_USER }}
       - name: Start Sauce Connect
         uses: saucelabs/sauce-connect-action@cb88b508c6f9ff4d84490093733315dbd55de022 # v3
+        timeout-minutes: 10
         with:
           username: ${{ vars.SAUCE_USERNAME }}
           accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}

--- a/tests/e2e/assets/protractor-saucelabs.conf.js
+++ b/tests/e2e/assets/protractor-saucelabs.conf.js
@@ -63,19 +63,17 @@ exports.config = {
 
   // NOTE: https://saucelabs.com/products/platform-configurator can be used to determine configuration values
   multiCapabilities: capabilities.map((caps) => {
+    const { version, platform, ...rest } = caps;
     const w3cCaps = {
-      ...caps,
-      browserVersion: caps.version,
-      platformName: caps.platform,
+      ...rest,
+      browserVersion: version,
+      platformName: platform,
     };
 
     if (tunnelIdentifier) {
       return {
         ...w3cCaps,
-        tunnelIdentifier,
-        tunnelName: tunnelIdentifier,
         'sauce:options': {
-          tunnelIdentifier,
           tunnelName: tunnelIdentifier,
         },
       };


### PR DESCRIPTION
Starting July 31, 2026, Sauce Labs servers will no longer support Sauce Connect 4 traffic. During the upgrade to Sauce Connect 5 (`saucelabs/sauce-connect-action@v3`), passing both `tunnelIdentifier` and `tunnelName` caused Sauce Labs W3C WebDriver session creation to fail with:

```
Both desired capabilities 'tunnelIdentifier' and 'tunnelName' were provided at the same time. Since 'tunnelIdentifier' is deprecated, please only use 'tunnelName' for specifying your Sauce Connect tunnel name.
```

This commit removes the deprecated `tunnelIdentifier` capability from both the top-level capability object and `'sauce:options'`, only passing `tunnelName` inside `'sauce:options'` to ensure 100% W3C WebDriver specification compliance for Sauce Connect 5.
