### PR TITLE
fix(@angular/ssr): abort web request signal when node request is aborted

### DIFF
--- a/packages/angular/ssr/node/src/request.ts
+++ b/packages/angular/ssr/node/src/request.ts
@@ -55,9 +55,18 @@ export function createWebRequestFromNodeRequest(
   const { headers, method = 'GET' } = nodeRequest;
   const withBody = method !== 'GET' && method !== 'HEAD';
   const referrer = headers.referer && URL.canParse(headers.referer) ? headers.referer : undefined;
+  const controller = new AbortController();
+  if (nodeRequest.aborted) {
+    controller.abort();
+  } else {
+    const onAbort = () => controller.abort();
+    nodeRequest.once('aborted', onAbort);
+    nodeRequest.once('close', () => nodeRequest.off('aborted', onAbort));
+  }
 
   return new Request(createRequestUrl(nodeRequest, trustProxyHeadersNormalized), {
     method,
+    signal: controller.signal,
     headers: createRequestHeaders(headers),
     body: withBody ? nodeRequest : undefined,
     duplex: withBody ? 'half' : undefined,

--- a/packages/angular/ssr/node/test/request_http1_spec.ts
+++ b/packages/angular/ssr/node/test/request_http1_spec.ts
@@ -208,5 +208,23 @@ describe('createWebRequestFromNodeRequest (HTTP/1.1)', () => {
 
       expect(webRequest.signal.aborted).toBeTrue();
     });
+
+    it('should create an aborted web request signal when the node request is already aborted', async () => {
+      const nodeRequest = await extractNodeRequest(() => {
+        request({
+          hostname: 'localhost',
+          port,
+          path: '/already-aborted',
+          method: 'GET',
+        }).end();
+      });
+
+      Object.defineProperty(nodeRequest, 'aborted', { get: () => true, configurable: true });
+
+      const webRequest = createWebRequestFromNodeRequest(nodeRequest);
+      expect(webRequest.signal.aborted).toBeTrue();
+
+      delete (nodeRequest as { aborted?: boolean }).aborted;
+    });
   });
 });

--- a/packages/angular/ssr/node/test/request_http1_spec.ts
+++ b/packages/angular/ssr/node/test/request_http1_spec.ts
@@ -189,4 +189,24 @@ describe('createWebRequestFromNodeRequest (HTTP/1.1)', () => {
       expect(await webRequest.text()).toBe('');
     });
   });
+
+  describe('abort handling', () => {
+    it('should abort the web request signal when the node request is aborted', async () => {
+      const nodeRequest = await extractNodeRequest(() => {
+        request({
+          hostname: 'localhost',
+          port,
+          path: '/abort',
+          method: 'GET',
+        }).end();
+      });
+
+      const webRequest = createWebRequestFromNodeRequest(nodeRequest);
+      expect(webRequest.signal.aborted).toBeFalse();
+
+      nodeRequest.emit('aborted');
+
+      expect(webRequest.signal.aborted).toBeTrue();
+    });
+  });
 });

--- a/packages/angular/ssr/node/test/request_http2_spec.ts
+++ b/packages/angular/ssr/node/test/request_http2_spec.ts
@@ -188,4 +188,24 @@ describe('createWebRequestFromNodeRequest (HTTP/2)', () => {
       expect(await webRequest.text()).toBe('');
     });
   });
+
+  describe('abort handling', () => {
+    it('should abort the web request signal when the node request is aborted', async () => {
+      const nodeRequest = await extractNodeRequest(() => {
+        client
+          .request({
+            ':path': '/abort',
+            ':method': 'GET',
+          })
+          .end();
+      });
+
+      const webRequest = createWebRequestFromNodeRequest(nodeRequest);
+      expect(webRequest.signal.aborted).toBeFalse();
+
+      nodeRequest.emit('aborted');
+
+      expect(webRequest.signal.aborted).toBeTrue();
+    });
+  });
 });

--- a/packages/angular/ssr/node/test/request_http2_spec.ts
+++ b/packages/angular/ssr/node/test/request_http2_spec.ts
@@ -207,5 +207,23 @@ describe('createWebRequestFromNodeRequest (HTTP/2)', () => {
 
       expect(webRequest.signal.aborted).toBeTrue();
     });
+
+    it('should create an aborted web request signal when the node request is already aborted', async () => {
+      const nodeRequest = await extractNodeRequest(() => {
+        client
+          .request({
+            ':path': '/already-aborted',
+            ':method': 'GET',
+          })
+          .end();
+      });
+
+      Object.defineProperty(nodeRequest, 'aborted', { get: () => true, configurable: true });
+
+      const webRequest = createWebRequestFromNodeRequest(nodeRequest);
+      expect(webRequest.signal.aborted).toBeTrue();
+
+      delete (nodeRequest as { aborted?: boolean }).aborted;
+    });
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When converting a Node.js `IncomingMessage` or `Http2ServerRequest` into a Web `Request` object in `@angular/ssr`, if the underlying Node request is aborted/closed prematurely, the Web `Request` object's `signal` does not abort.

## What is the new behavior?

Connects an `AbortController` to the `aborted` event on the Node.js request so that the Web `Request`'s `signal` is aborted whenever the incoming Node request is aborted.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No