### PR TITLE
ci: fix Sauce Labs E2E capabilities and SSL bumping in Sauce Connect 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,12 @@ jobs:
           region: us-west-1
           tunnelName: ${{ env.SAUCE_TUNNEL_IDENTIFIER }}
           proxyLocalhost: allow
+          # By default we disable SSL bumping for all requests. This is because SSL bumping is not needed
+          # for our test setup and in order to perform the SSL bumping, Saucelabs intercepts all HTTP
+          # requests in the tunnel VM and modifies them. This can cause flakiness as it makes all requests
+          # dependent on the SSL bumping middleware.
+          # See: https://wiki.saucelabs.com/display/DOCS/Troubleshooting+Sauce+Connect#TroubleshootingSauceConnect-DisablingSSLBumping
+          tlsPassthroughDomains: all
       - name: Run E2E Browser tests
         env:
           SAUCE_USERNAME: ${{ vars.SAUCE_USERNAME }}

--- a/tests/e2e/assets/protractor-saucelabs.conf.js
+++ b/tests/e2e/assets/protractor-saucelabs.conf.js
@@ -62,24 +62,10 @@ exports.config = {
   specs: ['./src/**/*.e2e-spec.ts'],
 
   // NOTE: https://saucelabs.com/products/platform-configurator can be used to determine configuration values
-  multiCapabilities: capabilities.map((caps) => {
-    const config = {
-      ...caps,
-      browserVersion: caps.version,
-      platformName: caps.platform,
-    };
-
-    if (tunnelIdentifier) {
-      return {
-        ...config,
-        'sauce:options': {
-          tunnelName: tunnelIdentifier,
-        },
-      };
-    }
-
-    return config;
-  }),
+  multiCapabilities: capabilities.map((caps) => ({
+    ...caps,
+    tunnelIdentifier,
+  })),
 
   // Only allow one session at a time to prevent over saturation of Saucelabs sessions.
   maxSessions: 1,


### PR DESCRIPTION
This PR resolves all remaining E2E browser test failures in `//tests:e2e.saucelabs` (`tests/misc/browsers.ts`):

1. **Reverts `multiCapabilities` in `protractor-saucelabs.conf.js` to Pure Legacy JWP Capabilities**
   - Strips W3C capability keys (`browserVersion`, `platformName`, `sauce:options`) and restores pure JSON Wire Protocol (JWP) capabilities (`browserName`, `version`, `platform`, `tunnelIdentifier`). This is required by Protractor 7 (`selenium-webdriver@3.6.0`) and ensures Chrome and Edge connect through the Sauce Connect tunnel while fixing session negotiation on Firefox and Safari.
2. **Configures `tlsPassthroughDomains: all` in `.github/workflows/ci.yml`**
   - Disables SSL bumping across all domains in Sauce Connect 5 (`saucelabs/sauce-connect-action@v3`) to eliminate SSL middleware flakiness.