### PR TITLE
fix(@angular/build): set es2016 target for Rolldown prebundling in Zone.js apps

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite/index.ts
+++ b/packages/angular/build/src/builders/dev-server/vite/index.ts
@@ -389,11 +389,15 @@ export async function* serveWithVite(
         ? browserOptions.polyfills
         : [browserOptions.polyfills];
 
-      const target = transformSupportedBrowsersToTargets(browsers);
-      if (!isZonelessApp(polyfills)) {
-        // Rolldown doesn't have an option to support Zone.js/async-await, so we need to support es2016.
-        target.push('es2016');
-      }
+      // TODO(alanagius): This is a workaround for https://github.com/rolldown/rolldown/issues/10633
+      const target = isZonelessApp(polyfills) ? ['es2022'] : ['es2016'];
+
+      // Once the above issue is fixed, uncomment the below code.
+      // const target = transformSupportedBrowsersToTargets(browsers);
+      // if (!isZonelessApp(polyfills)) {
+      //   // Rolldown doesn't have an option to support Zone.js/async-await, so we need to support es2016.
+      //   target.push('es2016');
+      // }
 
       let ssrMode: ServerSsrMode = ServerSsrMode.NoSsr;
       if (

--- a/packages/angular/build/src/builders/dev-server/vite/server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite/server.ts
@@ -104,6 +104,7 @@ function createSsrConfig(
   prebundleLoaderExtensions: RolldownLoaderOption | undefined,
   thirdPartySourcemaps: boolean,
   define: ApplicationBuilderInternalOptions['define'],
+  target: string[],
 ): Vite.SSROptions {
   return {
     // Note: `true` and `/.*/` have different sematics. When true, the `external` option is ignored.
@@ -111,6 +112,7 @@ function createSsrConfig(
     // Exclude any Node.js built in module and provided dependencies (currently build defined externals)
     external: externalMetadata.explicitServer,
     optimizeDeps: getDepOptimizationConfig({
+      target,
       // Only enable with caching since it causes prebundle dependencies to be cached
       disabled: serverOptions.prebundle === false,
       // Exclude any explicitly defined dependencies (currently build defined externals and node.js built-ins)
@@ -214,6 +216,7 @@ export async function setupServer(
             prebundleLoaderExtensions,
             thirdPartySourcemaps,
             define,
+            target,
           ),
     plugins: [
       createAngularSetupMiddlewaresPlugin({
@@ -239,6 +242,7 @@ export async function setupServer(
     ],
     // Browser only optimizeDeps. (This does not run for SSR dependencies).
     optimizeDeps: getDepOptimizationConfig({
+      target,
       // Only enable with caching since it causes prebundle dependencies to be cached
       disabled: serverOptions.prebundle === false,
       // Exclude any explicitly defined dependencies (currently build defined externals)

--- a/packages/angular/build/src/tools/vite/utils.ts
+++ b/packages/angular/build/src/tools/vite/utils.ts
@@ -48,6 +48,7 @@ export type RolldownLoaderOption = Exclude<
 >['moduleTypes'];
 
 export function getDepOptimizationConfig({
+  target,
   disabled,
   exclude,
   include,
@@ -56,6 +57,7 @@ export function getDepOptimizationConfig({
   thirdPartySourcemaps,
   define = {},
 }: {
+  target: string[];
   disabled: boolean;
   exclude: string[];
   include: string[];
@@ -73,6 +75,7 @@ export function getDepOptimizationConfig({
     noDiscovery: disabled,
     rolldownOptions: {
       transform: {
+        target,
         define,
       },
       moduleTypes: loader,


### PR DESCRIPTION

Rolldown dependency prebundling in Vite dev server was not receiving target options, leaving native `async`/`await` intact in prebundled dependencies (such as `@angular/common/http`'s `FetchBackend`). When an application uses Zone.js, native `async`/`await` causes Zone.js context loss across native `await` ticks.

This PR passes `target` to `rolldownOptions.transform.target` during dependency optimization. For non-zoneless applications (apps using Zone.js), `target` is set to `['es2016']` to downlevel native `async`/`await` in prebundled dependencies.

Fixes #33770
