### PR TITLE
refactor(@angular/build): decouple compilation abstraction from TypeScript

### DIFF
--- a/packages/angular/build/src/tools/angular/compilation/angular-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/angular-compilation.ts
@@ -19,6 +19,28 @@ export interface EmitFileResult {
   dependencies?: readonly string[];
 }
 
+export interface FileTransformResult {
+  contents: string;
+  watchFiles?: readonly string[];
+}
+
+export interface AngularCompilationOptions {
+  allowJs?: boolean;
+  isolatedModules?: boolean;
+  sourceMap?: boolean;
+  inlineSourceMap?: boolean;
+  _useTypeScriptTranspilation?: boolean;
+  [key: string]: unknown;
+}
+
+export interface AngularCompilationResult {
+  compilerOptions: AngularCompilationOptions;
+  referencedFiles: readonly string[];
+  externalStylesheets?: ReadonlyMap<string, string>;
+  templateUpdates?: ReadonlyMap<string, string>;
+  componentResourcesDependencies?: ReadonlyMap<string, readonly string[]>;
+}
+
 export enum DiagnosticModes {
   None = 0,
   Option = 1 << 0,
@@ -70,24 +92,25 @@ export abstract class AngularCompilation {
     tsconfig: string,
     hostOptions: AngularHostOptions,
     compilerOptionsTransformer?: (compilerOptions: ng.CompilerOptions) => ng.CompilerOptions,
-  ): Promise<{
-    affectedFiles: ReadonlySet<ts.SourceFile>;
-    compilerOptions: ng.CompilerOptions;
-    referencedFiles: readonly string[];
-    externalStylesheets?: ReadonlyMap<string, string>;
-    templateUpdates?: ReadonlyMap<string, string>;
-    componentResourcesDependencies?: ReadonlyMap<string, readonly string[]>;
-  }>;
+  ): Promise<AngularCompilationResult>;
 
-  abstract emitAffectedFiles(): Iterable<EmitFileResult> | Promise<Iterable<EmitFileResult>>;
+  emitAffectedFiles(): Iterable<EmitFileResult> | Promise<Iterable<EmitFileResult>> {
+    return [];
+  }
 
-  protected abstract collectDiagnostics(
+  transformFile?(filename: string, content: string): Promise<FileTransformResult | null>;
+
+  protected collectDiagnostics?(
     modes: DiagnosticModes,
   ): Iterable<ts.Diagnostic> | Promise<Iterable<ts.Diagnostic>>;
 
   async diagnoseFiles(
     modes = DiagnosticModes.All,
   ): Promise<{ errors?: PartialMessage[]; warnings?: PartialMessage[] }> {
+    if (!this.collectDiagnostics) {
+      return {};
+    }
+
     const result: { errors?: PartialMessage[]; warnings?: PartialMessage[] } = {};
 
     // Avoid loading typescript until actually needed.
@@ -95,7 +118,12 @@ export abstract class AngularCompilation {
     const typescript = await AngularCompilation.loadTypescript();
 
     await profileAsync('NG_DIAGNOSTICS_TOTAL', async () => {
-      for (const diagnostic of await this.collectDiagnostics(modes)) {
+      const diagnostics = await this.collectDiagnostics?.(modes);
+      if (!diagnostics) {
+        return;
+      }
+
+      for (const diagnostic of diagnostics) {
         const message = convertTypeScriptDiagnostic(typescript, diagnostic);
         if (diagnostic.category === typescript.DiagnosticCategory.Error) {
           (result.errors ??= []).push(message);

--- a/packages/angular/build/src/tools/angular/compilation/angular-compilation_spec.ts
+++ b/packages/angular/build/src/tools/angular/compilation/angular-compilation_spec.ts
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import type { AngularHostOptions } from '../angular-host';
+import {
+  AngularCompilation,
+  AngularCompilationResult,
+  NoopCompilation,
+  createAngularCompilation,
+} from './index';
+
+describe('AngularCompilation', () => {
+  class CustomTransformCompilation extends AngularCompilation {
+    override async initialize(): Promise<AngularCompilationResult> {
+      return {
+        compilerOptions: { allowJs: false },
+        referencedFiles: ['/src/main.ts'],
+      };
+    }
+
+    override async transformFile(filename: string, content: string) {
+      if (filename.endsWith('.ts')) {
+        return {
+          contents: content + '\n// transformed',
+          watchFiles: ['/src/dep.ts'],
+        };
+      }
+
+      return null;
+    }
+  }
+
+  it('allows implementing on-demand transformFile without collectDiagnostics', async () => {
+    const compilation = new CustomTransformCompilation();
+    const initResult = await compilation.initialize();
+
+    expect(initResult.referencedFiles).toEqual(['/src/main.ts']);
+    expect(initResult.compilerOptions.allowJs).toBe(false);
+
+    const transformResult = await compilation.transformFile?.(
+      '/src/main.ts',
+      'console.log("hello");',
+    );
+    expect(transformResult).toEqual({
+      contents: 'console.log("hello");\n// transformed',
+      watchFiles: ['/src/dep.ts'],
+    });
+
+    const diagnostics = await compilation.diagnoseFiles();
+    expect(diagnostics).toEqual({});
+  });
+
+  describe('NoopCompilation', () => {
+    it('initializes with empty referencedFiles and compiler options', async () => {
+      const compilation = new NoopCompilation();
+      const mockHostOptions = {} as AngularHostOptions;
+      const result = await compilation.initialize('tsconfig.json', mockHostOptions, (opts) => ({
+        ...opts,
+        customOption: true,
+      }));
+
+      expect(result.referencedFiles).toEqual([]);
+      expect(result.compilerOptions['customOption']).toBe(true);
+    });
+
+    it('throws when calling collectDiagnostics or emitAffectedFiles', () => {
+      const compilation = new NoopCompilation();
+      expect(() =>
+        (compilation as unknown as { collectDiagnostics(): unknown }).collectDiagnostics(),
+      ).toThrowError('Not available when using noop compilation.');
+      expect(() => compilation.emitAffectedFiles()).toThrowError(
+        'Not available when using noop compilation.',
+      );
+    });
+  });
+
+  describe('createAngularCompilation', () => {
+    it('creates JitCompilation when mode is "jit"', async () => {
+      const compilation = await createAngularCompilation('jit', true, false);
+      expect(compilation.constructor.name).toBe('JitCompilation');
+    });
+
+    it('creates AotCompilation when mode is "aot"', async () => {
+      const compilation = await createAngularCompilation('aot', true, false);
+      expect(compilation.constructor.name).toBe('AotCompilation');
+    });
+
+    it('creates JitCompilation when mode is boolean true (legacy)', async () => {
+      const compilation = await createAngularCompilation(true, true, false);
+      expect(compilation.constructor.name).toBe('JitCompilation');
+    });
+
+    it('creates AotCompilation when mode is boolean false (legacy)', async () => {
+      const compilation = await createAngularCompilation(false, true, false);
+      expect(compilation.constructor.name).toBe('AotCompilation');
+    });
+
+    it('throws when mode is "transform"', async () => {
+      await expectAsync(createAngularCompilation('transform', true, false)).toBeRejectedWithError(
+        'Transform compilation mode is not supported.',
+      );
+    });
+  });
+});

--- a/packages/angular/build/src/tools/angular/compilation/aot-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/aot-compilation.ts
@@ -20,7 +20,12 @@ import {
 import { replaceBootstrap } from '../transformers/jit-bootstrap-transformer';
 import { lazyRoutesTransformer } from '../transformers/lazy-routes-transformer';
 import { createWorkerTransformer } from '../transformers/web-worker-transformer';
-import { AngularCompilation, DiagnosticModes, EmitFileResult } from './angular-compilation';
+import {
+  AngularCompilation,
+  AngularCompilationResult,
+  DiagnosticModes,
+  EmitFileResult,
+} from './angular-compilation';
 import { collectHmrCandidates } from './hmr-candidates';
 import { printSourceFileWithMap } from './typescript-printer';
 
@@ -59,14 +64,7 @@ export class AotCompilation extends AngularCompilation {
     tsconfig: string,
     hostOptions: AngularHostOptions,
     compilerOptionsTransformer?: (compilerOptions: ng.CompilerOptions) => ng.CompilerOptions,
-  ): Promise<{
-    affectedFiles: ReadonlySet<ts.SourceFile>;
-    compilerOptions: ng.CompilerOptions;
-    referencedFiles: readonly string[];
-    externalStylesheets?: ReadonlyMap<string, string>;
-    templateUpdates?: ReadonlyMap<string, string>;
-    componentResourcesDependencies?: ReadonlyMap<string, readonly string[]>;
-  }> {
+  ): Promise<AngularCompilationResult> {
     // Dynamically load the Angular compiler CLI package
     const { NgtscProgram, OptimizeFor } = await AngularCompilation.loadCompilerCli();
 
@@ -231,7 +229,6 @@ export class AotCompilation extends AngularCompilation {
     );
 
     return {
-      affectedFiles,
       compilerOptions,
       referencedFiles,
       externalStylesheets: hostOptions.externalStylesheets,
@@ -240,7 +237,7 @@ export class AotCompilation extends AngularCompilation {
     };
   }
 
-  *collectDiagnostics(modes: DiagnosticModes): Iterable<ts.Diagnostic> {
+  protected override *collectDiagnostics(modes: DiagnosticModes): Iterable<ts.Diagnostic> {
     assert(this.#state, 'Angular compilation must be initialized prior to collecting diagnostics.');
     const {
       affectedFiles,
@@ -313,7 +310,7 @@ export class AotCompilation extends AngularCompilation {
     }
   }
 
-  emitAffectedFiles(): Iterable<EmitFileResult> {
+  override emitAffectedFiles(): Iterable<EmitFileResult> {
     assert(this.#state, 'Angular compilation must be initialized prior to emitting files.');
     const {
       affectedFiles,

--- a/packages/angular/build/src/tools/angular/compilation/factory.ts
+++ b/packages/angular/build/src/tools/angular/compilation/factory.ts
@@ -9,26 +9,35 @@
 import { useParallelTs } from '../../../utils/environment-options';
 import type { AngularCompilation } from './angular-compilation';
 
+export type AngularCompilationMode = 'aot' | 'jit' | 'transform';
+
 /**
  * Creates an Angular compilation object that can be used to perform Angular application
- * compilation either for AOT or JIT mode. By default a parallel compilation is created
+ * compilation either for AOT, JIT, or on-demand transform mode. By default a parallel compilation is created
  * that uses a Node.js worker thread.
- * @param jit True, for Angular JIT compilation; False, for Angular AOT compilation.
+ * @param mode True or 'jit' for JIT mode; False or 'aot' for AOT compilation; 'transform' for on-demand transformation.
  * @param browserOnlyBuild True, for browser only builds; False, for browser and server builds.
+ * @param parallel True to execute compilation in a worker thread.
  * @returns An instance of an Angular compilation object.
  */
 export async function createAngularCompilation(
-  jit: boolean,
+  mode: boolean | AngularCompilationMode,
   browserOnlyBuild: boolean,
   parallel: boolean = useParallelTs,
 ): Promise<AngularCompilation> {
+  if (mode === 'transform') {
+    throw new Error('Transform compilation mode is not supported.');
+  }
+
+  const isJit = mode === true || mode === 'jit';
+
   if (parallel) {
     const { ParallelCompilation } = await import('./parallel-compilation');
 
-    return new ParallelCompilation(jit, browserOnlyBuild);
+    return new ParallelCompilation(isJit, browserOnlyBuild);
   }
 
-  if (jit) {
+  if (isJit) {
     const { JitCompilation } = await import('./jit-compilation');
 
     return new JitCompilation(browserOnlyBuild);

--- a/packages/angular/build/src/tools/angular/compilation/index.ts
+++ b/packages/angular/build/src/tools/angular/compilation/index.ts
@@ -6,6 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-export { AngularCompilation, DiagnosticModes } from './angular-compilation';
-export { createAngularCompilation } from './factory';
+export {
+  AngularCompilation,
+  type AngularCompilationOptions,
+  type AngularCompilationResult,
+  DiagnosticModes,
+  type EmitFileResult,
+  type FileTransformResult,
+} from './angular-compilation';
+export { createAngularCompilation, type AngularCompilationMode } from './factory';
 export { NoopCompilation } from './noop-compilation';

--- a/packages/angular/build/src/tools/angular/compilation/jit-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/jit-compilation.ts
@@ -14,7 +14,12 @@ import { AngularHostOptions, createAngularCompilerHost } from '../angular-host';
 import { createJitResourceTransformer } from '../transformers/jit-resource-transformer';
 import { lazyRoutesTransformer } from '../transformers/lazy-routes-transformer';
 import { createWorkerTransformer } from '../transformers/web-worker-transformer';
-import { AngularCompilation, DiagnosticModes, EmitFileResult } from './angular-compilation';
+import {
+  AngularCompilation,
+  AngularCompilationResult,
+  DiagnosticModes,
+  EmitFileResult,
+} from './angular-compilation';
 
 class JitCompilationState {
   constructor(
@@ -37,11 +42,7 @@ export class JitCompilation extends AngularCompilation {
     tsconfig: string,
     hostOptions: AngularHostOptions,
     compilerOptionsTransformer?: (compilerOptions: ng.CompilerOptions) => ng.CompilerOptions,
-  ): Promise<{
-    affectedFiles: ReadonlySet<ts.SourceFile>;
-    compilerOptions: ng.CompilerOptions;
-    referencedFiles: readonly string[];
-  }> {
+  ): Promise<AngularCompilationResult> {
     // Dynamically load the Angular compiler CLI package
     const { constructorParametersDownlevelTransform } =
       await import('@angular/compiler-cli/private/tooling');
@@ -85,10 +86,10 @@ export class JitCompilation extends AngularCompilation {
       .getSourceFiles()
       .map((sourceFile) => sourceFile.fileName);
 
-    return { affectedFiles, compilerOptions, referencedFiles };
+    return { compilerOptions, referencedFiles };
   }
 
-  *collectDiagnostics(modes: DiagnosticModes): Iterable<ts.Diagnostic> {
+  protected override *collectDiagnostics(modes: DiagnosticModes): Iterable<ts.Diagnostic> {
     assert(this.#state, 'Compilation must be initialized prior to collecting diagnostics.');
     const { typeScriptProgram } = this.#state;
 
@@ -110,7 +111,7 @@ export class JitCompilation extends AngularCompilation {
     }
   }
 
-  emitAffectedFiles(): Iterable<EmitFileResult> {
+  override emitAffectedFiles(): Iterable<EmitFileResult> {
     assert(this.#state, 'Compilation must be initialized prior to emitting files.');
     const {
       compilerHost,

--- a/packages/angular/build/src/tools/angular/compilation/noop-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/noop-compilation.ts
@@ -7,33 +7,28 @@
  */
 
 import type * as ng from '@angular/compiler-cli';
-import type ts from 'typescript';
 import { AngularHostOptions } from '../angular-host';
-import { AngularCompilation } from './angular-compilation';
+import { AngularCompilation, AngularCompilationResult } from './angular-compilation';
 
 export class NoopCompilation extends AngularCompilation {
   async initialize(
     tsconfig: string,
     hostOptions: AngularHostOptions,
     compilerOptionsTransformer?: (compilerOptions: ng.CompilerOptions) => ng.CompilerOptions,
-  ): Promise<{
-    affectedFiles: ReadonlySet<ts.SourceFile>;
-    compilerOptions: ng.CompilerOptions;
-    referencedFiles: readonly string[];
-  }> {
+  ): Promise<AngularCompilationResult> {
     // Load the compiler configuration and transform as needed
     const { options: originalCompilerOptions } = await this.loadConfiguration(tsconfig);
     const compilerOptions =
       compilerOptionsTransformer?.(originalCompilerOptions) ?? originalCompilerOptions;
 
-    return { affectedFiles: new Set(), compilerOptions, referencedFiles: [] };
+    return { compilerOptions, referencedFiles: [] };
   }
 
-  collectDiagnostics(): never {
+  protected override collectDiagnostics(): never {
     throw new Error('Not available when using noop compilation.');
   }
 
-  emitAffectedFiles(): never {
+  override emitAffectedFiles(): never {
     throw new Error('Not available when using noop compilation.');
   }
 }

--- a/packages/angular/build/src/tools/angular/compilation/parallel-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/parallel-compilation.ts
@@ -10,11 +10,15 @@ import type { CompilerOptions } from '@angular/compiler-cli';
 import type { PartialMessage } from 'esbuild';
 import { createRequire } from 'node:module';
 import { MessageChannel } from 'node:worker_threads';
-import type { SourceFile } from 'typescript';
 import { WorkerPool } from '../../../utils/worker-pool';
 import { mergeCumulativeDurations } from '../../esbuild/profiling';
 import type { AngularHostOptions } from '../angular-host';
-import { AngularCompilation, DiagnosticModes, EmitFileResult } from './angular-compilation';
+import {
+  AngularCompilation,
+  AngularCompilationResult,
+  DiagnosticModes,
+  EmitFileResult,
+} from './angular-compilation';
 
 /**
  * An Angular compilation which uses a Node.js Worker thread to load and execute
@@ -47,12 +51,7 @@ export class ParallelCompilation extends AngularCompilation {
     tsconfig: string,
     hostOptions: AngularHostOptions,
     compilerOptionsTransformer?: (compilerOptions: CompilerOptions) => CompilerOptions,
-  ): Promise<{
-    affectedFiles: ReadonlySet<SourceFile>;
-    compilerOptions: CompilerOptions;
-    referencedFiles: readonly string[];
-    externalStylesheets?: ReadonlyMap<string, string>;
-  }> {
+  ): Promise<AngularCompilationResult> {
     const stylesheetChannel = new MessageChannel();
     // The request identifier is required because Angular can issue multiple concurrent requests
     stylesheetChannel.port1.on(

--- a/packages/angular/build/src/tools/angular/compilation/parallel-worker.ts
+++ b/packages/angular/build/src/tools/angular/compilation/parallel-worker.ts
@@ -13,7 +13,11 @@ import { type MessagePort, receiveMessageOnPort } from 'node:worker_threads';
 import { initializeHash } from '../../../utils/hash';
 import { SourceFileCache } from '../../esbuild/angular/source-file-cache';
 import { getAndClearCumulativeDurations } from '../../esbuild/profiling';
-import type { AngularCompilation, DiagnosticModes } from './angular-compilation';
+import type {
+  AngularCompilation,
+  AngularCompilationResult,
+  DiagnosticModes,
+} from './angular-compilation';
 import { AotCompilation } from './aot-compilation';
 import { JitCompilation } from './jit-compilation';
 
@@ -33,7 +37,7 @@ let compilation: AngularCompilation | undefined;
 
 const sourceFileCache = new SourceFileCache();
 
-export async function initialize(request: InitRequest) {
+export async function initialize(request: InitRequest): Promise<AngularCompilationResult> {
   await initializeHash();
   compilation ??= request.jit
     ? new JitCompilation(request.browserOnlyBuild)

--- a/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
@@ -362,24 +362,26 @@ export function createCompilerPlugin(
           }
         }
 
-        // Update TypeScript file output cache for all affected files
-        try {
-          await profileAsync('NG_EMIT_TS', async () => {
-            for (const { filename, contents } of await compilation.emitAffectedFiles()) {
-              typeScriptFileCache.set(path.normalize(filename), contents);
-            }
-          });
-        } catch (error) {
-          (result.errors ??= []).push({
-            text: 'Angular compilation emit failed.',
-            location: null,
-            notes: [
-              {
-                text: error instanceof Error ? (error.stack ?? error.message) : `${error}`,
-                location: null,
-              },
-            ],
-          });
+        // Update TypeScript file output cache for all affected files if not using on-demand transforms
+        if (!compilation.transformFile) {
+          try {
+            await profileAsync('NG_EMIT_TS', async () => {
+              for (const { filename, contents } of await compilation.emitAffectedFiles()) {
+                typeScriptFileCache.set(path.normalize(filename), contents);
+              }
+            });
+          } catch (error) {
+            (result.errors ??= []).push({
+              text: 'Angular compilation emit failed.',
+              location: null,
+              notes: [
+                {
+                  text: error instanceof Error ? (error.stack ?? error.message) : `${error}`,
+                  location: null,
+                },
+              ],
+            });
+          }
         }
 
         const diagnostics = await compilation.diagnoseFiles(
@@ -434,6 +436,35 @@ export function createCompilerPlugin(
         // cache is later stored to disk, then the options that affect transform output
         // would need to be added to the key as well as a check for any change of content.
         let contents = typeScriptFileCache.get(request);
+        let directContents: string | undefined;
+
+        if (contents === undefined && compilation.transformFile) {
+          try {
+            directContents = await readFile(request, 'utf-8');
+            const transformResult = await compilation.transformFile(request, directContents);
+            if (transformResult) {
+              contents = transformResult.contents;
+              if (transformResult.watchFiles) {
+                referencedFileTracker.add(request, transformResult.watchFiles);
+              }
+            }
+          } catch (error) {
+            return {
+              errors: [
+                {
+                  text: 'Angular compilation transform failed.',
+                  location: { file: request },
+                  notes: [
+                    {
+                      text: error instanceof Error ? (error.stack ?? error.message) : `${error}`,
+                      location: null,
+                    },
+                  ],
+                },
+              ],
+            };
+          }
+        }
 
         if (contents === undefined) {
           // If the Angular compilation had errors the file may not have been emitted.
@@ -452,7 +483,7 @@ export function createCompilerPlugin(
 
           // Evaluate whether the file requires the Angular compiler transpilation.
           // If not, issue a warning but allow bundler to process the file (no type-checking).
-          const directContents = await readFile(request, 'utf-8');
+          directContents ??= await readFile(request, 'utf-8');
           if (!requiresAngularCompiler(directContents)) {
             return {
               warnings: [createMissingFileDiagnostic(request, args.path, diangosticRoot, false)],


### PR DESCRIPTION
Decouple the AngularCompilation base class and related compilation interfaces from TypeScript-specific AST types (ts.SourceFile) and diagnostics, allowing non-TypeScript and on-demand preprocessor/transformer compilation implementations.

This introduces AngularCompilationResult, AngularCompilationOptions, and FileTransformResult while making collectDiagnostics optional on AngularCompilation so that non-TypeScript compilations can bypass TypeScript diagnostic loading. An optional transformFile hook is also added to AngularCompilation for on-demand transformation during bundling, and createCompilerPlugin is updated to support on-demand streaming transforms in build.onLoad while skipping upfront emit in build.onStart. AotCompilation, JitCompilation, NoopCompilation, and ParallelCompilation are updated to conform to AngularCompilationResult, and createAngularCompilation now supports explicit compilation modes.