### PR TITLE
fix(@angular/ssr): destroy platform when response stream is cancelled

### DIFF
--- a/packages/angular/ssr/src/app.ts
+++ b/packages/angular/ssr/src/app.ts
@@ -366,10 +366,18 @@ export class AngularServerApp {
     // Use a stream to send the response before finishing rendering and inling critical CSS, improving performance via header flushing.
     const stream = new ReadableStream({
       start: async (controller) => {
-        const renderedHtml = await result.content();
-        const finalHtml = await this.inlineCriticalCssWithCache(renderedHtml, url);
-        controller.enqueue(finalHtml);
-        controller.close();
+        try {
+          const renderedHtml = await result.content();
+          const finalHtml = await this.inlineCriticalCssWithCache(renderedHtml, url);
+          controller.enqueue(finalHtml);
+          controller.close();
+        } catch (error) {
+          result.destroy();
+          controller.error(error);
+        }
+      },
+      cancel: () => {
+        result.destroy();
       },
     });
 

--- a/packages/angular/ssr/src/utils/ng.ts
+++ b/packages/angular/ssr/src/utils/ng.ts
@@ -34,8 +34,7 @@ import { addTrailingSlash, joinUrlParts, stripIndexHtmlFromURL, stripTrailingSla
  * - A function that returns a `Promise<ApplicationRef>`, which resolves with the root application reference.
  */
 export type AngularBootstrap =
-  | Type<unknown>
-  | ((context: BootstrapContext) => Promise<ApplicationRef>);
+  Type<unknown> | ((context: BootstrapContext) => Promise<ApplicationRef>);
 
 /**
  * Renders an Angular application or module to an HTML string.
@@ -60,7 +59,12 @@ export async function renderAngular(
   serverContext: string,
 ): Promise<
   | { hasNavigationError: true }
-  | { hasNavigationError: boolean; redirectTo?: string; content: () => Promise<string> }
+  | {
+      hasNavigationError: boolean;
+      redirectTo?: string;
+      content: () => Promise<string>;
+      destroy: () => void;
+    }
 > {
   // A request to `http://www.example.com/page/index.html` will render the Angular route corresponding to `http://www.example.com/page`.
   const urlToRender = stripIndexHtmlFromURL(url);
@@ -134,6 +138,7 @@ export async function renderAngular(
     }
 
     return {
+      destroy: () => void asyncDestroyPlatform(platformRef),
       hasNavigationError,
       redirectTo,
       content: () =>
@@ -177,6 +182,10 @@ export function isNgModule(value: AngularBootstrap): value is Type<unknown> {
  * @param platformRef - The platform reference to be destroyed.
  */
 function asyncDestroyPlatform(platformRef: PlatformRef): Promise<void> {
+  if (platformRef.destroyed) {
+    return Promise.resolve();
+  }
+
   return new Promise((resolve) => {
     setTimeout(() => {
       if (!platformRef.destroyed) {

--- a/packages/angular/ssr/test/app_spec.ts
+++ b/packages/angular/ssr/test/app_spec.ts
@@ -14,6 +14,7 @@ import '@angular/compiler';
 import { APP_BASE_HREF } from '@angular/common';
 import { Component, PlatformRef, REQUEST, RESPONSE_INIT, inject } from '@angular/core';
 import { ActivatedRoute, CanActivateFn, Router } from '@angular/router';
+import { setTimeout } from 'node:timers/promises';
 import { AngularServerApp } from '../src/app';
 import { RenderMode } from '../src/routes/route-config';
 import { setAngularAppTestingManifest } from './testing-utils';
@@ -363,6 +364,16 @@ describe('AngularServerApp', () => {
         const response = await app.handle(request);
         expect(response?.status).toBe(200);
         expect(await response?.text()).toContain('Home works');
+      });
+
+      it('should destroy the platform when the response stream is cancelled', async () => {
+        const destroySpy = spyOn(PlatformRef.prototype, 'destroy').and.callThrough();
+        const response = await app.handle(new Request('http://localhost/home'));
+        expect(response?.body).toBeInstanceOf(ReadableStream);
+        await response?.body?.cancel();
+        // Wait for the macrotask queue to clear since destroy is called asynchronously
+        await setTimeout(0);
+        expect(destroySpy).toHaveBeenCalled();
       });
 
       describe('APP_BASE_HREF / X-Forwarded-Prefix', () => {


### PR DESCRIPTION
Ensures PlatformRef is properly destroyed when an active response stream is cancelled or encounters an error during rendering to prevent memory leaks.
