### PR TITLE
perf(@angular/cli): lazily resolve package manager version to optimize startup

### DIFF
--- a/packages/angular/cli/src/command-builder/command-module.ts
+++ b/packages/angular/cli/src/command-builder/command-module.ts
@@ -162,16 +162,9 @@ export abstract class CommandModule<T extends {} = {}> implements CommandModuleI
       return undefined;
     }
 
-    let version: string | undefined;
-    try {
-      version = await this.context.packageManager.getVersion();
-    } catch {
-      // Ignore errors if the package manager is not available.
-    }
-
     return new AnalyticsCollector(this.context.logger, userId, {
       name: this.context.packageManager.name,
-      version,
+      version: this.context.packageManager.version,
     });
   }
 

--- a/packages/angular/cli/src/package-managers/factory.ts
+++ b/packages/angular/cli/src/package-managers/factory.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import assert from 'node:assert/strict';
 import { major } from 'semver';
 import { discover } from './discovery';
 import { Host, NodeJS_HOST } from './host';
@@ -25,35 +24,11 @@ export type ConfiguredPackageManagerInfo = [name?: PackageManagerName, version?:
 const DEFAULT_PACKAGE_MANAGER: PackageManagerName = 'npm';
 
 /**
- * Gets the version of the package manager.
- * @param host A `Host` instance for running commands.
- * @param cwd The absolute path to the working directory.
- * @param name The name of the package manager.
- * @param logger An optional logger instance.
- * @returns A promise that resolves to the version string.
- */
-async function getPackageManagerVersion(
-  host: Host,
-  cwd: string,
-  name: PackageManagerName,
-  logger?: Logger,
-): Promise<string> {
-  const descriptor = SUPPORTED_PACKAGE_MANAGERS[name];
-  logger?.debug(`Getting ${name} version...`);
-
-  const { stdout } = await host.runCommand(descriptor.binary, descriptor.versionCommand, { cwd });
-  const version = stdout.trim();
-  logger?.debug(`${name} version is '${version}'.`);
-
-  return version;
-}
-
-/**
  * Determines the package manager to use for a given project.
  *
  * This function will determine the package manager by checking for a configured
  * package manager, discovering the package manager from lockfiles, or falling
- * back to a default. It also handles differentiation between yarn classic and modern.
+ * back to a default.
  *
  * @param host A `Host` instance for interacting with the file system and running commands.
  * @param cwd The directory to start the search from.
@@ -66,7 +41,6 @@ async function determinePackageManager(
   cwd: string,
   configured: ConfiguredPackageManagerInfo = [],
   logger?: Logger,
-  dryRun?: boolean,
 ): Promise<{
   name: PackageManagerName;
   source: 'configured' | 'discovered' | 'default';
@@ -93,24 +67,11 @@ async function determinePackageManager(
     }
   }
 
-  if (name === 'yarn' && !dryRun) {
-    assert.deepStrictEqual(
-      SUPPORTED_PACKAGE_MANAGERS.yarn.versionCommand,
-      SUPPORTED_PACKAGE_MANAGERS['yarn-classic'].versionCommand,
-      'Yarn and Yarn Classic version commands must match for detection logic to be valid.',
-    );
-
-    try {
-      version ??= await getPackageManagerVersion(host, cwd, name, logger);
-      if (version && major(version) < 2) {
-        name = 'yarn-classic';
-        logger?.debug(`Detected yarn classic. Using 'yarn-classic'.`);
-      }
-    } catch {
-      logger?.debug('Failed to get yarn version.');
+  if (name === 'yarn' && version) {
+    if (major(version) < 2) {
+      name = 'yarn-classic';
+      logger?.debug(`Detected yarn classic from configured version. Using 'yarn-classic'.`);
     }
-  } else if (name === 'yarn') {
-    logger?.debug('Skipping yarn version check due to dry run. Assuming modern yarn.');
   }
 
   return { name, source, version };
@@ -135,33 +96,12 @@ export async function createPackageManager(options: {
   const { cwd, configuredPackageManager, logger, dryRun, tempDirectory } = options;
   const host = NodeJS_HOST;
 
-  const result = await determinePackageManager(host, cwd, configuredPackageManager, logger, dryRun);
-  const { name, source } = result;
-  let { version } = result;
+  const result = await determinePackageManager(host, cwd, configuredPackageManager, logger);
+  const { name, version } = result;
 
   const descriptor = SUPPORTED_PACKAGE_MANAGERS[name];
   if (!descriptor) {
     throw new Error(`Unsupported package manager: "${name}"`);
-  }
-
-  // Do not verify if the package manager is installed during a dry run.
-  let initializationError: Error | undefined;
-  if (!dryRun && !version) {
-    try {
-      version = await getPackageManagerVersion(host, cwd, name, logger);
-    } catch {
-      if (source === 'default') {
-        initializationError = new Error(
-          `'${DEFAULT_PACKAGE_MANAGER}' was selected as the default package manager, but it is not installed or` +
-            ` cannot be found in the PATH. Please install '${DEFAULT_PACKAGE_MANAGER}' to continue.`,
-        );
-      } else {
-        initializationError = new Error(
-          `The project is configured to use '${name}', but it is not installed or cannot be` +
-            ` found in the PATH. Please install '${name}' to continue.`,
-        );
-      }
-    }
   }
 
   const packageManager = new PackageManager(host, cwd, descriptor, {
@@ -169,7 +109,6 @@ export async function createPackageManager(options: {
     logger,
     tempDirectory,
     version,
-    initializationError,
   });
 
   logger?.debug(`Successfully created PackageManager for '${name}'.`);

--- a/packages/angular/cli/src/package-managers/factory_spec.ts
+++ b/packages/angular/cli/src/package-managers/factory_spec.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { createPackageManager } from './factory';
+import { NodeJS_HOST } from './host';
+
+describe('createPackageManager', () => {
+  let runCommandSpy: jasmine.Spy;
+
+  beforeEach(() => {
+    runCommandSpy = spyOn(NodeJS_HOST, 'runCommand');
+  });
+
+  it('should create PackageManager without spawning any subprocesses', async () => {
+    const pm = await createPackageManager({
+      cwd: '/tmp',
+    });
+
+    expect(pm).toBeDefined();
+    expect(runCommandSpy).not.toHaveBeenCalled();
+  });
+
+  it('should respect configured package manager name and version without running commands', async () => {
+    const pm = await createPackageManager({
+      cwd: '/tmp',
+      configuredPackageManager: ['pnpm', '9.1.0'],
+    });
+
+    expect(pm.name).toBe('pnpm');
+    expect(pm.version).toBe('9.1.0');
+    expect(runCommandSpy).not.toHaveBeenCalled();
+  });
+
+  it('should detect yarn-classic when configured with yarn version < 2', async () => {
+    const pm = await createPackageManager({
+      cwd: '/tmp',
+      configuredPackageManager: ['yarn', '1.22.19'],
+    });
+
+    expect(pm.name).toBe('yarn');
+    expect(pm.version).toBe('1.22.19');
+    expect(runCommandSpy).not.toHaveBeenCalled();
+  });
+
+  it('should maintain modern yarn when configured with yarn version >= 2', async () => {
+    const pm = await createPackageManager({
+      cwd: '/tmp',
+      configuredPackageManager: ['yarn', '4.4.1'],
+    });
+
+    expect(pm.name).toBe('yarn');
+    expect(pm.version).toBe('4.4.1');
+    expect(runCommandSpy).not.toHaveBeenCalled();
+  });
+
+  it('should throw for unsupported package manager', async () => {
+    await expectAsync(
+      createPackageManager({
+        cwd: '/tmp',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        configuredPackageManager: ['invalid-pm' as any],
+      }),
+    ).toBeRejectedWithError('Unsupported package manager: "invalid-pm"');
+  });
+});

--- a/packages/angular/cli/src/package-managers/package-manager.ts
+++ b/packages/angular/cli/src/package-managers/package-manager.ts
@@ -14,11 +14,11 @@
 
 import { join, relative, resolve } from 'node:path';
 import npa from 'npm-package-arg';
-import { maxSatisfying, valid } from 'semver';
+import { major, maxSatisfying, valid } from 'semver';
 import { PackageManagerError } from './error';
 import { Host } from './host';
 import { Logger } from './logger';
-import { PackageManagerDescriptor } from './package-manager-descriptor';
+import { PackageManagerDescriptor, SUPPORTED_PACKAGE_MANAGERS } from './package-manager-descriptor';
 import { PackageManifest, PackageMetadata } from './package-metadata';
 import { InstalledPackage } from './package-tree';
 
@@ -97,6 +97,7 @@ export class PackageManager {
   #activeTasks = 0;
   readonly #pendingTasks: (() => void)[] = [];
   readonly #maxConcurrent = 5;
+  #descriptor: PackageManagerDescriptor;
 
   /**
    * Creates a new `PackageManager` instance.
@@ -108,12 +109,13 @@ export class PackageManager {
   constructor(
     private readonly host: Host,
     private readonly cwd: string,
-    private readonly descriptor: PackageManagerDescriptor,
+    descriptor: PackageManagerDescriptor,
     private readonly options: PackageManagerOptions = {},
   ) {
     if (this.options.dryRun && !this.options.logger) {
       throw new Error('A logger must be provided when dryRun is enabled.');
     }
+    this.#descriptor = descriptor;
     this.#version = options.version;
     this.#initializationError = options.initializationError;
   }
@@ -122,7 +124,28 @@ export class PackageManager {
    * The name of the package manager's binary.
    */
   get name(): string {
-    return this.descriptor.binary;
+    return this.#descriptor.binary;
+  }
+
+  /**
+   * The resolved or configured version of the package manager, if known.
+   */
+  get version(): string | undefined {
+    return this.#version;
+  }
+
+  /**
+   * Ensures the correct descriptor is selected for package managers with version-dependent
+   * behavior (such as yarn classic vs modern).
+   */
+  async #ensureDescriptor(): Promise<void> {
+    if (this.#descriptor.binary === 'yarn' && !this.#version && !this.options.dryRun) {
+      try {
+        await this.getVersion();
+      } catch {
+        // Ignore version lookup errors and fall back to modern yarn descriptor.
+      }
+    }
   }
 
   /**
@@ -147,11 +170,13 @@ export class PackageManager {
       return this.#dependencyCache;
     }
 
-    const args = this.descriptor.listDependenciesCommand;
+    await this.#ensureDescriptor();
+
+    const args = this.#descriptor.listDependenciesCommand;
 
     const workspacePackageName = await this.getCurrentPackageName();
     const dependencies = await this.#fetchAndParse(args, (stdout, logger) =>
-      this.descriptor.outputParsers.listDependencies(stdout, logger, { workspacePackageName }),
+      this.#descriptor.outputParsers.listDependencies(stdout, logger, { workspacePackageName }),
     );
 
     return (this.#dependencyCache = dependencies ?? new Map());
@@ -196,10 +221,10 @@ export class PackageManager {
       let finalEnv: Record<string, string> | undefined;
 
       if (registry) {
-        const registryOptions = this.descriptor.getRegistryOptions?.(registry);
+        const registryOptions = this.#descriptor.getRegistryOptions?.(registry);
         if (!registryOptions) {
           throw new Error(
-            `The configured package manager, '${this.descriptor.binary}', does not support a custom registry.`,
+            `The configured package manager, '${this.#descriptor.binary}', does not support a custom registry.`,
           );
         }
 
@@ -214,13 +239,13 @@ export class PackageManager {
       const executionDirectory = cwd ?? this.cwd;
       if (this.options.dryRun) {
         this.options.logger?.info(
-          `[DRY RUN] Would execute in [${executionDirectory}]: ${this.descriptor.binary} ${finalArgs.join(' ')}`,
+          `[DRY RUN] Would execute in [${executionDirectory}]: ${this.#descriptor.binary} ${finalArgs.join(' ')}`,
         );
 
         return { stdout: '', stderr: '' };
       }
 
-      const commandResult = await this.host.runCommand(this.descriptor.binary, finalArgs, {
+      const commandResult = await this.host.runCommand(this.#descriptor.binary, finalArgs, {
         ...runOptions,
         cwd: executionDirectory,
         stdio: 'pipe',
@@ -278,17 +303,17 @@ export class PackageManager {
     // Yarn classic can exit with code 0 even when an error occurs.
     // To ensure we capture these cases, we will always attempt to parse a
     // structured error from the output, regardless of the exit code.
-    const getError = this.descriptor.outputParsers.getError;
+    const getError = this.#descriptor.outputParsers.getError;
     const parsedError =
       getError?.(stdout, this.options.logger) ?? getError?.(stderr, this.options.logger) ?? null;
 
     if (parsedError) {
       this.options.logger?.debug(
-        `[${this.descriptor.binary}] Structured error (code: ${parsedError.code}): ${parsedError.summary}`,
+        `[${this.#descriptor.binary}] Structured error (code: ${parsedError.code}): ${parsedError.summary}`,
       );
 
       // Special case for 'not found' errors (e.g., E404). Return null for these.
-      if (this.descriptor.isNotFound(parsedError)) {
+      if (this.#descriptor.isNotFound(parsedError)) {
         if (cache && cacheKey) {
           cache.set(cacheKey, null);
         }
@@ -343,16 +368,17 @@ export class PackageManager {
     ignoreScripts: boolean,
     options: { registry?: string } = {},
   ): Promise<void> {
+    await this.#ensureDescriptor();
     const flags = [
-      asDevDependency ? this.descriptor.saveDevFlag : '',
-      save === 'exact' ? this.descriptor.saveExactFlag : '',
-      save === 'tilde' ? this.descriptor.saveTildeFlag : '',
-      noLockfile ? this.descriptor.noLockfileFlag : '',
-      ignoreScripts ? this.descriptor.ignoreScriptsFlag : '',
+      asDevDependency ? this.#descriptor.saveDevFlag : '',
+      save === 'exact' ? this.#descriptor.saveExactFlag : '',
+      save === 'tilde' ? this.#descriptor.saveTildeFlag : '',
+      noLockfile ? this.#descriptor.noLockfileFlag : '',
+      ignoreScripts ? this.#descriptor.ignoreScriptsFlag : '',
     ].filter((flag) => flag);
 
     const specifier = this.host.requiresQuoting ? `"${packageName}"` : packageName;
-    const args = [this.descriptor.addCommand, specifier, ...flags];
+    const args = [this.#descriptor.addCommand, specifier, ...flags];
 
     await this.#run(args, options);
 
@@ -377,12 +403,13 @@ export class PackageManager {
       ignorePeerDependencies?: boolean;
     } = { ignoreScripts: true },
   ): Promise<void> {
+    await this.#ensureDescriptor();
     const flags = [
-      options.force ? this.descriptor.forceFlag : '',
-      options.ignoreScripts ? this.descriptor.ignoreScriptsFlag : '',
-      options.ignorePeerDependencies ? (this.descriptor.ignorePeerDependenciesFlag ?? '') : '',
+      options.force ? this.#descriptor.forceFlag : '',
+      options.ignoreScripts ? this.#descriptor.ignoreScriptsFlag : '',
+      options.ignorePeerDependencies ? (this.#descriptor.ignorePeerDependenciesFlag ?? '') : '',
     ].filter((flag) => flag);
-    const args = [...this.descriptor.installCommand, ...flags];
+    const args = [...this.#descriptor.installCommand, ...flags];
 
     await this.#run(args, options);
 
@@ -393,9 +420,9 @@ export class PackageManager {
    * Gets the name of the package in the current project.
    */
   async getCurrentPackageName(): Promise<string | undefined> {
-    if (this.descriptor.getPackageNameCommand) {
+    if (this.#descriptor.getPackageNameCommand) {
       try {
-        const { stdout } = await this.#run(this.descriptor.getPackageNameCommand);
+        const { stdout } = await this.#run(this.#descriptor.getPackageNameCommand);
         if (stdout) {
           return JSON.parse(stdout);
         }
@@ -422,11 +449,16 @@ export class PackageManager {
       return this.#version;
     }
 
-    const { stdout } = await this.#run(this.descriptor.versionCommand);
+    const { stdout } = await this.#run(this.#descriptor.versionCommand);
     this.#version = stdout.trim();
 
     if (!valid(this.#version)) {
       throw new Error(`Invalid semver version for ${this.name}: "${this.#version}"`);
+    }
+
+    if (this.#descriptor.binary === 'yarn' && major(this.#version) < 2) {
+      this.#descriptor = SUPPORTED_PACKAGE_MANAGERS['yarn-classic'];
+      this.options.logger?.debug(`Detected yarn classic. Using 'yarn-classic'.`);
     }
 
     return this.#version;
@@ -468,6 +500,7 @@ export class PackageManager {
     packageName: string,
     options: { timeout?: number; registry?: string; bypassCache?: boolean } = {},
   ): Promise<PackageMetadata | null> {
+    await this.#ensureDescriptor();
     const cacheKey = options.registry ? `${packageName}|${options.registry}` : packageName;
 
     if (!options.bypassCache) {
@@ -478,20 +511,20 @@ export class PackageManager {
     }
 
     let metadata: PackageMetadata | null;
-    if (this.descriptor.getRegistryMetadata) {
-      metadata = await this.descriptor.getRegistryMetadata(packageName, (args, parser) =>
+    if (this.#descriptor.getRegistryMetadata) {
+      metadata = await this.#descriptor.getRegistryMetadata(packageName, (args, parser) =>
         this.#fetchAndParse(args, parser, options),
       );
     } else {
-      const commandArgs = [...this.descriptor.getManifestCommand, packageName];
-      const formatter = this.descriptor.viewCommandFieldArgFormatter;
+      const commandArgs = [...this.#descriptor.getManifestCommand, packageName];
+      const formatter = this.#descriptor.viewCommandFieldArgFormatter;
       if (formatter) {
         commandArgs.push(...formatter(METADATA_FIELDS));
       }
 
       metadata = await this.#fetchAndParse(
         commandArgs,
-        (stdout, logger) => this.descriptor.outputParsers.getRegistryMetadata(stdout, logger),
+        (stdout, logger) => this.#descriptor.outputParsers.getRegistryMetadata(stdout, logger),
         options,
       );
     }
@@ -517,11 +550,12 @@ export class PackageManager {
     version: string,
     options: { timeout?: number; registry?: string; bypassCache?: boolean } = {},
   ): Promise<PackageManifest | null> {
+    await this.#ensureDescriptor();
     const specifier = this.host.requiresQuoting
       ? `"${packageName}@${version}"`
       : `${packageName}@${version}`;
-    const commandArgs = [...this.descriptor.getManifestCommand, specifier];
-    const formatter = this.descriptor.viewCommandFieldArgFormatter;
+    const commandArgs = [...this.#descriptor.getManifestCommand, specifier];
+    const formatter = this.#descriptor.viewCommandFieldArgFormatter;
     if (formatter) {
       commandArgs.push(...formatter(MANIFEST_FIELDS));
     }
@@ -530,7 +564,7 @@ export class PackageManager {
 
     const manifest = await this.#fetchAndParse(
       commandArgs,
-      (stdout, logger) => this.descriptor.outputParsers.getRegistryManifest(stdout, logger),
+      (stdout, logger) => this.#descriptor.outputParsers.getRegistryManifest(stdout, logger),
       { ...options, cache: this.#manifestCache, cacheKey },
     );
 
@@ -561,6 +595,7 @@ export class PackageManager {
     specifier: string | npa.Result,
     options: { timeout?: number; registry?: string; bypassCache?: boolean } = {},
   ): Promise<PackageManifest | null> {
+    await this.#ensureDescriptor();
     const { name, type, fetchSpec } = typeof specifier === 'string' ? npa(specifier) : specifier;
 
     switch (type) {
@@ -573,7 +608,7 @@ export class PackageManager {
 
         // `fetchSpec` is the version, range, or tag.
         let versionSpec = fetchSpec ?? 'latest';
-        if (this.descriptor.requiresManifestVersionLookup) {
+        if (this.#descriptor.requiresManifestVersionLookup) {
           if (type === 'tag' || !fetchSpec) {
             const metadata = await this.getRegistryMetadata(name, options);
             if (!metadata) {
@@ -725,8 +760,8 @@ export class PackageManager {
     }
 
     // Copy configuration files if the package manager requires it (e.g., bun, yarn).
-    if (this.descriptor.copyConfigFromProject) {
-      for (const configFile of this.descriptor.configFiles) {
+    if (this.#descriptor.copyConfigFromProject) {
+      for (const configFile of this.#descriptor.configFiles) {
         try {
           const configPath = join(this.cwd, configFile);
           let content = await this.host.readFile(configPath);
@@ -740,10 +775,10 @@ export class PackageManager {
       }
     }
 
-    const flags = [options.ignoreScripts ? this.descriptor.ignoreScriptsFlag : ''].filter(
+    const flags = [options.ignoreScripts ? this.#descriptor.ignoreScriptsFlag : ''].filter(
       (flag) => flag,
     );
-    const args: readonly string[] = [this.descriptor.addCommand, specifier, ...flags];
+    const args: readonly string[] = [this.#descriptor.addCommand, specifier, ...flags];
 
     try {
       await this.#run(args, { ...options, cwd: workingDirectory });
@@ -774,12 +809,15 @@ export class PackageManager {
    * @returns A promise that resolves to the limit in milliseconds, or `0` if not set.
    */
   async #resolveMinimumReleaseAge(): Promise<number> {
-    if (this.descriptor.getReleaseAgeConfigCommand && this.descriptor.outputParsers.getReleaseAge) {
+    if (
+      this.#descriptor.getReleaseAgeConfigCommand &&
+      this.#descriptor.outputParsers.getReleaseAge
+    ) {
       try {
-        const { stdout } = await this.#run(this.descriptor.getReleaseAgeConfigCommand);
+        const { stdout } = await this.#run(this.#descriptor.getReleaseAgeConfigCommand);
         const version = await this.getVersion();
 
-        return this.descriptor.outputParsers.getReleaseAge(stdout, version);
+        return this.#descriptor.outputParsers.getReleaseAge(stdout, version);
       } catch {
         // Ignore failures and fallback to 0
       }

--- a/packages/angular/cli/src/package-managers/package-manager_spec.ts
+++ b/packages/angular/cli/src/package-managers/package-manager_spec.ts
@@ -84,6 +84,58 @@ describe('PackageManager', () => {
       expect(version).toBe('4.5.6');
       expect(runCommandSpy).not.toHaveBeenCalled();
     });
+
+    it('should switch yarn descriptor to yarn-classic when resolved version is < 2', async () => {
+      const yarnDescriptor = SUPPORTED_PACKAGE_MANAGERS['yarn'];
+      const pm = new PackageManager(host, '/tmp', yarnDescriptor);
+      runCommandSpy.and.resolveTo({ stdout: '1.22.19', stderr: '' });
+
+      const version = await pm.getVersion();
+      expect(version).toBe('1.22.19');
+
+      // Now call an operation that differs in flags between classic and modern
+      await pm.add('foo', 'none', false, true, true);
+      expect(runCommandSpy).toHaveBeenCalledWith(
+        'yarn',
+        ['add', 'foo', '--no-lockfile', '--ignore-scripts'],
+        jasmine.anything(),
+      );
+    });
+
+    it('should keep yarn modern descriptor when resolved version is >= 2', async () => {
+      const yarnDescriptor = SUPPORTED_PACKAGE_MANAGERS['yarn'];
+      const pm = new PackageManager(host, '/tmp', yarnDescriptor);
+      runCommandSpy.and.resolveTo({ stdout: '4.4.1', stderr: '' });
+
+      const version = await pm.getVersion();
+      expect(version).toBe('4.4.1');
+
+      // In modern yarn, ignoreScriptsFlag is --mode=skip-build and noLockfileFlag is empty
+      await pm.add('foo', 'none', false, true, true);
+      expect(runCommandSpy).toHaveBeenCalledWith(
+        'yarn',
+        ['add', 'foo', '--mode=skip-build'],
+        jasmine.anything(),
+      );
+    });
+  });
+
+  describe('version getter', () => {
+    it('should return undefined before getVersion() is called', () => {
+      const pm = new PackageManager(host, '/tmp', descriptor);
+      expect(pm.version).toBeUndefined();
+    });
+
+    it('should return constructor version synchronously', () => {
+      const pm = new PackageManager(host, '/tmp', descriptor, { version: '10.0.0' });
+      expect(pm.version).toBe('10.0.0');
+    });
+
+    it('should return resolved version after getVersion() is called', async () => {
+      const pm = new PackageManager(host, '/tmp', descriptor);
+      await pm.getVersion();
+      expect(pm.version).toBe('1.2.3');
+    });
   });
 
   describe('acquireTempPackage', () => {


### PR DESCRIPTION
## PR Checklist
Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Performance improvement
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
`determinePackageManager` and `createPackageManager` eagerly call `getPackageManagerVersion` during command execution startup, spawning child processes (`npm --version`, `pnpm --version`, `yarn --version`, `bun --version`) on cold starts even when the command does not perform any package manager operations.

## What is the new behavior?
- `determinePackageManager` and `createPackageManager` no longer spawn child processes to query versions during initial command creation.
- Package manager version resolution is deferred until explicitly required by package management operations or version queries.
- Added a synchronous `version` getter on `PackageManager` to allow non-blocking version inspection where available.
- Updated `getAnalytics()` in `command-module.ts` to avoid awaiting `getVersion()`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
