### PR TITLE
refactor(@angular/cli): use Node.js styleText for color helpers

### DIFF
--- a/packages/angular/cli/src/commands/update/utilities/migration.ts
+++ b/packages/angular/cli/src/commands/update/utilities/migration.ts
@@ -13,10 +13,11 @@ import {
   FileSystemSchematicDescription,
   NodeWorkflow,
 } from '@angular-devkit/schematics/tools';
+import { figures } from 'listr2';
 import { SpawnSyncReturns } from 'node:child_process';
 import * as semver from 'semver';
 import { subscribeToWorkflow } from '../../../command-builder/utilities/schematic-workflow';
-import { colors, figures } from '../../../utilities/color';
+import { colors } from '../../../utilities/color';
 import { assertIsError } from '../../../utilities/error';
 import { writeErrorToLogFile } from '../../../utilities/log-file';
 import { formatFiles } from '../../../utilities/prettier';

--- a/packages/angular/cli/src/utilities/color.ts
+++ b/packages/angular/cli/src/utilities/color.ts
@@ -7,8 +7,23 @@
  */
 
 import { WriteStream } from 'node:tty';
+import { styleText } from 'node:util';
 
-export { color as colors, figures } from 'listr2';
+export const colors = Object.freeze({
+  black: (text: string) => styleText('black', text),
+  blue: (text: string) => styleText('blue', text),
+  bold: (text: string) => styleText('bold', text),
+  cyan: (text: string) => styleText('cyan', text),
+  dim: (text: string) => styleText('dim', text),
+  gray: (text: string) => styleText('gray', text),
+  green: (text: string) => styleText('green', text),
+  italic: (text: string) => styleText('italic', text),
+  magenta: (text: string) => styleText('magenta', text),
+  red: (text: string) => styleText('red', text),
+  underline: (text: string) => styleText('underline', text),
+  white: (text: string) => styleText('white', text),
+  yellow: (text: string) => styleText('yellow', text),
+});
 
 export function supportColor(stream: NodeJS.WritableStream = process.stdout): boolean {
   if (stream instanceof WriteStream) {


### PR DESCRIPTION
Replaces listr2 re-exports in the CLI color helper with Node.js built-in `styleText` utilities from `node:util`.

Previously, importing colors from `utilities/color.ts` eagerly pulled in `listr2` along with its transitive dependencies (`wrap-ansi`, `string-width`, `get-east-asian-width`), introducing synchronous ESM module evaluation and ANSI formatting overhead during early CLI startup.