### PR TITLE
fix(@angular/build): prevent syntax corruption for Crockford-style enum IIFE

### DIFF
--- a/packages/angular/build/src/tools/oxc/adjust-typescript-enums_oxc_spec.ts
+++ b/packages/angular/build/src/tools/oxc/adjust-typescript-enums_oxc_spec.ts
@@ -300,4 +300,83 @@ describe('adjust-typescript-enums oxc-transform implementation', () => {
       `,
     }),
   );
+
+  it(
+    'handles TypeScript enums wrapped in parentheses',
+    testCase({
+      input: `
+        var ChangeDetectionStrategy;
+        ((function (ChangeDetectionStrategy) {
+            ChangeDetectionStrategy[ChangeDetectionStrategy["OnPush"] = 0] = "OnPush";
+            ChangeDetectionStrategy[ChangeDetectionStrategy["Default"] = 1] = "Default";
+        })(ChangeDetectionStrategy || (ChangeDetectionStrategy = {})));
+      `,
+      expected: `
+        var ChangeDetectionStrategy = /*#__PURE__*/ (function (ChangeDetectionStrategy) {
+          ChangeDetectionStrategy[(ChangeDetectionStrategy["OnPush"] = 0)] = "OnPush";
+          ChangeDetectionStrategy[(ChangeDetectionStrategy["Default"] = 1)] = "Default";
+          return ChangeDetectionStrategy;
+        })(ChangeDetectionStrategy || {});
+      `,
+    }),
+  );
+
+  it(
+    'wraps Crockford-style TypeScript enum IIFE without leaving dangling parentheses',
+    testCase({
+      input: `
+        var HDirection;
+        (function (HDirection) {
+          HDirection[HDirection['Backwards'] = -1] = 'Backwards';
+          HDirection[HDirection['Forwards'] = 1] = 'Forwards';
+        }(HDirection || (HDirection = {})));
+        const nextStatement = true;
+      `,
+      expected: `
+        var HDirection = /*#__PURE__*/ (function (HDirection) {
+          HDirection[(HDirection['Backwards'] = -1)] = 'Backwards';
+          HDirection[(HDirection['Forwards'] = 1)] = 'Forwards';
+          return HDirection;
+        }(HDirection || {}));
+
+        const nextStatement = true;
+      `,
+    }),
+  );
+
+  it(
+    'wraps TypeScript enum IIFE with multiple nested parentheses',
+    testCase({
+      input: `
+        var Foo;
+        (((function (Foo) {
+          Foo[Foo['A'] = 0] = 'A';
+        }(Foo || (Foo = {})))));
+      `,
+      expected: `
+        var Foo = /*#__PURE__*/ (function (Foo) {
+          Foo[(Foo['A'] = 0)] = 'A';
+          return Foo;
+        }(Foo || {}));
+      `,
+    }),
+  );
+
+  it(
+    'wraps Crockford-style TypeScript enum IIFE with chained export assignments',
+    testCase({
+      input: `
+        var Foo;
+        (function (Foo) {
+          Foo[Foo['A'] = 0] = 'A';
+        }(Foo || (Foo = exports.Foo = {})));
+      `,
+      expected: `
+        var Foo = /*#__PURE__*/ (function (Foo) {
+          Foo[(Foo['A'] = 0)] = 'A';
+          return Foo;
+        }(Foo || (exports.Foo = {})));
+      `,
+    }),
+  );
 });

--- a/packages/angular/build/src/tools/oxc/oxc-transform.ts
+++ b/packages/angular/build/src/tools/oxc/oxc-transform.ts
@@ -412,9 +412,10 @@ export function transform(filename: string, code: string, options: OxcTransformO
         continue;
       }
 
-      // 1. Remove only the trailing characters/semicolon of the expression statement
+      // 1. Remove leading/trailing characters/parentheses of the expression statement
+      s.remove(nextStatement.start, nextExpr.start);
       s.remove(nextExpr.end, nextStatement.end);
-      markEdited(nextExpr.end, nextStatement.end);
+      markEdited(nextStatement.start, nextStatement.end);
 
       // 2. Add return statement inside IIFE body
       s.appendRight(callee.body.end - 1, `; return ${paramName};`);
@@ -435,7 +436,6 @@ export function transform(filename: string, code: string, options: OxcTransformO
       // 4. Move IIFE to the var initializer
       s.move(nextExpr.start, nextExpr.end, decl.id.end);
       s.appendLeft(decl.id.end, ' = /*#__PURE__*/ ');
-      markEdited(nextExpr.start, nextExpr.end);
     }
   }
 


### PR DESCRIPTION
When transforming Crockford-style TypeScript enum IIFEs (e.g. `(function (E) { ... }(E || (E = {})));`), ensure all leading and trailing parentheses of the expression statement are removed when moving the IIFE call expression to the var initializer so no dangling parentheses remain before subsequent statements.

Fixes #33785