### PR TITLE
fix(@angular-devkit/build-angular): update webpack-dev-server to 5.2.6

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -57,7 +57,7 @@
     "tslib": "2.8.1",
     "webpack": "5.105.0",
     "webpack-dev-middleware": "7.4.2",
-    "webpack-dev-server": "5.2.5",
+    "webpack-dev-server": "5.2.6",
     "webpack-merge": "6.0.1",
     "webpack-subresource-integrity": "5.1.0"
   },

--- a/packages/angular_devkit/build_webpack/package.json
+++ b/packages/angular_devkit/build_webpack/package.json
@@ -23,7 +23,7 @@
     "@angular-devkit/core": "workspace:0.0.0-PLACEHOLDER",
     "@ngtools/webpack": "workspace:0.0.0-PLACEHOLDER",
     "webpack": "5.105.0",
-    "webpack-dev-server": "5.2.5"
+    "webpack-dev-server": "5.2.6"
   },
   "peerDependencies": {
     "webpack": "^5.30.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -741,8 +741,8 @@ importers:
         specifier: 7.4.2
         version: 7.4.2(webpack@5.105.0(esbuild@0.28.1))
       webpack-dev-server:
-        specifier: 5.2.5
-        version: 5.2.5(bufferutil@4.0.9)(utf-8-validate@6.0.5)(webpack@5.105.0(esbuild@0.28.1))
+        specifier: 5.2.6
+        version: 5.2.6(bufferutil@4.0.9)(utf-8-validate@6.0.5)(webpack@5.105.0(esbuild@0.28.1))
       webpack-merge:
         specifier: 6.0.1
         version: 6.0.1
@@ -789,8 +789,8 @@ importers:
         specifier: 5.105.0
         version: 5.105.0(esbuild@0.28.1)
       webpack-dev-server:
-        specifier: 5.2.5
-        version: 5.2.5(bufferutil@4.0.9)(utf-8-validate@6.0.5)(webpack@5.105.0(esbuild@0.28.1))
+        specifier: 5.2.6
+        version: 5.2.6(bufferutil@4.0.9)(utf-8-validate@6.0.5)(webpack@5.105.0(esbuild@0.28.1))
 
   packages/angular_devkit/core:
     dependencies:
@@ -6930,8 +6930,8 @@ packages:
     resolution: {integrity: sha512-+CCssgnrWKx9aI3OeZwroa/ckG4JICxvIFnSiOUyl2Uv+UTI+xIw0FfFrWS7cQFpoePpr9o8csss7KzsTzNL8Q==}
     engines: {node: ^4.8.4 || ^6.10.1 || ^7.10.1 || >= 8.1.4}
 
-  launch-editor@2.11.1:
-    resolution: {integrity: sha512-SEET7oNfgSaB6Ym0jufAdCeo3meJVeCaaDyzRygy0xsp2BFKCprcfHljTq4QkzTLUxEKkFK6OK4811YM2oSrRg==}
+  launch-editor@2.14.1:
+    resolution: {integrity: sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==}
 
   less-loader@12.3.0:
     resolution: {integrity: sha512-0M6+uYulvYIWs52y0LqN4+QM9TqWAohYSNTo4htE8Z7Cn3G/qQMEmktfHmyJT23k+20kU9zHH2wrfFXkxNLtVw==}
@@ -8448,8 +8448,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
     engines: {node: '>= 0.4'}
 
   shelljs@0.10.0:
@@ -9361,8 +9361,8 @@ packages:
       webpack:
         optional: true
 
-  webpack-dev-server@5.2.5:
-    resolution: {integrity: sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==}
+  webpack-dev-server@5.2.6:
+    resolution: {integrity: sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==}
     engines: {node: '>= 18.12.0'}
     hasBin: true
     peerDependencies:
@@ -15281,7 +15281,7 @@ snapshots:
       etag: 1.8.1
       finalhandler: 1.3.1
       fresh: 0.5.2
-      http-errors: 2.0.0
+      http-errors: 2.0.1
       merge-descriptors: 1.0.3
       methods: 1.1.2
       on-finished: 2.4.1
@@ -16720,10 +16720,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  launch-editor@2.11.1:
+  launch-editor@2.14.1:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.3
+      shell-quote: 1.10.0
 
   less-loader@12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.28.1)):
     dependencies:
@@ -18396,7 +18396,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.10.0: {}
 
   shelljs@0.10.0:
     dependencies:
@@ -19438,7 +19438,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.105.0(esbuild@0.28.1)
 
-  webpack-dev-server@5.2.5(bufferutil@4.0.9)(utf-8-validate@6.0.5)(webpack@5.105.0(esbuild@0.28.1)):
+  webpack-dev-server@5.2.6(bufferutil@4.0.9)(utf-8-validate@6.0.5)(webpack@5.105.0(esbuild@0.28.1)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -19458,7 +19458,7 @@ snapshots:
       graceful-fs: 4.2.11
       http-proxy-middleware: 2.0.9(@types/express@4.17.25)
       ipaddr.js: 2.2.0
-      launch-editor: 2.11.1
+      launch-editor: 2.14.1
       open: 10.2.0
       p-retry: 6.2.1
       schema-utils: 4.3.3


### PR DESCRIPTION
Updates `webpack-dev-server` to `5.2.6` to mitigate GHSA-m28w-2pqf-7qgj (CVE-2026-14631) and GHSA-f5vj-f2hx-8m93 (CVE-2026-14620).

Fixes #33903