### PR TITLE
refactor(@angular/build): pre-warm transformer worker pool and pass static options via workerData

### DIFF
--- a/packages/angular/build/src/tools/esbuild/javascript-transformer-worker.ts
+++ b/packages/angular/build/src/tools/esbuild/javascript-transformer-worker.ts
@@ -9,6 +9,7 @@
 import remapping, { type DecodedSourceMap, type EncodedSourceMap } from '@ampproject/remapping';
 import { type PluginItem, transformAsync } from '@babel/core';
 import { createRequire } from 'node:module';
+import { workerData } from 'node:worker_threads';
 import Piscina from 'piscina';
 import { useBabelLinker } from '../../utils/environment-options.js';
 import {
@@ -18,16 +19,15 @@ import {
   loadInputSourceMapFromUrl,
   removeSourceMappingURL,
 } from '../../utils/source-map';
+import { linkWithOxc } from '../angular/linker/oxc-linker.js';
+import { transform as transformWithOxc } from '../oxc/oxc-transform.js';
+import type { JavaScriptTransformerOptions } from './javascript-transformer';
 
 interface JavaScriptTransformRequest {
   filename: string;
   data: string | Uint8Array;
-  sourcemap: boolean;
-  thirdPartySourcemaps: boolean;
-  advancedOptimizations: boolean;
   skipLinker?: boolean;
   sideEffects?: boolean;
-  jit: boolean;
   instrumentForCoverage?: boolean;
 }
 
@@ -35,6 +35,13 @@ interface TransformOptions extends Omit<JavaScriptTransformRequest, 'filename' |
   inputSourceMap?: EncodedSourceMap;
   isAlreadyStripped?: boolean;
 }
+
+const {
+  sourcemap = false,
+  thirdPartySourcemaps = false,
+  advancedOptimizations = false,
+  jit = false,
+} = (workerData || {}) as Partial<JavaScriptTransformerOptions>;
 
 const textDecoder = new TextDecoder();
 const textEncoder = new TextEncoder();
@@ -89,8 +96,7 @@ export default async function transformJavaScript(
   const { filename, data, ...options } = request;
 
   const useInputSourcemap =
-    options.sourcemap &&
-    (!!options.thirdPartySourcemaps || !/[\\/]node_modules[\\/]/.test(filename));
+    sourcemap && (!!thirdPartySourcemaps || !/[\\/]node_modules[\\/]/.test(filename));
 
   let textData: string;
   let inputSourceMap: EncodedSourceMap | undefined;
@@ -145,16 +151,6 @@ export default async function transformJavaScript(
   return Piscina.move(textEncoder.encode(transformedData));
 }
 
-/**
- * Cached instance of the OXC linker module.
- */
-let oxcLinkerModule: typeof import('../angular/linker/oxc-linker.js') | undefined;
-
-/**
- * Cached instance of the OXC transform module.
- */
-let oxcTransformModule: typeof import('../oxc/oxc-transform.js') | undefined;
-
 async function transformJavaScriptImpl(
   filename: string,
   data: string,
@@ -162,8 +158,7 @@ async function transformJavaScriptImpl(
 ): Promise<string> {
   const shouldLink = !options.skipLinker;
   const useInputSourcemap =
-    options.sourcemap &&
-    (!!options.thirdPartySourcemaps || !/[\\/]node_modules[\\/]/.test(filename));
+    sourcemap && (!!thirdPartySourcemaps || !/[\\/]node_modules[\\/]/.test(filename));
 
   let code = data;
   const maps: (DecodedSourceMap | EncodedSourceMap)[] = [];
@@ -198,7 +193,7 @@ async function transformJavaScriptImpl(
               relative: (_from: string, to: string) => to,
             } as never,
             logger: new ConsoleLogger(LogLevel.info),
-            linkerJitMode: options.jit,
+            linkerJitMode: jit,
             // This is a workaround until https://github.com/angular/angular/issues/42769 is fixed.
             sourceMapping: false,
           }) as PluginItem,
@@ -210,10 +205,9 @@ async function transformJavaScriptImpl(
         maps.push(result.map as EncodedSourceMap);
       }
     } else {
-      oxcLinkerModule ??= await import('../angular/linker/oxc-linker.js');
-      const result = oxcLinkerModule.linkWithOxc(filename, code, {
+      const result = linkWithOxc(filename, code, {
         sourcemap: useInputSourcemap,
-        jit: options.jit,
+        jit,
         skipCheck: true,
       });
       code = result.code;
@@ -224,14 +218,13 @@ async function transformJavaScriptImpl(
   }
 
   // Run advanced optimizations using our fast oxc-transform
-  if (options.advancedOptimizations) {
-    oxcTransformModule ??= await import('../oxc/oxc-transform.js');
+  if (advancedOptimizations) {
     const sideEffectFree = options.sideEffects === false;
     const safeAngularPackage =
       sideEffectFree && /[\\/]node_modules[\\/]@angular[\\/]/.test(filename);
     const topLevelSafeMode = !safeAngularPackage;
 
-    const result = oxcTransformModule.transform(filename, code, {
+    const result = transformWithOxc(filename, code, {
       sourcemap: useInputSourcemap,
       sideEffects: options.sideEffects,
       topLevelSafeMode,

--- a/packages/angular/build/src/tools/esbuild/javascript-transformer.ts
+++ b/packages/angular/build/src/tools/esbuild/javascript-transformer.ts
@@ -93,6 +93,7 @@ export class JavaScriptTransformer {
       jit,
     };
     this.#fileCacheKeyBase = Buffer.from(JSON.stringify(this.#commonOptions), 'utf-8');
+    this.#workerPool = this.#ensureWorkerPool();
   }
 
   /**
@@ -130,6 +131,8 @@ export class JavaScriptTransformer {
     const workerPoolOptions: WorkerPoolOptions = {
       filename: require.resolve('./javascript-transformer-worker'),
       maxThreads: this.maxThreads,
+      minThreads: this.maxThreads,
+      workerData: this.#commonOptions,
     };
 
     // Prevent passing SSR `--import` (loader-hooks) from parent to child worker.
@@ -250,7 +253,6 @@ export class JavaScriptTransformer {
         skipLinker: !shouldLink,
         sideEffects,
         instrumentForCoverage,
-        ...this.#commonOptions,
       },
       {
         transferList: isTransferable ? [data.buffer] : undefined,


### PR DESCRIPTION
Eagerly instantiate the worker pool in the JavaScriptTransformer constructor and set minThreads equal to maxThreads so worker threads are pre-warmed upfront during build context setup.

Pass global, static transformer options (sourcemap, thirdPartySourcemaps, advancedOptimizations, and jit) once during pool initialization via Piscina's workerData option instead of redundantly serializing them in per-file IPC task payloads.