### PR TITLE
fix(@angular/build): avoid premature worker pool termination during route prerender

### DIFF
--- a/packages/angular/build/src/utils/server-rendering/prerender.ts
+++ b/packages/angular/build/src/utils/server-rendering/prerender.ts
@@ -273,7 +273,6 @@ async function renderPages(
           errors.push(
             `An error occurred while prerendering route '${route}'.\n\n${err.stack ?? err.message ?? err.code ?? err}`,
           );
-          void renderWorker.destroy();
         });
 
       renderingPromises.push(renderResult);


### PR DESCRIPTION
Removes worker pool destruction on individual route prerender errors so that other in-flight route renders can complete normally.
