### PR TITLE
refactor(@angular/ssr): simplify response destroyed/closed check

### DIFF
--- a/packages/angular/ssr/node/src/response.ts
+++ b/packages/angular/ssr/node/src/response.ts
@@ -17,13 +17,11 @@ import type { Http2ServerResponse } from 'node:http2';
  */
 function isResponseDestroyedOrClosed(destination: ServerResponse | Http2ServerResponse): boolean {
   return (
-    Boolean(destination.destroyed) ||
-    Boolean(destination.closed) ||
-    Boolean(destination.writableEnded) ||
+    destination.destroyed ||
+    destination.closed ||
+    destination.writableEnded ||
     ('stream' in destination &&
-      (!destination.stream ||
-        Boolean(destination.stream.destroyed) ||
-        Boolean(destination.stream.closed)))
+      (!destination.stream || destination.stream.destroyed || destination.stream.closed))
   );
 }
 


### PR DESCRIPTION

Simplifies `isResponseDestroyedOrClosed` by directly evaluating boolean properties on the response destination and its underlying stream.
