### PR TITLE
fix(@angular/build): prevent memory leaks in parallel compilation and caches

### DIFF
--- a/packages/angular/build/src/tools/angular/compilation/parallel-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/parallel-compilation.ts
@@ -30,6 +30,7 @@ import {
  */
 export class ParallelCompilation extends AngularCompilation {
   readonly #worker: WorkerPool;
+  #webWorkerChannel?: MessageChannel;
 
   constructor(
     private readonly jit: boolean,
@@ -47,7 +48,7 @@ export class ParallelCompilation extends AngularCompilation {
     });
   }
 
-  override initialize(
+  override async initialize(
     tsconfig: string,
     hostOptions: AngularHostOptions,
     compilerOptionsTransformer?: (compilerOptions: CompilerOptions) => CompilerOptions,
@@ -64,9 +65,12 @@ export class ParallelCompilation extends AngularCompilation {
       },
     );
 
+    this.#webWorkerChannel?.port1.close();
+
     // The web worker processing is a synchronous operation and uses shared memory combined with
     // the Atomics API to block execution here until a response is received.
     const webWorkerChannel = new MessageChannel();
+    this.#webWorkerChannel = webWorkerChannel;
     const webWorkerSignal = new Int32Array(new SharedArrayBuffer(4));
     webWorkerChannel.port1.on('message', ({ workerFile, containingFile }) => {
       try {
@@ -89,31 +93,44 @@ export class ParallelCompilation extends AngularCompilation {
         const transformedOptions = compilerOptionsTransformer?.(compilerOptions) ?? compilerOptions;
         optionsChannel.port1.postMessage({ transformedOptions });
       } catch (error) {
-        webWorkerChannel.port1.postMessage({ error });
+        optionsChannel.port1.postMessage({ error });
       } finally {
         Atomics.store(optionsSignal, 0, 1);
         Atomics.notify(optionsSignal, 0);
       }
     });
 
-    // Execute the initialize function in the worker thread
-    return this.#worker.run(
-      {
-        fileReplacements: hostOptions.fileReplacements,
-        tsconfig,
-        jit: this.jit,
-        browserOnlyBuild: this.browserOnlyBuild,
-        stylesheetPort: stylesheetChannel.port2,
-        optionsPort: optionsChannel.port2,
-        optionsSignal,
-        webWorkerPort: webWorkerChannel.port2,
-        webWorkerSignal,
-      },
-      {
-        name: 'initialize',
-        transferList: [stylesheetChannel.port2, optionsChannel.port2, webWorkerChannel.port2],
-      },
-    );
+    let success = false;
+    try {
+      // Execute the initialize function in the worker thread
+      const result = await this.#worker.run(
+        {
+          fileReplacements: hostOptions.fileReplacements,
+          tsconfig,
+          jit: this.jit,
+          browserOnlyBuild: this.browserOnlyBuild,
+          stylesheetPort: stylesheetChannel.port2,
+          optionsPort: optionsChannel.port2,
+          optionsSignal,
+          webWorkerPort: webWorkerChannel.port2,
+          webWorkerSignal,
+        },
+        {
+          name: 'initialize',
+          transferList: [stylesheetChannel.port2, optionsChannel.port2, webWorkerChannel.port2],
+        },
+      );
+      success = true;
+
+      return result;
+    } finally {
+      stylesheetChannel.port1.close();
+      optionsChannel.port1.close();
+      if (!success) {
+        this.#webWorkerChannel?.port1.close();
+        this.#webWorkerChannel = undefined;
+      }
+    }
   }
 
   /**
@@ -135,8 +152,13 @@ export class ParallelCompilation extends AngularCompilation {
     return result;
   }
 
-  override emitAffectedFiles(): Promise<Iterable<EmitFileResult>> {
-    return this.#worker.run(undefined, { name: 'emit' });
+  override async emitAffectedFiles(): Promise<Iterable<EmitFileResult>> {
+    try {
+      return await this.#worker.run(undefined, { name: 'emit' });
+    } finally {
+      this.#webWorkerChannel?.port1.close();
+      this.#webWorkerChannel = undefined;
+    }
   }
 
   override update(files: Set<string>): Promise<void> {
@@ -144,6 +166,9 @@ export class ParallelCompilation extends AngularCompilation {
   }
 
   override close() {
+    this.#webWorkerChannel?.port1.close();
+    this.#webWorkerChannel = undefined;
+
     return this.#worker.destroy();
   }
 }

--- a/packages/angular/build/src/tools/angular/compilation/parallel-worker.ts
+++ b/packages/angular/build/src/tools/angular/compilation/parallel-worker.ts
@@ -33,99 +33,122 @@ export interface InitRequest {
 }
 
 let compilation: AngularCompilation | undefined;
+let activeWebWorkerPort: MessagePort | undefined;
 
 const modifiedFiles = new Set<string>();
 
 export async function initialize(request: InitRequest): Promise<AngularCompilationResult> {
+  activeWebWorkerPort?.close();
+  activeWebWorkerPort = request.webWorkerPort;
+
   const currentModifiedFiles = new Set(modifiedFiles);
   modifiedFiles.clear();
 
-  await initializeHash();
-  compilation ??= request.jit
-    ? new JitCompilation(request.browserOnlyBuild)
-    : new AotCompilation(request.browserOnlyBuild);
+  let success = false;
+  try {
+    await initializeHash();
+    compilation ??= request.jit
+      ? new JitCompilation(request.browserOnlyBuild)
+      : new AotCompilation(request.browserOnlyBuild);
 
-  const stylesheetRequests = new Map<string, [(value: string) => void, (reason: Error) => void]>();
-  request.stylesheetPort.on('message', ({ requestId, value, error }) => {
-    if (error) {
-      stylesheetRequests.get(requestId)?.[1](error);
-    } else {
-      stylesheetRequests.get(requestId)?.[0](value);
-    }
-  });
+    const stylesheetRequests = new Map<
+      string,
+      [(value: string) => void, (reason: Error) => void]
+    >();
+    request.stylesheetPort.on('message', ({ requestId, value, error }) => {
+      const handlers = stylesheetRequests.get(requestId);
+      if (handlers) {
+        stylesheetRequests.delete(requestId);
+        if (error) {
+          handlers[1](error);
+        } else {
+          handlers[0](value);
+        }
+      }
+    });
 
-  const {
-    compilerOptions,
-    referencedFiles,
-    externalStylesheets,
-    templateUpdates,
-    componentResourcesDependencies,
-  } = await compilation.initialize(
-    request.tsconfig,
-    {
-      fileReplacements: request.fileReplacements,
-      modifiedFiles: currentModifiedFiles,
-      transformStylesheet(data, containingFile, stylesheetFile, order, className) {
-        const requestId = randomUUID();
-        const resultPromise = new Promise<string>((resolve, reject) =>
-          stylesheetRequests.set(requestId, [resolve, reject]),
-        );
+    const {
+      compilerOptions,
+      referencedFiles,
+      externalStylesheets,
+      templateUpdates,
+      componentResourcesDependencies,
+    } = await compilation.initialize(
+      request.tsconfig,
+      {
+        fileReplacements: request.fileReplacements,
+        modifiedFiles: currentModifiedFiles,
+        transformStylesheet(data, containingFile, stylesheetFile, order, className) {
+          const requestId = randomUUID();
+          const resultPromise = new Promise<string>((resolve, reject) =>
+            stylesheetRequests.set(requestId, [resolve, reject]),
+          );
 
-        request.stylesheetPort.postMessage({
-          requestId,
-          data,
-          containingFile,
-          stylesheetFile,
-          order,
-          className,
-        });
+          request.stylesheetPort.postMessage({
+            requestId,
+            data,
+            containingFile,
+            stylesheetFile,
+            order,
+            className,
+          });
 
-        return resultPromise;
+          return resultPromise;
+        },
+        processWebWorker(workerFile, containingFile) {
+          Atomics.store(request.webWorkerSignal, 0, 0);
+          request.webWorkerPort.postMessage({ workerFile, containingFile });
+
+          Atomics.wait(request.webWorkerSignal, 0, 0);
+          const result = receiveMessageOnPort(request.webWorkerPort)?.message;
+
+          if (result?.error) {
+            throw result.error;
+          }
+
+          return result?.workerCodeFile ?? workerFile;
+        },
       },
-      processWebWorker(workerFile, containingFile) {
-        Atomics.store(request.webWorkerSignal, 0, 0);
-        request.webWorkerPort.postMessage({ workerFile, containingFile });
+      (compilerOptions) => {
+        Atomics.store(request.optionsSignal, 0, 0);
+        request.optionsPort.postMessage(compilerOptions);
 
-        Atomics.wait(request.webWorkerSignal, 0, 0);
-        const result = receiveMessageOnPort(request.webWorkerPort)?.message;
+        Atomics.wait(request.optionsSignal, 0, 0);
+        const result = receiveMessageOnPort(request.optionsPort)?.message;
 
         if (result?.error) {
           throw result.error;
         }
 
-        return result?.workerCodeFile ?? workerFile;
+        return result?.transformedOptions ?? compilerOptions;
       },
-    },
-    (compilerOptions) => {
-      Atomics.store(request.optionsSignal, 0, 0);
-      request.optionsPort.postMessage(compilerOptions);
+    );
 
-      Atomics.wait(request.optionsSignal, 0, 0);
-      const result = receiveMessageOnPort(request.optionsPort)?.message;
+    success = true;
 
-      if (result?.error) {
-        throw result.error;
-      }
-
-      return result?.transformedOptions ?? compilerOptions;
-    },
-  );
-
-  return {
-    externalStylesheets,
-    templateUpdates,
-    referencedFiles,
-    // TODO: Expand? `allowJs`, `isolatedModules`, `sourceMap`, `inlineSourceMap` are the only fields needed currently.
-    compilerOptions: {
-      allowJs: compilerOptions.allowJs,
-      isolatedModules: compilerOptions.isolatedModules,
-      sourceMap: compilerOptions.sourceMap,
-      inlineSourceMap: compilerOptions.inlineSourceMap,
-      _useTypeScriptTranspilation: compilerOptions['_useTypeScriptTranspilation'] as
-        boolean | undefined,
-    },
-    componentResourcesDependencies,
-  };
+    return {
+      externalStylesheets,
+      templateUpdates,
+      referencedFiles,
+      // TODO: Expand? `allowJs`, `isolatedModules`, `sourceMap`, `inlineSourceMap` are the only fields needed currently.
+      compilerOptions: {
+        allowJs: compilerOptions.allowJs,
+        isolatedModules: compilerOptions.isolatedModules,
+        sourceMap: compilerOptions.sourceMap,
+        inlineSourceMap: compilerOptions.inlineSourceMap,
+        _useTypeScriptTranspilation: compilerOptions['_useTypeScriptTranspilation'] as
+          boolean | undefined,
+      },
+      componentResourcesDependencies,
+    };
+  } finally {
+    request.stylesheetPort.close();
+    request.optionsPort.close();
+    if (!success) {
+      activeWebWorkerPort?.close();
+      activeWebWorkerPort = undefined;
+    }
+  }
 }
 
 export async function diagnose(modes: DiagnosticModes): Promise<{
@@ -147,9 +170,14 @@ export async function diagnose(modes: DiagnosticModes): Promise<{
 export async function emit() {
   assert(compilation);
 
-  const files = await compilation.emitAffectedFiles();
+  try {
+    const files = await compilation.emitAffectedFiles();
 
-  return [...files];
+    return [...files];
+  } finally {
+    activeWebWorkerPort?.close();
+    activeWebWorkerPort = undefined;
+  }
 }
 
 export async function update(files: Set<string>): Promise<void> {

--- a/packages/angular/build/src/tools/esbuild/angular/component-stylesheets.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/component-stylesheets.ts
@@ -176,6 +176,7 @@ export class ComponentStylesheetBundler {
     }
 
     const normalizedFiles = [...files].map(path.normalize);
+    const normalizedFilesSet = new Set(normalizedFiles);
     let entries: string[] | undefined;
 
     for (const [entry, bundler] of this.#fileContexts.entries()) {
@@ -184,8 +185,17 @@ export class ComponentStylesheetBundler {
         entries.push(entry);
       }
     }
-    for (const bundler of this.#inlineContexts.values()) {
-      bundler.invalidate(normalizedFiles);
+    for (const [entry, bundler] of this.#inlineContexts.entries()) {
+      // Entry is format: [language, id, filename].join(';')
+      const firstSemi = entry.indexOf(';');
+      const secondSemi = firstSemi !== -1 ? entry.indexOf(';', firstSemi + 1) : -1;
+      const filename = secondSemi !== -1 ? entry.slice(secondSemi + 1) : '';
+      if (filename && normalizedFilesSet.has(path.normalize(filename))) {
+        this.#inlineContexts.delete(entry);
+        void bundler.dispose();
+      } else {
+        bundler.invalidate(normalizedFiles);
+      }
     }
 
     return entries;

--- a/packages/angular/build/src/tools/esbuild/angular/source-file-cache_spec.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/source-file-cache_spec.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { SourceFileCache } from './source-file-cache';
+
+describe('SourceFileCache', () => {
+  let cache: SourceFileCache;
+
+  beforeEach(() => {
+    cache = new SourceFileCache();
+  });
+
+  it('should clean up all caches on clear()', async () => {
+    cache.typeScriptFileCache.set('/test/app.component.ts', 'console.log("test");');
+    cache.modifiedFiles.add('/test/app.component.ts');
+    cache.referencedFiles = ['/test/app.component.ts'];
+    await cache.loadResultCache.put('file:/test/app.component.ts', {
+      contents: 'test',
+      loader: 'js',
+    });
+
+    cache.clear();
+
+    expect(cache.typeScriptFileCache.size).toBe(0);
+    expect(cache.modifiedFiles.size).toBe(0);
+    expect(cache.referencedFiles).toBeUndefined();
+    expect(cache.loadResultCache.get('file:/test/app.component.ts')).toBeUndefined();
+  });
+});

--- a/packages/angular/build/src/tools/esbuild/cache.ts
+++ b/packages/angular/build/src/tools/esbuild/cache.ts
@@ -196,6 +196,15 @@ export class Cache<V, S extends CacheStore<V> = CacheStore<V>> {
   }
 
   /**
+   * Clears internal state for a specific namespaced key (requests, write counts, and pending gets).
+   */
+  protected deleteInternal(namespacedKey: string): void {
+    this.#requests.delete(namespacedKey);
+    this.#writeCounts.delete(namespacedKey);
+    this.#pendingGets.delete(namespacedKey);
+  }
+
+  /**
    * Clears the base class internal state (requests, write counts, and pending gets).
    */
   protected clearInternal(): void {
@@ -211,6 +220,18 @@ export class Cache<V, S extends CacheStore<V> = CacheStore<V>> {
 export class MemoryCache<V> extends Cache<V, Map<string, V>> {
   constructor() {
     super(new Map());
+  }
+
+  /**
+   * Removes the specified key from the cache instance.
+   * @param key The key to remove.
+   * @returns True if an element in the Map existed and has been removed, or false if the element does not exist.
+   */
+  delete(key: string): boolean {
+    const namespacedKey = this.withNamespace(key);
+    this.deleteInternal(namespacedKey);
+
+    return this.store.delete(namespacedKey);
   }
 
   /**

--- a/packages/angular/build/src/tools/esbuild/cache_spec.ts
+++ b/packages/angular/build/src/tools/esbuild/cache_spec.ts
@@ -141,4 +141,21 @@ describe('MemoryCache', () => {
     const val2 = await cache.getOrCreate('key', () => 'should-not-run');
     expect(val2).toBe('override-value');
   });
+
+  it('should delete a cached key and allow creating a new value', async () => {
+    await cache.put('key', 'value-1');
+    expect(await cache.get('key')).toBe('value-1');
+
+    const deleted = cache.delete('key');
+    expect(deleted).toBeTrue();
+    expect(await cache.get('key')).toBeUndefined();
+
+    // Subsequent getOrCreate should call creator
+    const newValue = await cache.getOrCreate('key', () => 'value-2');
+    expect(newValue).toBe('value-2');
+  });
+
+  it('should return false when deleting a non-existent key', () => {
+    expect(cache.delete('non-existent')).toBeFalse();
+  });
 });

--- a/packages/angular/build/src/tools/esbuild/load-result-cache.ts
+++ b/packages/angular/build/src/tools/esbuild/load-result-cache.ts
@@ -57,14 +57,35 @@ export class MemoryLoadResultCache implements LoadResultCache {
   }
 
   async put(path: string, result: OnLoadResult): Promise<void> {
+    const previousWatchFiles = this.#watchFilesPerKey.get(path);
+
     if (result.errors && result.errors.length > 0) {
-      const previousWatchFiles = this.#watchFilesPerKey.get(path);
       if (previousWatchFiles) {
         result.watchFiles = Array.from(
           new Set([...(result.watchFiles ?? []), ...previousWatchFiles]),
         );
       }
-    } else if (result.watchFiles && result.watchFiles.length > 0) {
+    }
+
+    const currentNormalizedWatchFiles = new Set(result.watchFiles?.map(normalize) ?? []);
+
+    // Clean up any previous file dependencies that are no longer referenced
+    if (previousWatchFiles) {
+      for (const watchFile of previousWatchFiles) {
+        const normalizedWatchFile = normalize(watchFile);
+        if (!currentNormalizedWatchFiles.has(normalizedWatchFile)) {
+          const affected = this.#fileDependencies.get(normalizedWatchFile);
+          if (affected) {
+            affected.delete(path);
+            if (affected.size === 0) {
+              this.#fileDependencies.delete(normalizedWatchFile);
+            }
+          }
+        }
+      }
+    }
+
+    if (result.watchFiles && result.watchFiles.length > 0) {
       this.#watchFilesPerKey.set(path, [...result.watchFiles]);
     } else {
       this.#watchFilesPerKey.delete(path);

--- a/packages/angular/build/src/tools/esbuild/load-result-cache_spec.ts
+++ b/packages/angular/build/src/tools/esbuild/load-result-cache_spec.ts
@@ -82,4 +82,35 @@ describe('MemoryLoadResultCache', () => {
     expect(invalidated).toBeTrue();
     expect(cache.get('file:/test/styles.css')).toBeUndefined();
   });
+
+  it('should clean up previous file dependencies when put updates watchFiles', async () => {
+    const initialResult = {
+      contents: 'body { color: red; }',
+      loader: 'css' as const,
+      watchFiles: ['/test/styles.css', '/test/old-dep.json'],
+    };
+
+    await cache.put('file:/test/styles.css', initialResult);
+    expect(cache.watchFiles).toContain('/test/old-dep.json');
+
+    // Update with new watch files (not containing old-dep.json)
+    const updatedResult = {
+      contents: 'body { color: blue; }',
+      loader: 'css' as const,
+      watchFiles: ['/test/styles.css', '/test/new-dep.json'],
+    };
+
+    await cache.put('file:/test/styles.css', updatedResult);
+    expect(cache.watchFiles).not.toContain('/test/old-dep.json');
+    expect(cache.watchFiles).toContain('/test/new-dep.json');
+
+    // Invalidating old dependency should not affect the cache
+    expect(cache.invalidate('/test/old-dep.json')).toBeFalse();
+    expect(cache.get('file:/test/styles.css')).toBe(updatedResult);
+
+    // Invalidating new dependency should invalidate the cache
+    expect(cache.invalidate('/test/new-dep.json')).toBeTrue();
+    expect(cache.get('file:/test/styles.css')).toBeUndefined();
+    expect(cache.watchFiles).not.toContain('/test/new-dep.json');
+  });
 });


### PR DESCRIPTION
## PR Checklist
Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Performance improvement
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
1. In `parallel-worker.ts`, `stylesheetRequests` retains `[resolve, reject]` promise callbacks permanently in memory because `stylesheetRequests.delete(requestId)` is omitted when receiving stylesheet transformation responses.
2. In `parallel-worker.ts` and `parallel-compilation.ts`, MessageChannel ports and event listeners are not closed across compilation cycles.
3. In `source-file-cache.ts`, `this.typeScriptFileCache` is not pruned when files are invalidated, permanently retaining bytecode buffers for modified or deleted files.
4. In `MemoryLoadResultCache`, obsolete watch file dependencies are not pruned when cache entries are updated.
5. In `parallel-compilation.ts`, error handling in `optionsChannel` incorrectly posted errors to `webWorkerChannel.port1` instead of `optionsChannel.port1`.

## What is the new behavior?
1. `stylesheetRequests.delete(requestId)` is invoked upon receiving stylesheet responses over IPC.
2. Wrapped `initialize()` in `try...finally` blocks to close message channels and ports.
3. `SourceFileCache.invalidate(files)` deletes invalidated entries from `this.typeScriptFileCache`.
4. `MemoryLoadResultCache` prunes obsolete watch files on update and cleans up empty dependency sets upon invalidation.
5. Corrected `optionsChannel.port1.postMessage({ error })` to preserve IPC channel isolation.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
