### PR TITLE
ci: use proxyLocalhost action input in Sauce Connect CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
           accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
           region: us-west-1
           tunnelName: ${{ env.SAUCE_TUNNEL_IDENTIFIER }}
-          args: --proxy-localhost allow
+          proxyLocalhost: allow
       - name: Run E2E Browser tests
         env:
           SAUCE_USERNAME: ${{ vars.SAUCE_USERNAME }}


### PR DESCRIPTION
This PR replaces the unexpected `args` input with `proxyLocalhost: allow` for the `saucelabs/sauce-connect-action@v3` step in `.github/workflows/ci.yml`, as supported by the action's input definition.