### PR TITLE
fix(@angular/cli): disable searching current directory for bare executable names on Windows

### DIFF
--- a/packages/angular/cli/lib/init.ts
+++ b/packages/angular/cli/lib/init.ts
@@ -39,6 +39,9 @@ let forceExit = false;
         // Ignore failure to change directory
       }
     }
+
+    // Ensure Windows CreateProcess does not search the current directory for bare executable names.
+    process.env['NoDefaultCurrentDirectoryInExePath'] = '1';
   }
 
   /**
@@ -48,6 +51,7 @@ let forceExit = false;
    * See: https://github.com/browserslist/browserslist/blob/819c4337456996d19db6ba953014579329e9c6e1/node.js#L324
    */
   process.env.BROWSERSLIST_IGNORE_OLD_DATA = '1';
+
   const rawCommandName = process.argv[2];
 
   /**


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

On Windows, Node.js child process execution (`execFileSync` / `spawn`) implicitly searches `process.cwd()` for bare executable names when `NoDefaultCurrentDirectoryInExePath` is not set.

Issue Number: #33755

## What is the new behavior?

Sets `process.env['NoDefaultCurrentDirectoryInExePath'] = '1'` early in CLI initialization on Windows. This ensures Windows `CreateProcess` does not search the current directory for bare executable names (such as `git` or `which`).

Fixes #33755

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No