### PR TITLE
fix(@angular/build): normalize setupFiles paths to POSIX for vitest runner

### DIFF
--- a/packages/angular/build/src/builders/unit-test/options.ts
+++ b/packages/angular/build/src/builders/unit-test/options.ts
@@ -10,7 +10,7 @@ import { type BuilderContext, targetFromTargetString } from '@angular-devkit/arc
 import { constants, promises as fs } from 'node:fs';
 import path from 'node:path';
 import { normalizeCacheOptions } from '../../utils/normalize-cache';
-import { canonicalizePath } from '../../utils/path';
+import { canonicalizePath, toPosixPath } from '../../utils/path';
 import { getProjectRootPaths } from '../../utils/project-metadata';
 import { isTTY } from '../../utils/tty';
 import { Runner, type Schema as UnitTestBuilderOptions } from './schema';
@@ -143,7 +143,7 @@ export async function normalizeOptions(
     quiet: options.quiet ?? (process.env['CI'] ? false : true),
     providersFile: options.providersFile && path.join(workspaceRoot, options.providersFile),
     setupFiles: options.setupFiles
-      ? options.setupFiles.map((setupFile) => path.join(workspaceRoot, setupFile))
+      ? options.setupFiles.map((setupFile) => toPosixPath(path.join(workspaceRoot, setupFile)))
       : [],
     dumpVirtualFiles: options.dumpVirtualFiles,
     listTests: options.listTests,


### PR DESCRIPTION

On Windows, absolute paths generated by joining the workspace root and the configured setup files contain backslashes. This causes a mismatch during test execution when the Vitest in-memory loading plugin resolves paths in POSIX format (with forward slashes) and attempts to look them up in the entry point mapping, leading to failed import resolutions.

Normalizing `setupFiles` paths to POSIX at the options normalization stage ensures consistency across the entire build and execution pipeline, resolving the import resolution errors on Windows.

Closes #33749
