### PR TITLE
fix(@angular/build): serialize server manifest asset paths

### DIFF
--- a/packages/angular/build/src/utils/server-rendering/manifest.ts
+++ b/packages/angular/build/src/utils/server-rendering/manifest.ts
@@ -183,8 +183,10 @@ export function generateAngularServerAppManifest(
         pos = file.text.indexOf('\r\n', pos + 2);
       }
 
+      // Asset paths can contain prerendered route values. Serialize both path uses before embedding
+      // them in the executable server manifest so they remain JavaScript string data.
       serverAssets[file.path] =
-        `{size: ${size}, hash: '${file.hash}', text: () => import('./${jsChunkFilePath}').then(m => m.default)}`;
+        `{size: ${size}, hash: '${file.hash}', text: () => import(${JSON.stringify(`./${jsChunkFilePath}`)}).then(m => m.default)}`;
     }
   }
 
@@ -203,7 +205,7 @@ export default {
   entryPointToBrowserMapping: ${JSON.stringify(entryPointToBrowserMapping, undefined, 2)},
   assets: {
     ${Object.entries(serverAssets)
-      .map(([key, value]) => `'${key}': ${value}`)
+      .map(([key, value]) => `${JSON.stringify(key)}: ${value}`)
       .join(',\n    ')}
   },
 };

--- a/packages/angular/build/src/utils/server-rendering/manifest_spec.ts
+++ b/packages/angular/build/src/utils/server-rendering/manifest_spec.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { transform } from 'esbuild';
+import { BuildOutputFileType, createOutputFile } from '../../tools/esbuild/bundler-files';
+import { generateAngularServerAppManifest } from './manifest';
+
+describe('generateAngularServerAppManifest', () => {
+  it('serializes asset paths embedded in the executable manifest', async () => {
+    const assetPath = "products/quote's-name/index.html";
+    const chunkPath = `assets-chunks/${assetPath.replace(/[./]/g, '_')}.mjs`;
+    const asset = createOutputFile(assetPath, '<html></html>', BuildOutputFileType.Browser);
+
+    const { manifestContent } = generateAngularServerAppManifest(
+      new Map([[assetPath, asset]]),
+      [],
+      false,
+      undefined,
+      undefined,
+      '/',
+      new Set(),
+      { inputs: {}, outputs: {} },
+      undefined,
+    );
+
+    expect(manifestContent).toContain(`${JSON.stringify(assetPath)}: {`);
+    expect(manifestContent).toContain(`import(${JSON.stringify(`./${chunkPath}`)})`);
+    expect(manifestContent).not.toContain(`'${assetPath}':`);
+
+    const { warnings } = await transform(manifestContent);
+    expect(warnings).toEqual([]);
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Prerendered route parameters can become HTML output paths. The server manifest
generator then embeds each output path into executable JavaScript in two places
without serializing it as a JavaScript string.

The vulnerable code is in
[`generateAngularServerAppManifest()`](https://github.com/angular/angular-cli/blob/9a1b250bbd3617ce66ff67730075dcda054b5e79/packages/angular/build/src/utils/server-rendering/manifest.ts#L186-L207):

```ts
serverAssets[file.path] =
  `{size: ${size}, hash: '${file.hash}', text: () => import('./${jsChunkFilePath}').then(m => m.default)}`;

// ...

Object.entries(serverAssets)
  .map(([key, value]) => `'${key}': ${value}`)
```

`file.path` is used as a single-quoted object key and its derived chunk path is
used as a single-quoted dynamic import specifier. A quote or line terminator in
a route-derived output path is therefore interpreted as JavaScript syntax
instead of remaining string data.

The source-to-sink path is:

```text
getPrerenderParams() route value
  -> prerendered <route>/index.html output path
  -> additionalHtmlOutputFiles
  -> generateAngularServerAppManifest()
  -> unescaped object key and dynamic import specifier
  -> executable angular-app-manifest.mjs
```

Because `main.server.mjs` imports the generated manifest, injected source can
execute when the emitted Node server artifact is imported or started. The
build itself does not need to execute the inserted source.

Issue Number: N/A

## What is the new behavior?

Both route-derived path uses are emitted with `JSON.stringify()`. This keeps
quotes, line terminators, backslashes, and other JavaScript-significant
characters inside string literals.

The regression test supplies a file-system-valid asset path containing an
apostrophe, verifies the exact serialized object key and import specifier, and
parses the complete generated manifest with esbuild.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The affected path is part of the standard application builder's SSR/prerender
flow. The fix does not change safe asset paths, chunk naming, route semantics,
or the generated manifest API.

Validation:

```text
pnpm bazel test //packages/angular/build:test --test_filter='generateAngularServerAppManifest'
```
