### PR TITLE
fix(@schematics/angular): import UrlSegment instead of subPath in guard generator

### DIFF
--- a/packages/schematics/angular/guard/index.ts
+++ b/packages/schematics/angular/guard/index.ts
@@ -34,7 +34,7 @@ export default function (options: GuardOptions): Rule {
     const routerNamedImports: string[] = [...options.implements, 'MaybeAsync', 'GuardResult'];
 
     if (options.implements.includes(GuardInterface.CanMatch)) {
-      routerNamedImports.push('Route', 'subPath');
+      routerNamedImports.push('Route', 'UrlSegment');
 
       if (options.implements.length > 1) {
         routerNamedImports.push(...commonRouterNameImports);

--- a/packages/schematics/angular/guard/index_spec.ts
+++ b/packages/schematics/angular/guard/index_spec.ts
@@ -165,7 +165,7 @@ describe('Guard Schematic', () => {
     const options = { ...defaultOptions, implements: implementationOptions, functional: false };
     const tree = await schematicRunner.runSchematic('guard', options, appTree);
     const fileString = tree.readContent('/projects/bar/src/app/foo-guard.ts');
-    const expectedImports = `import { CanMatch, GuardResult, MaybeAsync, Route, subPath } from '@angular/router';`;
+    const expectedImports = `import { CanMatch, GuardResult, MaybeAsync, Route, UrlSegment } from '@angular/router';`;
 
     expect(fileString).toContain(expectedImports);
   });
@@ -198,7 +198,7 @@ describe('Guard Schematic', () => {
     const fileString = tree.readContent('/projects/bar/src/app/foo-guard.ts');
     const expectedImports =
       `import { ActivatedRouteSnapshot, CanActivate, CanActivateChild, CanMatch, GuardResult, ` +
-      `MaybeAsync, Route, RouterStateSnapshot, subPath } from '@angular/router';`;
+      `MaybeAsync, Route, RouterStateSnapshot, UrlSegment } from '@angular/router';`;
 
     expect(fileString).toContain(expectedImports);
   });


### PR DESCRIPTION
When generating class-based `CanMatch` guards (`ng g guard --implements=CanMatch --no-functional`), the guard implementation template defines `canMatch(route: Route, segments: UrlSegment[])`.

Previously, the schematic added `'subPath'` instead of `'UrlSegment'` to `@angular/router` named imports. Because `@angular/router` does not export `subPath`, this generated code with broken imports (`Module '"@angular/router"' has no exported member 'subPath'`) while leaving `UrlSegment` unimported (`Cannot find name 'UrlSegment'`).

This change ensures `UrlSegment` is imported when generating `CanMatch` guards.