### PR TITLE
ci: use tunnelName inside sauce:options capability block in Sauce Labs E2E config

### DIFF
--- a/tests/e2e/assets/protractor-saucelabs.conf.js
+++ b/tests/e2e/assets/protractor-saucelabs.conf.js
@@ -5,7 +5,7 @@
 
 const { SpecReporter, StacktraceOption } = require('jasmine-spec-reporter');
 
-const tunnelIdentifier = process.env['SAUCE_TUNNEL_IDENTIFIER'];
+const tunnelName = process.env['SAUCE_TUNNEL_IDENTIFIER'];
 
 const capabilities = [
   {
@@ -64,7 +64,7 @@ exports.config = {
   // NOTE: https://saucelabs.com/products/platform-configurator can be used to determine configuration values
   multiCapabilities: capabilities.map((caps) => ({
     ...caps,
-    tunnelIdentifier,
+    tunnelName,
   })),
 
   // Only allow one session at a time to prevent over saturation of Saucelabs sessions.


### PR DESCRIPTION

In Sauce Connect 5 and modern Sauce Labs W3C/JWP capabilities, 'tunnelName' replaces the deprecated 'tunnelIdentifier' capability.