### PR TITLE
ci: limit schematics dependencies rule to minor and patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,7 @@
         "packages/schematics/angular/utility/latest-versions/package.json"
       ],
       "matchPackageNames": ["*"],
+      "matchUpdateTypes": ["minor", "patch"],
       "groupName": "schematics dependencies",
       "lockFileMaintenance": {
         "enabled": false


### PR DESCRIPTION
Add `matchUpdateTypes` to target only minor and patch updates in the schematics dependencies Renovate group configuration.