### PR TITLE
fix(@angular/build): bump undici to 7.29.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "source-map-support": "0.5.21",
     "ts-node": "^10.9.1",
     "tslib": "2.8.1",
-    "undici": "7.28.0",
+    "undici": "7.29.0",
     "unenv": "^1.10.0",
     "verdaccio": "6.2.9",
     "verdaccio-auth-memory": "^10.0.0",

--- a/packages/angular/build/package.json
+++ b/packages/angular/build/package.json
@@ -42,7 +42,7 @@
     "semver": "7.7.4",
     "source-map-support": "0.5.21",
     "tinyglobby": "0.2.15",
-    "undici": "7.28.0",
+    "undici": "7.29.0",
     "vite": "7.3.6",
     "watchpack": "2.5.1"
   },

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -69,7 +69,7 @@
     "@web/test-runner": "0.20.2",
     "browser-sync": "3.0.4",
     "ng-packagr": "21.2.3",
-    "undici": "7.28.0"
+    "undici": "7.29.0"
   },
   "peerDependencies": {
     "@angular/core": "0.0.0-ANGULAR-FW-PEER-DEP",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,8 +288,8 @@ importers:
         specifier: 2.8.1
         version: 2.8.1
       undici:
-        specifier: 7.28.0
-        version: 7.28.0
+        specifier: 7.29.0
+        version: 7.29.0
       unenv:
         specifier: ^1.10.0
         version: 1.10.0
@@ -411,8 +411,8 @@ importers:
         specifier: 0.2.15
         version: 0.2.15
       undici:
-        specifier: 7.28.0
-        version: 7.28.0
+        specifier: 7.29.0
+        version: 7.29.0
       vite:
         specifier: 7.3.6
         version: 7.3.6(@types/node@24.12.2)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
@@ -745,8 +745,8 @@ importers:
         specifier: 21.2.3
         version: 21.2.3(@angular/compiler-cli@21.2.12(@angular/compiler@21.2.12)(typescript@6.0.3))(tslib@2.8.1)(typescript@6.0.3)
       undici:
-        specifier: 7.28.0
-        version: 7.28.0
+        specifier: 7.29.0
+        version: 7.29.0
     optionalDependencies:
       esbuild:
         specifier: 0.28.1
@@ -9222,8 +9222,8 @@ packages:
     resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
     engines: {node: '>=20.18.1'}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unenv@1.10.0:
@@ -19459,7 +19459,7 @@ snapshots:
 
   undici@7.24.4: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unenv@1.10.0:
     dependencies:


### PR DESCRIPTION
Bumps undici to version 7.29.0 to resolve a number of CVEs including CVE-2026-13697 (GHSA-4cwx-7wf7-3272) and CVE-2026-16729 (GHSA-v3r7-h72x-cjcm).

Closes #33822