### PR TITLE
fix(@angular/build): disable code splitting for unit test builds

### DIFF
--- a/packages/angular/build/src/builders/application/options.ts
+++ b/packages/angular/build/src/builders/application/options.ts
@@ -126,6 +126,20 @@ interface InternalOptions {
    * Suppress build summary and stats table.
    */
   quiet?: boolean;
+
+  /**
+   * Disables esbuild code splitting for the browser code bundle.
+   *
+   * Splitting emits shared chunks whose exports are read across chunk boundaries as live ESM
+   * bindings. A module hoisted into a shared chunk is wrapped in a lazy initializer, so its exported
+   * value is only assigned once that initializer runs. Runners that load the generated output
+   * through a module runner rather than the browser's own ESM implementation do not reliably
+   * preserve those bindings, and an importing chunk can observe the export as `undefined`.
+   *
+   * Test bundles are never downloaded by a browser, so there is nothing for splitting to optimize
+   * there. Used exclusively for tests and shouldn't be used for other kinds of builds.
+   */
+  disableCodeSplitting?: boolean;
 }
 
 /** Full set of options for `application` builder. */
@@ -439,6 +453,7 @@ export async function normalizeOptions(
     partialSSRBuild = false,
     externalRuntimeStyles,
     instrumentForCoverage,
+    disableCodeSplitting,
   } = options;
 
   // Return all the normalized options
@@ -475,6 +490,7 @@ export async function normalizeOptions(
     watch,
     workspaceRoot,
     entryPoints,
+    disableCodeSplitting,
     optimizationOptions,
     outputOptions,
     outExtension,

--- a/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
@@ -257,6 +257,12 @@ export async function getVitestBuildOptions(
     outputHashing: adjustOutputHashing(baseBuildOptions.outputHashing),
     optimization: false,
     entryPoints,
+    // Every spec file is its own entry point, so splitting hoists any module shared between two
+    // specs into a chunk whose exports are then read across a chunk boundary. Those reads rely on
+    // live ESM bindings, and a module placed in a shared chunk is only assigned its exported value
+    // when that chunk's lazy initializer runs, so an importing chunk can read `undefined`. Nothing
+    // downloads these bundles, so there is no benefit to weigh against that.
+    disableCodeSplitting: true,
     // Enable support for vitest browser prebundling. Excludes can be controlled with a runnerConfig
     // and the `optimizeDeps.exclude` option.
     externalPackages: true,

--- a/packages/angular/build/src/builders/unit-test/tests/behavior/vitest-shared-chunk-init_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/behavior/vitest-shared-chunk-init_spec.ts
@@ -1,0 +1,172 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { execute } from '../../index';
+import {
+  BASE_OPTIONS,
+  describeBuilder,
+  UNIT_TEST_BUILDER_INFO,
+  setupApplicationTarget,
+} from '../setup';
+
+describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
+  describe('Behavior: "Vitest shared chunk initialization"', () => {
+    // Regression test for https://github.com/angular/angular-cli/issues/33728.
+    //
+    // Without `disableCodeSplitting`, esbuild hoists a module imported by more than one spec
+    // entry point into a shared chunk behind a lazy `__esm` initializer, and a class-field
+    // initializer in another chunk reads the exported value as `undefined` under the jsdom
+    // runner. All four trigger conditions are required and encoded below:
+    //   1. two spec entry points import the shared module (so it lands in a shared chunk);
+    //   2. a component in one entry reads the export during class-field initialization;
+    //   3. that component's spec file contains an `async` test callback (no `await` needed);
+    //   4. zone.js is in the polyfills (the `setupApplicationTarget` default), which downlevels
+    //      async and makes esbuild emit the spec entry CommonJS-wrapped.
+    //
+    // NOTE: the failure this guards against is sensitive to inert content — adding a top-level
+    // side effect (even a `console.log`) to the shared or importing module below defused it
+    // during reduction. Mirror https://github.com/jonmarozick/ng-shared-chunk-repro when
+    // modifying these fixtures.
+    it('should provide shared-module exports to class-field initializers in async specs', async () => {
+      setupApplicationTarget(harness);
+
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+      });
+
+      // Keep the default project's spec deterministic; a third spec entry that does not touch
+      // the shared module does not affect the reproduction (verified in a fresh workspace).
+      await harness.writeFile(
+        'src/app/app.component.spec.ts',
+        `
+        import { describe, it, expect } from 'vitest';
+
+        describe('AppComponent placeholder', () => {
+            it('runs', () => {
+                expect(1 + 1).toBe(2);
+            });
+        });
+      `,
+      );
+
+      // The shared `const`. Reached from both spec entry points, so it is hoisted into a chunk
+      // shared between them.
+      await harness.writeFile(
+        'src/environments/env-config.ts',
+        `
+        export interface DealerConfig {
+            dealerId: string;
+            clientKey: string;
+        }
+
+        export const DEALERS: DealerConfig[] = [
+            { dealerId: 'dealer-one', clientKey: 'KEY-ONE' },
+            { dealerId: 'dealer-two', clientKey: 'KEY-TWO' },
+            { dealerId: 'dealer-three', clientKey: 'KEY-THREE' },
+            { dealerId: 'dealer-four', clientKey: 'KEY-FOUR' },
+        ];
+      `,
+      );
+
+      // Reached by both spec entries, so it and env-config.ts land in the shared chunk. Reads the
+      // const inside a method — after module initialization — and is the passing control.
+      await harness.writeFile(
+        'src/app/features/lead-generator/services/lead.service.ts',
+        `
+        import { Injectable } from '@angular/core';
+
+        import { DEALERS } from '../../../../environments/env-config';
+
+        @Injectable({ providedIn: 'root' })
+        export class LeadService {
+            resolveClientKey(dealerId: string, clientKey?: string): string {
+                return clientKey ?? DEALERS.find((d) => d.dealerId === dealerId)?.clientKey ?? '';
+            }
+        }
+      `,
+      );
+
+      await harness.writeFile(
+        'src/app/features/lead-generator/services/index.ts',
+        `export * from './lead.service';\n`,
+      );
+
+      // Spec entry point 1 — the second importer that causes the chunk to be shared at all.
+      await harness.writeFile(
+        'src/app/features/lead-generator/services/lead.service.spec.ts',
+        `
+        import { describe, it, expect } from 'vitest';
+        import { TestBed } from '@angular/core/testing';
+
+        import { LeadService } from './lead.service';
+
+        describe('LeadService', () => {
+            it('reads DEALERS inside a method', () => {
+                TestBed.configureTestingModule({ providers: [LeadService] });
+
+                expect(TestBed.inject(LeadService).resolveClientKey('dealer-one')).toBe('KEY-ONE');
+            });
+        });
+      `,
+      );
+
+      // In the other chunk; reads the shared export eagerly during class-field initialization.
+      await harness.writeFile(
+        'src/app/features/lead-generator/lead-generator.container.ts',
+        `
+        import { Component, inject } from '@angular/core';
+
+        import { LeadService } from './services';
+        import { DEALERS, DealerConfig } from '../../../environments/env-config';
+
+        @Component({
+            selector: 'app-lead-generator',
+            standalone: true,
+            template: '',
+        })
+        export class LeadGeneratorContainer {
+            private readonly leadService = inject(LeadService);
+
+            readonly dealers: DealerConfig[] = DEALERS;
+            readonly dealerOptions = this.dealers.map((d) => d.dealerId);
+
+            hasService(): boolean {
+                return this.leadService != null;
+            }
+        }
+      `,
+      );
+
+      // Spec entry point 2 — the failing case without the fix. The `async` is load-bearing:
+      // zone.js makes the builder downlevel it, the spec then imports the `__async` helper, and
+      // esbuild emits this entry CommonJS-wrapped with the component module behind a lazy
+      // `__esm` initializer. No `await` is needed; a synchronous callback hides the defect.
+      await harness.writeFile(
+        'src/app/features/lead-generator/lead-generator.container.spec.ts',
+        `
+        import { describe, it, expect } from 'vitest';
+        import { TestBed } from '@angular/core/testing';
+
+        import { LeadGeneratorContainer } from './lead-generator.container';
+
+        describe('LeadGeneratorContainer', () => {
+            it('reads DEALERS in a class-field initialiser', async () => {
+                const fixture = TestBed.createComponent(LeadGeneratorContainer);
+
+                expect(fixture.componentInstance.dealers.length).toBe(4);
+            });
+        });
+      `,
+      );
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBeTrue();
+    });
+  });
+});

--- a/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
@@ -71,6 +71,12 @@ export function createBrowserCodeBundleOptions(
       supported: getFeatureSupport(zoneless),
     };
 
+    if (options.disableCodeSplitting) {
+      // Splitting emits shared chunks that are read across chunk boundaries as live ESM bindings,
+      // which the unit-test runners' module loading does not reliably preserve.
+      buildOptions.splitting = false;
+    }
+
     buildOptions.plugins ??= [];
     buildOptions.plugins.push(
       createWasmPlugin({ allowAsync: zoneless, cache: loadCache }),


### PR DESCRIPTION
Fixes #33728

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features) — `unit-test/tests/behavior/vitest-shared-chunk-init_spec.ts`; see "Other information" for how the fixture was validated red/green.
- [ ] Docs have been added / updated (for bug fixes / features) — N/A: the new option is internal-only and not exposed in the builder schema.

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?

Issue Number: #33728

Under `@angular/build:unit-test` with the default (jsdom) runner, an export from a module that code
splitting hoisted into a shared chunk can be observed as `undefined` by an importing chunk — a
component reading an exported `const` in a class-field initializer fails with
`TypeError: Cannot read properties of undefined (reading 'map')`, in a test that never touches the
runner's own API. The emitted bundles are valid ESM and the same specs pass in browser mode, so the
defect is in how the Node-side module-runner path evaluates the split output, not in the bundles.

Every spec file is its own entry point, so splitting hoists any module reached from more than one
spec into a shared chunk behind lazy `__esm` initializers; importing chunks then read the export as
a live ESM binding, which that path does not reliably preserve at class-field-initialization time.
The full analysis — including the exact four-condition trigger set (shared chunk + cross-chunk
field read + an `async` test callback + zone.js polyfills) isolated by single-variable toggles — is
in #33728, with a minimal reproduction at https://github.com/jonmarozick/ng-shared-chunk-repro
(`npm install && npm test`: expected 2 passed, actual 1 failed).

The failure only appears once a project has more than one spec file, because a single entry point
inlines everything and never splits — so a suite can pass for a long time and then break when a
second spec file is added. The impact can also be silent: in a larger project on the same setup,
jsdom reported 108 of 216 tests (three spec files never loaded) in half the wall-clock of browser
mode.

## What is the new behavior?

esbuild code splitting is disabled for the unit-test build only, through a new internal option
(`disableCodeSplitting`) alongside the existing internal test-only options. Test bundles are never
downloaded by a browser, so splitting has nothing to optimize here. Three small changes:

- `application/options.ts` — declare the internal option and pass it through `normalizeOptions`.
- `esbuild/application-code-bundle.ts` — honour it in `createBrowserCodeBundleOptions`, following
  the existing `buildOptions.splitting = false` precedent used for the polyfills bundle.
- `unit-test/runners/vitest/build-options.ts` — set it for the Vitest runner's build.

With the change, the minimal reproduction passes (2/2) and no shared chunks are emitted for test
builds. Application builds are untouched.

## Does this PR introduce a breaking change?

- [x] No

Cost: shared modules are duplicated into each spec bundle. Measured on a real 105-spec-file
project via `--dump-virtual-files`:

| | output files | total size | chunks | wall |
|---|---|---|---|---|
| splitting on | 169 | 1.21 MB | 57 | 30s |
| splitting off | 112 | 6.93 MB | 0 | 28s |

Total output grows ~5.7×; test run time was unchanged. If the extra memory is a concern for very
large suites, gating the option on the runner being jsdom (rather than all Vitest builds) would
narrow it, since browser mode does not exhibit the bug — happy to adjust.

## Other information

**Verification.** Verified by applying the equivalent change to an installed 21.2.19
`@angular/build` (building the CLI from source with Bazel was not available on this machine), so CI
should be treated as the authoritative run:

| check | before | after |
|---|---|---|
| minimal reproduction (jsdom) | 1 failed / 1 passed | **2 passed** |
| real 105-spec-file project, browser mode | 1018 passed | **1018 passed** |
| `ng build` (application build, flag unset) | ok | ok, still splits |

**Regression test.** `unit-test/tests/behavior/vitest-shared-chunk-init_spec.ts` encodes the
issue's four trigger conditions: a shared `const` imported by two spec entries (shared chunk), a
component reading it in a class-field initializer, an **async test callback** in that component's
spec (no `await` needed), and zone.js in the polyfills (the `setupApplicationTarget` default).
Earlier fixture attempts passed without the fix because their test callbacks were synchronous —
zone forces async downleveling, the spec then imports the `__async` helper, and esbuild emits that
spec entry CommonJS-wrapped with the component module behind a lazy `__esm` initializer, which is
the shape in which the cross-chunk read fails.

Since Bazel wasn't runnable on my machine, the fixture's exact file contents were validated
against an installed 21.2.19 `@angular/build` in a fresh `ng new` workspace: **unpatched, the
container spec fails** with the issue's `TypeError` (1 failed / 2 passed); **with this change
applied, all pass** and no `chunk-*.js` is emitted. Please treat the CI run of the harness test as
authoritative. One caveat encoded as a comment in the test: the failure is sensitive to inert
content (a top-level `console.log` in either module defuses it), so the fixtures intentionally
mirror the reproduction byte-for-byte rather than a paraphrase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
