### PR TITLE
refactor(@angular/build): optimize removeSourceMappingURL with pre-check and range slicing

### DIFF
--- a/packages/angular/build/src/utils/source-map.ts
+++ b/packages/angular/build/src/utils/source-map.ts
@@ -21,7 +21,12 @@ import { fileURLToPath } from 'node:url';
  * @returns The code with top-level sourcemap comments removed.
  */
 export function removeSourceMappingURL(code: string): string {
+  if (!code.includes('//# sourceMappingURL=')) {
+    return code;
+  }
+
   const result: string[] = [];
+  let lastCopiedIndex = 0;
   let i = 0;
   const len = code.length;
 
@@ -30,7 +35,6 @@ export function removeSourceMappingURL(code: string): string {
   let currentState:
     'normal' | 'string_double' | 'string_single' | 'template' | 'comment_block' | 'comment_line' =
     'normal';
-  let isStrippingComment = false;
 
   while (i < len) {
     const char = code[i];
@@ -39,20 +43,19 @@ export function removeSourceMappingURL(code: string): string {
     if (currentState === 'normal') {
       if (char === '/' && nextChar === '*') {
         currentState = 'comment_block';
-        result.push('/*');
         i += 2;
         continue;
       }
       if (char === '/' && nextChar === '/') {
         // Detect if the comment is escaped (e.g. inside a regex literal like `/\/\/#/`).
         let isEscaped = false;
-        let prevIdx = result.length - 1;
-        while (prevIdx >= 0 && /\s/.test(result[prevIdx])) {
+        let prevIdx = i - 1;
+        while (prevIdx >= 0 && /\s/.test(code[prevIdx])) {
           prevIdx--;
         }
-        if (prevIdx >= 0 && result[prevIdx] === '\\') {
+        if (prevIdx >= 0 && code[prevIdx] === '\\') {
           let bsCount = 0;
-          while (prevIdx >= 0 && result[prevIdx] === '\\') {
+          while (prevIdx >= 0 && code[prevIdx] === '\\') {
             bsCount++;
             prevIdx--;
           }
@@ -62,34 +65,35 @@ export function removeSourceMappingURL(code: string): string {
         }
 
         if (!isEscaped && code.startsWith('//# sourceMappingURL=', i)) {
-          currentState = 'comment_line';
-          isStrippingComment = true;
-          i += 21; // Skip the '//# sourceMappingURL=' prefix
+          if (i > lastCopiedIndex) {
+            result.push(code.slice(lastCopiedIndex, i));
+          }
+          // Skip the rest of the comment line up to the newline
+          i += 21;
+          while (i < len && code[i] !== '\n' && code[i] !== '\r') {
+            i++;
+          }
+          lastCopiedIndex = i;
           continue;
         } else {
           currentState = 'comment_line';
-          isStrippingComment = false;
-          result.push('//');
           i += 2;
           continue;
         }
       }
       if (char === '"') {
         currentState = 'string_double';
-        result.push('"');
         i++;
         continue;
       }
       if (char === "'") {
         currentState = 'string_single';
-        result.push("'");
         i++;
         continue;
       }
       if (char === '`') {
         currentState = 'template';
         stack.push({ type: 'template', braceDepth: 0 });
-        result.push('`');
         i++;
         continue;
       }
@@ -98,7 +102,6 @@ export function removeSourceMappingURL(code: string): string {
         if (top) {
           top.braceDepth++;
         }
-        result.push('{');
         i++;
         continue;
       }
@@ -110,43 +113,35 @@ export function removeSourceMappingURL(code: string): string {
             // Exiting a template literal interpolation ${ ... }
             stack.pop();
             currentState = 'template';
-            result.push('}');
             i++;
             continue;
           }
         }
-        result.push('}');
         i++;
         continue;
       }
 
-      result.push(char);
       i++;
     } else if (currentState === 'string_double') {
       if (char === '\\') {
-        result.push(char, nextChar || '');
         i += 2;
         continue;
       }
       if (char === '"') {
         currentState = 'normal';
       }
-      result.push(char);
       i++;
     } else if (currentState === 'string_single') {
       if (char === '\\') {
-        result.push(char, nextChar || '');
         i += 2;
         continue;
       }
       if (char === "'") {
         currentState = 'normal';
       }
-      result.push(char);
       i++;
     } else if (currentState === 'template') {
       if (char === '\\') {
-        result.push(char, nextChar || '');
         i += 2;
         continue;
       }
@@ -154,7 +149,6 @@ export function removeSourceMappingURL(code: string): string {
         // Entering template literal interpolation context
         currentState = 'normal';
         stack.push({ type: 'template', braceDepth: 0 });
-        result.push('${');
         i += 2;
         continue;
       }
@@ -162,30 +156,28 @@ export function removeSourceMappingURL(code: string): string {
         stack.pop();
         currentState = 'normal';
       }
-      result.push(char);
       i++;
     } else if (currentState === 'comment_block') {
       if (char === '*' && nextChar === '/') {
         currentState = 'normal';
-        result.push('*/');
         i += 2;
         continue;
       }
-      result.push(char);
       i++;
     } else if (currentState === 'comment_line') {
       if (char === '\n' || char === '\r') {
         currentState = 'normal';
-        isStrippingComment = false;
-        result.push(char);
-        i++;
-        continue;
-      }
-      if (!isStrippingComment) {
-        result.push(char);
       }
       i++;
     }
+  }
+
+  if (lastCopiedIndex === 0) {
+    return code;
+  }
+
+  if (lastCopiedIndex < len) {
+    result.push(code.slice(lastCopiedIndex));
   }
 
   return result.join('');

--- a/packages/angular/build/src/utils/source-map_spec.ts
+++ b/packages/angular/build/src/utils/source-map_spec.ts
@@ -87,4 +87,14 @@ describe('removeSourceMappingURL', () => {
     const code = '// # sourceMappingURL=main.js.map\n//# sourceMappingURL=main.js.map';
     expect(removeSourceMappingURL(code)).toBe('// # sourceMappingURL=main.js.map\n');
   });
+
+  it('should return the exact input string when no sourcemap comment is present', () => {
+    const code = 'const x = 1;\nconsole.log(x);';
+    expect(removeSourceMappingURL(code)).toBe(code);
+  });
+
+  it('should handle sourcemap comments with CRLF newlines', () => {
+    const code = 'console.log("hello");\r\n//# sourceMappingURL=main.js.map\r\nconst next = 2;';
+    expect(removeSourceMappingURL(code)).toBe('console.log("hello");\r\n\r\nconst next = 2;');
+  });
 });


### PR DESCRIPTION
Add an early substring check to immediately return the original code when no source map comment is present in a file. In addition, replace the character-by-character string accumulator with range slicing to eliminate temporary single-character string allocations on large files, and add unit tests covering zero-comment early returns and CRLF line endings.