### PR TITLE
ci: fix Sauce Labs E2E browser tests with Sauce Connect 5 and legacy JWP capabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,7 @@ jobs:
           accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
           region: us-west-1
           tunnelName: ${{ env.SAUCE_TUNNEL_IDENTIFIER }}
+          args: --proxy-localhost allow
       - name: Run E2E Browser tests
         env:
           SAUCE_USERNAME: ${{ vars.SAUCE_USERNAME }}

--- a/tests/e2e/assets/protractor-saucelabs.conf.js
+++ b/tests/e2e/assets/protractor-saucelabs.conf.js
@@ -63,23 +63,22 @@ exports.config = {
 
   // NOTE: https://saucelabs.com/products/platform-configurator can be used to determine configuration values
   multiCapabilities: capabilities.map((caps) => {
-    const { version, platform, ...rest } = caps;
-    const w3cCaps = {
-      ...rest,
-      browserVersion: version,
-      platformName: platform,
+    const config = {
+      ...caps,
+      browserVersion: caps.version,
+      platformName: caps.platform,
     };
 
     if (tunnelIdentifier) {
       return {
-        ...w3cCaps,
+        ...config,
         'sauce:options': {
           tunnelName: tunnelIdentifier,
         },
       };
     }
 
-    return w3cCaps;
+    return config;
   }),
 
   // Only allow one session at a time to prevent over saturation of Saucelabs sessions.


### PR DESCRIPTION
This PR resolves 4 browser test failures in `//tests:e2e.saucelabs` (`tests/misc/browsers.ts`) caused by the Sauce Connect 5 upgrade and recent capability changes:

1. **Sauce Connect 5 Localhost Proxying (`--proxy-localhost deny` default)**
   - Passes `--proxy-localhost allow` to `saucelabs/sauce-connect-action@v3` in `.github/workflows/ci.yml` so remote Sauce Labs browser VMs can route traffic to `http://localhost:2000/` running on the CI runner.
2. **Protractor 7 / `selenium-webdriver@3.6.0` Protocol Mismatch**
   - Preserves legacy JSON Wire Protocol (JWP) capability keys (`version`, `platform`) alongside W3C keys (`browserVersion`, `platformName`) in `tests/e2e/assets/protractor-saucelabs.conf.js`, fixing `Unable to find a matching set of capabilities` on Firefox and `Unknown platform requested: 'macos 13'` on Safari.