### PR TITLE
fix(@angular/build): return direct file contents for non-Angular TypeScript files

### DIFF
--- a/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
@@ -456,7 +456,7 @@ export function createCompilerPlugin(
           if (!requiresAngularCompiler(directContents)) {
             return {
               warnings: [createMissingFileDiagnostic(request, args.path, diangosticRoot, false)],
-              contents,
+              contents: directContents,
               loader: 'ts',
               resolveDir: path.dirname(request),
             };


### PR DESCRIPTION
When a TypeScript file is requested that was not emitted by the TypeScript program compiler (`contents === undefined`), the compiler plugin checks whether the file requires Angular compiler transformations via `requiresAngularCompiler(directContents)`.

If the file does not require the Angular compiler, the load hook returns an object with `loader: 'ts'` and a missing file warning so esbuild can compile it directly. However, it previously returned `contents` (which was still `undefined`) instead of `directContents` (which was read directly from disk via `readFile`). This caused esbuild to receive an empty/undefined content object rather than the actual file source code.

This change ensures `contents: directContents` is returned so esbuild can properly transpile the file.