### PR TITLE
fix(@angular/build): return only lowest version per target engine

### DIFF
--- a/packages/angular/build/BUILD.bazel
+++ b/packages/angular/build/BUILD.bazel
@@ -337,7 +337,7 @@ npm_package(
     ],
     stamp_files = [
         "src/utils/version.js",
-        "src/tools/esbuild/utils.js",
+        "src/tools/esbuild/target.js",
         "src/utils/normalize-cache.js",
         "src/utils/supported-browsers.js",
     ],

--- a/packages/angular/build/src/builders/application/execute-build.ts
+++ b/packages/angular/build/src/builders/application/execute-build.ts
@@ -18,11 +18,8 @@ import { checkCommonJSModules } from '../../tools/esbuild/commonjs-checker';
 import { LOCALE_DATA_BASE_MODULE } from '../../tools/esbuild/i18n-locale-plugin';
 import { extractLicenses } from '../../tools/esbuild/license-extractor';
 import { profileAsync } from '../../tools/esbuild/profiling';
-import {
-  calculateEstimatedTransferSizes,
-  logBuildStats,
-  transformSupportedBrowsersToTargets,
-} from '../../tools/esbuild/utils';
+import { transformSupportedBrowsersToTargets } from '../../tools/esbuild/target';
+import { calculateEstimatedTransferSizes, logBuildStats } from '../../tools/esbuild/utils';
 import { BudgetCalculatorResult, checkBudgets } from '../../utils/bundle-calculator';
 import { optimizeChunksThreshold } from '../../utils/environment-options';
 import { resolveAssets } from '../../utils/resolve-assets';

--- a/packages/angular/build/src/builders/application/setup-bundling.ts
+++ b/packages/angular/build/src/builders/application/setup-bundling.ts
@@ -19,7 +19,7 @@ import {
 import { BundlerContext } from '../../tools/esbuild/bundler-context';
 import { createGlobalScriptsBundleOptions } from '../../tools/esbuild/global-scripts';
 import { createGlobalStylesBundleOptions } from '../../tools/esbuild/global-styles';
-import { getSupportedNodeTargets } from '../../tools/esbuild/utils';
+import { getSupportedNodeTargets } from '../../tools/esbuild/target';
 import type { NormalizedApplicationBuildOptions } from './options';
 
 /**

--- a/packages/angular/build/src/builders/dev-server/internal.ts
+++ b/packages/angular/build/src/builders/dev-server/internal.ts
@@ -13,7 +13,7 @@ export { getFeatureSupport, isZonelessApp } from '../../tools/esbuild/utils';
 export { type IndexHtmlTransform } from '../../utils/index-file/index-html-generator';
 export { purgeStaleBuildCache } from '../../utils/purge-cache';
 export { getSupportedBrowsers } from '../../utils/supported-browsers';
-export { transformSupportedBrowsersToTargets } from '../../tools/esbuild/utils';
+export { transformSupportedBrowsersToTargets } from '../../tools/esbuild/target';
 export { buildApplicationInternal } from '../../builders/application';
 export type { ApplicationBuilderInternalOptions } from '../../builders/application/options';
 export type { ExternalResultMetadata } from '../../tools/esbuild/bundler-execution-result';

--- a/packages/angular/build/src/builders/dev-server/vite/index.ts
+++ b/packages/angular/build/src/builders/dev-server/vite/index.ts
@@ -389,15 +389,11 @@ export async function* serveWithVite(
         ? browserOptions.polyfills
         : [browserOptions.polyfills];
 
-      // TODO(alanagius): This is a workaround for https://github.com/rolldown/rolldown/issues/10633
-      const target = isZonelessApp(polyfills) ? ['es2022'] : ['es2016'];
-
-      // Once the above issue is fixed, uncomment the below code.
-      // const target = transformSupportedBrowsersToTargets(browsers);
-      // if (!isZonelessApp(polyfills)) {
-      //   // Rolldown doesn't have an option to support Zone.js/async-await, so we need to support es2016.
-      //   target.push('es2016');
-      // }
+      const target = transformSupportedBrowsersToTargets(browsers);
+      if (!isZonelessApp(polyfills)) {
+        // Rolldown doesn't have an option to support Zone.js/async-await, so we need to support es2016.
+        target.push('es2016');
+      }
 
       let ssrMode: ServerSsrMode = ServerSsrMode.NoSsr;
       if (

--- a/packages/angular/build/src/private.ts
+++ b/packages/angular/build/src/private.ts
@@ -34,7 +34,7 @@ export {
 // Tools
 export type { ExternalResultMetadata } from './tools/esbuild/bundler-execution-result';
 export { emitFilesToDisk } from './tools/esbuild/utils';
-export { transformSupportedBrowsersToTargets } from './tools/esbuild/utils';
+export { transformSupportedBrowsersToTargets } from './tools/esbuild/target';
 export { SassWorkerImplementation } from './tools/sass/sass-service';
 
 export { SourceFileCache } from './tools/esbuild/angular/source-file-cache';

--- a/packages/angular/build/src/tools/esbuild/target.ts
+++ b/packages/angular/build/src/tools/esbuild/target.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { coerce, compare, minVersion } from 'semver';
+
+/**
+ * Compares two target version strings.
+ *
+ * This function is used to determine the lowest version for a given browser target.
+ *
+ * @param a The first version string.
+ * @param b The second version string.
+ * @returns A negative value if `a` is lower than `b`, a positive value if `a` is higher than `b`, and 0 if they are equal.
+ */
+function compareTargetVersions(a: string, b: string): number {
+  const aVersion = coerce(a);
+  const bVersion = coerce(b);
+
+  if (!aVersion || !bVersion) {
+    return aVersion ? -1 : bVersion ? 1 : 0;
+  }
+
+  return compare(aVersion, bVersion);
+}
+
+// https://esbuild.github.io/api/#target
+const ESBUILD_SUPPORTED_BROWSERS: ReadonlySet<string> = new Set([
+  'chrome',
+  'edge',
+  'firefox',
+  'ie',
+  'ios',
+  'node',
+  'opera',
+  'safari',
+]);
+
+/**
+ * Transform browserlists result to esbuild target.
+ *
+ * Only the lowest version for each browser is returned to avoid issues with esbuild and rolldown
+ * when multiple versions of the same target engine are specified.
+ *
+ * @see https://esbuild.github.io/api/#target
+ * @see https://github.com/evanw/esbuild/issues/4509
+ * @see https://github.com/rolldown/rolldown/issues/10633
+ */
+export function transformSupportedBrowsersToTargets(supportedBrowsers: string[]): string[] {
+  const browsers = new Map<string, string>();
+
+  for (const browser of supportedBrowsers) {
+    let [browserName, version] = browser.toLowerCase().split(' ');
+    if (!browserName || !version) {
+      continue;
+    }
+
+    // browserslist uses the name `ios_saf` for iOS Safari whereas esbuild uses `ios`
+    if (browserName === 'ios_saf') {
+      browserName = 'ios';
+    }
+
+    if (!ESBUILD_SUPPORTED_BROWSERS.has(browserName)) {
+      continue;
+    }
+
+    // browserslist uses ranges `15.2-15.3` versions but only the lowest is required
+    // to perform minimum supported feature checks. esbuild also expects a single version.
+    [version] = version.split('-');
+
+    if (browserName === 'safari' && version === 'tp') {
+      // esbuild only supports numeric versions so `TP` is converted to a high number (999) since
+      // a Technology Preview (TP) of Safari is assumed to support all currently known features.
+      version = '999';
+    } else if (!version.includes('.')) {
+      // A lone major version is considered by esbuild to include all minor versions. However,
+      // browserslist does not and is also inconsistent in its `.0` version naming. For example,
+      // Safari 15.0 is named `safari 15` but Safari 16.0 is named `safari 16.0`.
+      version += '.0';
+    }
+
+    const current = browsers.get(browserName);
+    if (!current || compareTargetVersions(version, current) < 0) {
+      browsers.set(browserName, version);
+    }
+  }
+
+  return Array.from(browsers, ([browserName, version]) => browserName + version);
+}
+
+const SUPPORTED_NODE_VERSIONS = '0.0.0-ENGINES-NODE';
+
+/**
+ * Transform supported Node.js versions to esbuild target.
+ *
+ * Only the lowest Node.js version is returned to avoid issues with esbuild and rolldown
+ * when multiple versions of the same target engine are specified.
+ *
+ * @see https://esbuild.github.io/api/#target
+ * @see https://github.com/evanw/esbuild/issues/4509
+ * @see https://github.com/rolldown/rolldown/issues/10633
+ */
+export function getSupportedNodeTargets(): string[] {
+  if (SUPPORTED_NODE_VERSIONS.charAt(0) === '0') {
+    // Unlike `pkg_npm`, `ts_library` which is used to run unit tests does not support substitutions.
+    return [];
+  }
+
+  const parsed = minVersion(SUPPORTED_NODE_VERSIONS);
+
+  return parsed ? ['node' + parsed.version] : [];
+}

--- a/packages/angular/build/src/tools/esbuild/target_spec.ts
+++ b/packages/angular/build/src/tools/esbuild/target_spec.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { getSupportedNodeTargets, transformSupportedBrowsersToTargets } from './target';
+
+describe('esbuild target', () => {
+  describe('transformSupportedBrowsersToTargets', () => {
+    it('should return the smallest version for each browser', () => {
+      const targets = transformSupportedBrowsersToTargets([
+        'chrome 122',
+        'chrome 120',
+        'chrome 121',
+        'firefox 116',
+        'firefox 115',
+        'safari 17.0',
+        'safari 16.4',
+      ]);
+
+      expect(targets).toEqual(['chrome120.0', 'firefox115.0', 'safari16.4']);
+    });
+
+    it('should handle version ranges and pick the lowest version', () => {
+      const targets = transformSupportedBrowsersToTargets([
+        'ios_saf 15.4',
+        'ios_saf 15.2-15.3',
+        'ios_saf 16.0',
+      ]);
+
+      expect(targets).toEqual(['ios15.2']);
+    });
+
+    it('should handle Safari TP (Technology Preview)', () => {
+      const targetsWithOlderSafari = transformSupportedBrowsersToTargets([
+        'safari TP',
+        'safari 16.4',
+      ]);
+      expect(targetsWithOlderSafari).toEqual(['safari16.4']);
+
+      const targetsWithOnlyTP = transformSupportedBrowsersToTargets(['safari TP']);
+      expect(targetsWithOnlyTP).toEqual(['safari999']);
+    });
+
+    it('should ignore browsers not supported by esbuild', () => {
+      const targets = transformSupportedBrowsersToTargets([
+        'android 4.4',
+        'samsung 22',
+        'kaios 2.5',
+        'chrome 115',
+      ]);
+
+      expect(targets).toEqual(['chrome115.0']);
+    });
+
+    it('should return empty array for empty supportedBrowsers', () => {
+      const targets = transformSupportedBrowsersToTargets([]);
+      expect(targets).toEqual([]);
+    });
+
+    it('should handle malformed or incomplete browser strings gracefully', () => {
+      const targets = transformSupportedBrowsersToTargets(['chrome', 'firefox ', '']);
+      expect(targets).toEqual([]);
+    });
+
+    it('should handle single major versions by appending .0', () => {
+      const targets = transformSupportedBrowsersToTargets(['chrome 120', 'edge 120']);
+      expect(targets).toEqual(['chrome120.0', 'edge120.0']);
+    });
+  });
+
+  describe('getSupportedNodeTargets', () => {
+    it('should return empty array when node versions are not stamped', () => {
+      expect(getSupportedNodeTargets()).toEqual([]);
+    });
+  });
+});

--- a/packages/angular/build/src/tools/esbuild/utils.ts
+++ b/packages/angular/build/src/tools/esbuild/utils.ts
@@ -12,7 +12,6 @@ import { Listr } from 'listr2';
 import { basename, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { brotliCompress } from 'node:zlib';
-import { coerce } from 'semver';
 import { NormalizedApplicationBuildOptions } from '../../builders/application/options';
 import { OutputMode } from '../../builders/application/schema';
 import { BudgetCalculatorResult } from '../../utils/bundle-calculator';
@@ -213,7 +212,7 @@ export async function emitFilesToDisk<T = BuildOutputAsset | BuildOutputFile>(
   writeFileCallback: (file: T) => Promise<void>,
 ): Promise<void> {
   // Write files in groups of MAX_CONCURRENT_WRITES to avoid too many open files
-  for (let fileIndex = 0; fileIndex < files.length; ) {
+  for (let fileIndex = 0; fileIndex < files.length;) {
     const groupMax = Math.min(fileIndex + MAX_CONCURRENT_WRITES, files.length);
 
     const actions = [];
@@ -223,71 +222,6 @@ export async function emitFilesToDisk<T = BuildOutputAsset | BuildOutputFile>(
 
     await Promise.all(actions);
   }
-}
-
-/**
- * Transform browserlists result to esbuild target.
- * @see https://esbuild.github.io/api/#target
- */
-export function transformSupportedBrowsersToTargets(supportedBrowsers: string[]): string[] {
-  const transformed: string[] = [];
-
-  // https://esbuild.github.io/api/#target
-  const esBuildSupportedBrowsers = new Set([
-    'chrome',
-    'edge',
-    'firefox',
-    'ie',
-    'ios',
-    'node',
-    'opera',
-    'safari',
-  ]);
-
-  for (const browser of supportedBrowsers) {
-    let [browserName, version] = browser.toLowerCase().split(' ');
-
-    // browserslist uses the name `ios_saf` for iOS Safari whereas esbuild uses `ios`
-    if (browserName === 'ios_saf') {
-      browserName = 'ios';
-    }
-
-    // browserslist uses ranges `15.2-15.3` versions but only the lowest is required
-    // to perform minimum supported feature checks. esbuild also expects a single version.
-    [version] = version.split('-');
-
-    if (esBuildSupportedBrowsers.has(browserName)) {
-      if (browserName === 'safari' && version === 'tp') {
-        // esbuild only supports numeric versions so `TP` is converted to a high number (999) since
-        // a Technology Preview (TP) of Safari is assumed to support all currently known features.
-        version = '999';
-      } else if (!version.includes('.')) {
-        // A lone major version is considered by esbuild to include all minor versions. However,
-        // browserslist does not and is also inconsistent in its `.0` version naming. For example,
-        // Safari 15.0 is named `safari 15` but Safari 16.0 is named `safari 16.0`.
-        version += '.0';
-      }
-
-      transformed.push(browserName + version);
-    }
-  }
-
-  return transformed;
-}
-
-const SUPPORTED_NODE_VERSIONS = '0.0.0-ENGINES-NODE';
-
-/**
- * Transform supported Node.js versions to esbuild target.
- * @see https://esbuild.github.io/api/#target
- */
-export function getSupportedNodeTargets(): string[] {
-  if (SUPPORTED_NODE_VERSIONS.charAt(0) === '0') {
-    // Unlike `pkg_npm`, `ts_library` which is used to run unit tests does not support substitutions.
-    return [];
-  }
-
-  return SUPPORTED_NODE_VERSIONS.split('||').map((v) => 'node' + coerce(v)?.version);
 }
 
 interface BuildManifest {


### PR DESCRIPTION
Only the lowest version for each browser and Node.js target is returned to avoid issues with esbuild and Rolldown when multiple versions of the same target engine are specified.

In addition, target resolution logic is relocated to `src/tools/esbuild/target.ts`.

See: https://github.com/evanw/esbuild/issues/4509
See: https://github.com/rolldown/rolldown/issues/10633