### PR TITLE
fix(@schematics/angular): generate CLAUDE.md for Claude Code instead of AGENTS.md

### DIFF
--- a/packages/schematics/angular/ai-config/index.ts
+++ b/packages/schematics/angular/ai-config/index.ts
@@ -19,7 +19,11 @@ const AGENTS_MD_CFG: ContextFileInfo = {
 
 const AI_TOOLS: { [key in Exclude<Tool, Tool.None>]: ContextFileInfo[] } = {
   ['claude-code']: [
-    AGENTS_MD_CFG,
+    {
+      type: ContextFileType.BestPracticesMd,
+      name: 'CLAUDE.md',
+      directory: '.',
+    },
     {
       type: ContextFileType.McpConfig,
       name: '.mcp.json',

--- a/packages/schematics/angular/ai-config/index_spec.ts
+++ b/packages/schematics/angular/ai-config/index_spec.ts
@@ -32,9 +32,9 @@ describe('AI Config Schematic', () => {
     workspaceTree = await schematicRunner.runSchematic('workspace', workspaceOptions);
   });
 
-  it('should create Angular MCP server config and AGENTS.md for Claude Code', async () => {
+  it('should create Angular MCP server config and CLAUDE.md for Claude Code', async () => {
     const tree = await runAiConfigSchematic([ConfigTool.ClaudeCode]);
-    expect(tree.exists('AGENTS.md')).toBeTruthy();
+    expect(tree.exists('CLAUDE.md')).toBeTruthy();
     expect(tree.exists('.mcp.json')).toBeTruthy();
   });
 
@@ -89,7 +89,7 @@ describe('AI Config Schematic', () => {
 
   it('should omit best practices creation, if the file already exists', async () => {
     const customContent = 'custom user content';
-    workspaceTree.create('AGENTS.md', customContent);
+    workspaceTree.create('CLAUDE.md', customContent);
 
     const messages: string[] = [];
     const loggerSubscription = schematicRunner.logger.subscribe((x) => messages.push(x.message));
@@ -97,9 +97,9 @@ describe('AI Config Schematic', () => {
     try {
       const tree = await runAiConfigSchematic([ConfigTool.ClaudeCode]);
 
-      expect(tree.readContent('AGENTS.md')).toBe(customContent);
+      expect(tree.readContent('CLAUDE.md')).toBe(customContent);
       expect(messages).toContain(
-        `Skipping configuration file for 'ClaudeCode' at './AGENTS.md' because it already exists.\n` +
+        `Skipping configuration file for 'ClaudeCode' at './CLAUDE.md' because it already exists.\n` +
           'This is to prevent overwriting a potentially customized file. ' +
           'If you want to regenerate it with Angular recommended defaults, please delete the existing file and re-run the command.\n' +
           'You can review the latest recommendations at https://angular.dev/ai/develop-with-ai.\n',

--- a/packages/schematics/angular/ai-config/schema.json
+++ b/packages/schematics/angular/ai-config/schema.json
@@ -4,7 +4,7 @@
   "title": "Angular AI Config File Options Schema",
   "type": "object",
   "additionalProperties": false,
-  "description": "Generates AI configuration files for Angular projects. This schematic creates AGENTS.md file and Angular MCP server configuration, improving the quality of AI-generated code and suggestions.",
+  "description": "Generates AI configuration files for Angular projects. This schematic creates instruction files (e.g. AGENTS.md, CLAUDE.md) and Angular MCP server configuration, improving the quality of AI-generated code and suggestions.",
   "properties": {
     "tool": {
       "type": "array",
@@ -20,7 +20,7 @@
           },
           {
             "value": "claude-code",
-            "label": "Claude Code   [ `AGENTS.md` + Angular MCP server config ]"
+            "label": "Claude Code   [ `CLAUDE.md` + Angular MCP server config ]"
           },
           {
             "value": "cursor",
@@ -40,7 +40,7 @@
           }
         ]
       },
-      "description": "Specifies which AI tools to generate configuration files (AGENTS.md, MCP server config) for.",
+      "description": "Specifies which AI tools to generate configuration files (AGENTS.md, CLAUDE.md, MCP server config) for.",
       "items": {
         "type": "string",
         "enum": ["none", "claude-code", "cursor", "gemini-cli", "open-ai-codex", "vscode"]

--- a/packages/schematics/angular/ng-new/index_spec.ts
+++ b/packages/schematics/angular/ng-new/index_spec.ts
@@ -109,7 +109,7 @@ describe('Ng New Schematic', () => {
 
     const tree = await schematicRunner.runSchematic('ng-new', options);
     const files = tree.files;
-    expect(files).toContain('/bar/AGENTS.md');
+    expect(files).toContain('/bar/CLAUDE.md');
     expect(files).toContain('/bar/.mcp.json');
     expect(files).toContain('/bar/.gemini/GEMINI.md');
     expect(files).toContain('/bar/.gemini/settings.json');


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When using `ng new` or `ng generate ai-config` and selecting `Claude Code`, it incorrectly generates `AGENTS.md` for Claude Code.

Issue Number: #33817

## What is the new behavior?

Generates `CLAUDE.md` instead of `AGENTS.md` when `Claude Code` is selected, aligning with Anthropic's official Claude Code documentation for project instructions.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This fixes a regression introduced in 22.1.0 where generating AI configuration for Claude Code (`claude-code`) incorrectly grouped it with other tools that generate `AGENTS.md`. According to Anthropic's official Claude Code documentation, the tool explicitly looks for a `CLAUDE.md` file in the project directory at the start of every session to serve as its system ruleset and permanent memory.

Additionally, this generation strategy creates a `.mcp.json` file. According to the [official Claude Code MCP documentation](https://code.claude.com/docs/en/mcp):
> "Project-scoped servers enable team collaboration by storing configurations in a `.mcp.json` file at your project’s root directory. When you add a project-scoped server, Claude Code automatically creates or updates this file with the appropriate configuration structure. Check `.mcp.json` into version control so everyone on your team gets the same MCP tools and services."
