### PR TITLE
refactor(@angular/cli): remove unused eslint-disable comment in git utility

### DIFF
--- a/packages/angular/cli/src/commands/update/utilities/git.ts
+++ b/packages/angular/cli/src/commands/update/utilities/git.ts
@@ -60,7 +60,7 @@ export function checkCleanGit(root: string): boolean {
         return false;
       }
     }
-  } catch {} // eslint-disable-line no-empty
+  } catch {}
 
   return true;
 }


### PR DESCRIPTION
Remove unused `// eslint-disable-line no-empty` comment in `checkCleanGit` utility function.