### PR TITLE
ci: schedule ng-snapshot Renovate updates for early morning only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,10 @@
   "ignorePaths": ["tests/e2e/assets/**", "tests/schematics/update/packages/**"],
   "packageRules": [
     {
+      "matchFileNames": ["tests/e2e/ng-snapshot/package.json"],
+      "schedule": ["before 8am"]
+    },
+    {
       "enabled": false,
       "matchFileNames": ["tests/e2e/ng-snapshot/package.json"],
       "matchBaseBranches": ["!main"]


### PR DESCRIPTION
Add a packageRule in `renovate.json` matching `tests/e2e/ng-snapshot/package.json` with `"schedule": ["before 8am"]` so that snapshot dependency update pull requests only open in the morning outside of office hours.