### PR TITLE
perf(@angular/build): consolidate build worker pools with shared router

### DIFF
--- a/packages/angular/build/src/tools/esbuild/i18n-inliner-worker.ts
+++ b/packages/angular/build/src/tools/esbuild/i18n-inliner-worker.ts
@@ -10,7 +10,6 @@ import remapping, { type DecodedSourceMap, type SourceMapInput } from '@ampproje
 import type { ɵParsedTranslation } from '@angular/localize';
 import type { Node } from '@oxc-project/types';
 import { MagicString } from 'magic-string';
-import assert from 'node:assert';
 import { deserialize } from 'node:v8';
 import { parseSync } from 'oxc-parser';
 import { traversePostOrder } from '../oxc/traversal';
@@ -43,18 +42,17 @@ export interface InlineCodeRequest {
    */
   translation?: Blob | SharedArrayBuffer;
 
+  translationKey?: string;
+
   /**
    * How to handle missing translations.
    */
   missingTranslation?: 'error' | 'warning' | 'ignore';
 }
 
-/**
- * The response returned from a code request.
- */
-export interface InlineCodeResult {
-  output: string;
-  messages: { type: 'error' | 'warning'; message: string }[];
+export interface InlineFileBatchLocaleEntry {
+  translation?: Blob | SharedArrayBuffer;
+  translationKey?: string;
 }
 
 /**
@@ -79,7 +77,7 @@ export interface InlineFileBatchRequest {
   /**
    * The locale specifiers and optional translations to use during the inlining process of the file.
    */
-  locales: ReadonlyMap<string, Blob | SharedArrayBuffer | undefined>;
+  locales: ReadonlyMap<string, InlineFileBatchLocaleEntry | Blob | SharedArrayBuffer | undefined>;
 
   /**
    * How to handle missing translations.
@@ -103,6 +101,38 @@ export interface InlineFileBatchRequest {
    * all long-term worker caches are cleared.
    */
   generation?: number;
+
+  /**
+   * Optional file contents Blob when dispatched via the shared worker pool.
+   */
+  fileBlob?: Blob;
+
+  /**
+   * Optional cache key uniquely identifying the file content and AST metadata.
+   */
+  fileKey?: string;
+
+  /**
+   * Optional sourcemap Blob for the file when dispatched via the shared worker pool.
+   */
+  mapBlob?: Blob;
+}
+
+export interface InlineDiagnosticMessage {
+  type: 'error' | 'warning';
+  message: string;
+}
+
+export interface InlineFileResult {
+  file: string;
+  code: string;
+  map?: string;
+  messages: InlineDiagnosticMessage[];
+}
+
+export interface InlineCodeResult {
+  output: string;
+  messages: InlineDiagnosticMessage[];
 }
 
 /**
@@ -112,7 +142,7 @@ export interface InlineLocaleResult {
   locale: string;
   code?: string;
   map?: string;
-  messages: { type: 'error' | 'warning'; message: string }[];
+  messages: InlineDiagnosticMessage[];
 }
 
 /**
@@ -131,6 +161,17 @@ export type InlineFileBatchResult =
     };
 
 /**
+ * Maximum number of AST metadata structures cached in memory per worker isolate.
+ * Bounding capacity prevents unbounded memory growth across watch rebuilds.
+ */
+const MAX_CACHED_FILES = 256;
+
+/**
+ * Maximum number of deserialized translation dictionaries cached in memory per worker isolate.
+ */
+const MAX_CACHED_TRANSLATIONS = 32;
+
+/**
  * Cached file data including code and extracted localization metadata.
  */
 interface CachedFileData {
@@ -139,12 +180,12 @@ interface CachedFileData {
 }
 
 /**
- * Cache of file data promises keyed by filename.
+ * Cache of file data promises keyed by `${filename}\0${hash}` or filename.
  */
 const fileDataCache = new Map<string, Promise<CachedFileData>>();
 
 /**
- * Cache of deserialized translation messages keyed by locale.
+ * Deserialized translation message dictionary cache keyed by `${locale}\0${translationKey}` or locale.
  */
 const deserializedTranslations = new Map<string, Promise<Record<string, ɵParsedTranslation>>>();
 
@@ -154,72 +195,106 @@ const deserializedTranslations = new Map<string, Promise<Record<string, ɵParsed
 let currentGeneration: number | undefined;
 
 /**
- * Retrieves the file data for a filename, loading and extracting localization metadata.
- * If `cache` is true, the result is cached in `fileDataCache` across requests in this Worker.
- * If `cache` is false (ephemeral), the result is not retained in `fileDataCache`, allowing it
- * to be garbage-collected once the batch request finishes.
+ * Retrieves the code and extracted localization metadata for a file.
+ * Caches the metadata promise in memory to avoid reparsing the AST across locales.
+ * If `cache` is false (ephemeral), the result is not retained in `fileDataCache`,
+ * allowing it to be garbage-collected once the batch request finishes.
  *
- * @param filename The name of the file to load.
+ * @param filename The name of the file.
  * @param codeBlob The source code file as a Blob.
+ * @param fileKey Optional cache key uniquely identifying the file content.
  * @param cache Whether to cache the loaded file data in the Worker's long-term cache.
- * @returns The cached or newly extracted code and localization metadata.
+ * @returns The cached file data.
  */
-function loadFileData(filename: string, codeBlob: Blob, cache = true): Promise<CachedFileData> {
-  const existing = fileDataCache.get(filename);
-  if (existing) {
-    if (!cache) {
-      fileDataCache.delete(filename);
-    }
+function getFileData(
+  filename: string,
+  codeBlob: Blob,
+  fileKey?: string,
+  cache = true,
+): Promise<CachedFileData> {
+  const cacheKey = fileKey ?? filename;
+  let dataPromise = fileDataCache.get(cacheKey);
+  if (!dataPromise) {
+    dataPromise = (async () => {
+      const code = await codeBlob.text();
 
-    return existing;
-  }
-
-  const fileDataPromise = (async () => {
-    const code = await codeBlob.text();
-    const metadata = extractLocalizeMetadata(filename, code);
-
-    return { code, metadata };
-  })();
-
-  if (cache) {
-    fileDataPromise.catch(() => {
-      fileDataCache.delete(filename);
+      return {
+        code,
+        metadata: extractLocalizeMetadata(filename, code),
+      };
+    })().catch((error) => {
+      if (fileDataCache.get(cacheKey) === dataPromise) {
+        fileDataCache.delete(cacheKey);
+      }
+      throw error;
     });
-    fileDataCache.set(filename, fileDataPromise);
+
+    if (cache) {
+      if (fileDataCache.size >= MAX_CACHED_FILES) {
+        const oldestKey = fileDataCache.keys().next().value;
+        if (oldestKey !== undefined) {
+          fileDataCache.delete(oldestKey);
+        }
+      }
+
+      fileDataCache.set(cacheKey, dataPromise);
+    }
+  } else if (cache) {
+    fileDataCache.delete(cacheKey);
+    fileDataCache.set(cacheKey, dataPromise);
+  } else {
+    fileDataCache.delete(cacheKey);
   }
 
-  return fileDataPromise;
+  return dataPromise;
 }
 
 /**
  * Deserializes or wraps the translation messages for a locale, reusing the result for any
- * subsequent request that targets the same locale.
- * @param locale The locale identifier.
- * @param translation Optional serialized translation messages (SharedArrayBuffer or Blob).
- * @returns The translation messages, or undefined if the locale has no translations.
+ * subsequent request that targets the same locale and translation payload.
+ *
+ * @param request The translation request object containing locale, translation payload, and optional key.
+ * @param explicitTranslation Optional fallback translation payload if request is a string.
  */
 function loadTranslation(
   locale: string,
   translation?: Blob | SharedArrayBuffer,
+  translationKey?: string,
 ): Promise<Record<string, ɵParsedTranslation>> | undefined {
   if (!translation) {
     return undefined;
   }
 
-  let messagesPromise = deserializedTranslations.get(locale);
+  const cacheKey = translationKey ? `${locale}\0${translationKey}` : undefined;
+  let messagesPromise = cacheKey ? deserializedTranslations.get(cacheKey) : undefined;
   if (!messagesPromise) {
     if (translation instanceof Blob) {
       messagesPromise = translation
         .arrayBuffer()
         .then((buffer) => deserialize(new Uint8Array(buffer)) as Record<string, ɵParsedTranslation>)
         .catch((error) => {
-          deserializedTranslations.delete(locale);
+          if (cacheKey && deserializedTranslations.get(cacheKey) === messagesPromise) {
+            deserializedTranslations.delete(cacheKey);
+          }
           throw error;
         });
     } else {
       messagesPromise = Promise.resolve(createSharedTranslationProxy(translation));
     }
-    deserializedTranslations.set(locale, messagesPromise);
+
+    if (cacheKey) {
+      if (deserializedTranslations.size >= MAX_CACHED_TRANSLATIONS) {
+        const oldestKey = deserializedTranslations.keys().next().value;
+        if (oldestKey !== undefined) {
+          deserializedTranslations.delete(oldestKey);
+        }
+      }
+
+      deserializedTranslations.set(cacheKey, messagesPromise);
+    }
+  } else if (cacheKey) {
+    deserializedTranslations.delete(cacheKey);
+    deserializedTranslations.set(cacheKey, messagesPromise);
   }
 
   return messagesPromise;
@@ -242,14 +317,25 @@ export async function inlineFileBatch(
 
   if (request.activeLocales) {
     const activeSet = new Set(request.activeLocales);
-    for (const locale of deserializedTranslations.keys()) {
-      if (!activeSet.has(locale)) {
-        deserializedTranslations.delete(locale);
+    for (const key of deserializedTranslations.keys()) {
+      const keyLocale = key.includes('\0') ? key.split('\0', 1)[0] : key;
+      if (!activeSet.has(keyLocale)) {
+        deserializedTranslations.delete(key);
       }
     }
   }
 
-  const { code, metadata } = await loadFileData(request.filename, request.code, !request.ephemeral);
+  const codeBlob = request.code ?? request.fileBlob;
+  if (!codeBlob) {
+    throw new Error(`File content not provided for: ${request.filename}`);
+  }
+
+  const { code, metadata } = await getFileData(
+    request.filename,
+    codeBlob,
+    request.fileKey,
+    !request.ephemeral,
+  );
 
   // Fast path: file has no $localize call sites or locale insert sites
   if (metadata.callSites.length === 0 && metadata.localeInsertSites.length === 0) {
@@ -265,20 +351,31 @@ export async function inlineFileBatch(
 
   // Parse the sourcemap once for the entire batch if provided.
   // It will naturally be garbage-collected after this batch action returns.
+  const rawMapBlob = request.map ?? request.mapBlob;
   let map: SourceMapInput | undefined;
-  if (request.map) {
-    const rawMap = await request.map.text();
+  let rawMap: string | undefined;
+  if (rawMapBlob) {
+    rawMap = await rawMapBlob.text();
     map = rawMap ? (JSON.parse(rawMap) as SourceMapInput) : undefined;
   }
 
   const results = await Promise.all(
-    Array.from(request.locales, async ([locale, translation]) => {
+    Array.from(request.locales, async ([locale, entry]) => {
+      const translation =
+        entry && typeof entry === 'object' && 'translation' in entry
+          ? entry.translation
+          : (entry as Blob | SharedArrayBuffer | undefined);
+      const translationKey =
+        entry && typeof entry === 'object' && 'translationKey' in entry
+          ? entry.translationKey
+          : undefined;
+
       const result = await inlineLocalize(
         code,
         map,
         metadata,
         locale,
-        await loadTranslation(locale, translation),
+        await loadTranslation(locale, translation, translationKey),
         request.filename,
         request.missingTranslation,
       );
@@ -302,7 +399,7 @@ export async function inlineFileBatch(
  * Inlines the provided locale and translation into JavaScript code that contains `$localize` usage.
  * This function is a secondary entry primarily for use with component HMR update modules.
  *
- * @param request An InlineRequest object representing the options for inlining
+ * @param request An InlineCodeRequest object representing the options for inlining
  * @returns An object containing the inlined code.
  */
 export async function inlineCode(request: InlineCodeRequest): Promise<InlineCodeResult> {
@@ -312,7 +409,7 @@ export async function inlineCode(request: InlineCodeRequest): Promise<InlineCode
     undefined,
     metadata,
     request.locale,
-    await loadTranslation(request.locale, request.translation),
+    await loadTranslation(request.locale, request.translation, request.translationKey),
     request.filename,
     request.missingTranslation,
   );
@@ -534,7 +631,7 @@ async function inlineLocalize(
   }
 
   const outputCode = magicString.toString();
-  let outputMap;
+  let outputMap: string | undefined;
   if (map) {
     // A decoded map is generated here rather than an encoded one because remapping decodes its
     // inputs. Encoding the mappings only for remapping to immediately decode them again doubles
@@ -544,12 +641,14 @@ async function inlineLocalize(
       includeContent: true,
       hires: 'boundary',
     });
-    outputMap = remapping([{ ...rawMap, version: 3 } satisfies DecodedSourceMap, map], () => null);
+    outputMap = JSON.stringify(
+      remapping([{ ...rawMap, version: 3 } satisfies DecodedSourceMap, map], () => null),
+    );
   }
 
   return {
     code: outputCode,
-    map: outputMap && JSON.stringify(outputMap),
+    map: outputMap,
     diagnostics,
   };
 }

--- a/packages/angular/build/src/tools/esbuild/i18n-inliner.ts
+++ b/packages/angular/build/src/tools/esbuild/i18n-inliner.ts
@@ -8,24 +8,20 @@
 
 import type { ɵParsedTranslation } from '@angular/localize';
 import assert from 'node:assert';
-import { createRequire } from 'node:module';
 import { extname, join } from 'node:path';
 import { serialize } from 'node:v8';
 import { calculateHash, createContentHash, initializeHash } from '../../utils/hash';
-import { WorkerPool } from '../../utils/worker-pool';
+import { type WorkerPool, getSharedBuildWorkerPool } from '../../utils/worker-pool';
 import { type BuildOutputFile, BuildOutputFileType, createOutputFile } from './bundler-files';
 import { type Cache, type PersistentCacheStore, createPersistentCacheStore } from './cache';
 import type {
   InlineCodeRequest,
   InlineCodeResult,
+  InlineDiagnosticMessage,
   InlineFileBatchRequest,
   InlineFileBatchResult,
 } from './i18n-inliner-worker';
 import { encodeTranslationToBuffer } from './i18n-translation-encoder';
-
-// TODO: Convert to import.meta usage during ESM transition
-const localRequire = createRequire(__filename);
-const INLINER_WORKER_PATH = localRequire.resolve('./i18n-inliner-worker');
 
 interface WorkerTaskMap {
   inlineFileBatch: {
@@ -84,33 +80,37 @@ async function serializeTranslation(
   }
 
   if (typeof SharedArrayBuffer !== 'undefined') {
-    if (translationIntegrity && translationCache) {
-      // Look up or generate binary translation data in the persistent cache.
-      // A Uint8Array view is stored in the cache store to allow binary persistence.
-      const binaryData = await translationCache.getOrCreate(translationIntegrity, () => {
-        return new Uint8Array(encodeTranslationToBuffer(translation));
-      });
+    try {
+      if (translationIntegrity && translationCache) {
+        // Look up or generate binary translation data in the persistent cache.
+        // A Uint8Array view is stored in the cache store to allow binary persistence.
+        const binaryData = await translationCache.getOrCreate(translationIntegrity, () => {
+          return new Uint8Array(encodeTranslationToBuffer(translation));
+        });
 
-      // On a cache miss, getOrCreate returns the newly created Uint8Array backed by the
-      // original SharedArrayBuffer. Return it directly to avoid an unnecessary allocation and copy.
-      if (
-        binaryData.buffer instanceof SharedArrayBuffer &&
-        binaryData.byteOffset === 0 &&
-        binaryData.byteLength === binaryData.buffer.byteLength
-      ) {
-        return binaryData.buffer;
+        // On a cache miss, getOrCreate returns the newly created Uint8Array backed by the
+        // original SharedArrayBuffer. Return it directly to avoid an unnecessary allocation and copy.
+        if (
+          binaryData.buffer instanceof SharedArrayBuffer &&
+          binaryData.byteOffset === 0 &&
+          binaryData.byteLength === binaryData.buffer.byteLength
+        ) {
+          return binaryData.buffer;
+        }
+
+        // On a warm cache hit, the restored data is backed by a standard ArrayBuffer from disk.
+        // Copy it into a SharedArrayBuffer so worker threads can access it via zero-copy shared memory.
+        const buffer = new SharedArrayBuffer(binaryData.byteLength);
+        new Uint8Array(buffer).set(binaryData);
+
+        return buffer;
       }
 
-      // On a warm cache hit, the restored data is backed by a standard ArrayBuffer from disk.
-      // Copy it into a SharedArrayBuffer so worker threads can access it via zero-copy shared memory.
-      const buffer = new SharedArrayBuffer(binaryData.byteLength);
-      new Uint8Array(buffer).set(binaryData);
-
-      return buffer;
+      // When persistent caching is not configured, encode directly into a SharedArrayBuffer.
+      return encodeTranslationToBuffer(translation);
+    } catch {
+      // Fall back to Blob serialization if SharedArrayBuffer allocation is restricted
     }
-
-    // When persistent caching is not configured, encode directly into a SharedArrayBuffer.
-    return encodeTranslationToBuffer(translation);
   }
 
   return new Blob([serialize(translation)]);
@@ -170,6 +170,33 @@ interface TransformedFileResult {
   messages: { type: 'error' | 'warning'; message: string }[];
 }
 
+export interface InlineTemplateUpdateResult {
+  code: string;
+  errors: string[];
+  warnings: string[];
+}
+
+/**
+ * Partitions diagnostic messages into error and warning strings.
+ */
+function partitionDiagnostics(messages: readonly InlineDiagnosticMessage[]): {
+  errors: string[];
+  warnings: string[];
+} {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  for (const message of messages) {
+    if (message.type === 'error') {
+      errors.push(message.message);
+    } else {
+      warnings.push(message.message);
+    }
+  }
+
+  return { errors, warnings };
+}
+
 /**
  * An uncached transformation request entry for a file within a specific locale.
  */
@@ -177,6 +204,7 @@ interface UncachedLocaleEntry {
   locale: string;
   cacheKey?: string;
   translation?: Blob | SharedArrayBuffer;
+  translationKey?: string;
 }
 
 /**
@@ -205,12 +233,7 @@ export class I18nInliner {
       throw new RangeError('options.maxConcurrency must be an integer greater than or equal to 1.');
     }
 
-    // Piscina uses object spread against default options internally. Only define
-    // maxThreads when specified to avoid overwriting Piscina's default thread count
-    // with undefined.
-    this.#workerPool = new WorkerPool({
-      ...(options.maxConcurrency !== undefined && { maxThreads: options.maxConcurrency }),
-    });
+    this.#workerPool = getSharedBuildWorkerPool();
   }
 
   #partitionFiles(files: Iterable<BuildOutputFile>): {
@@ -234,7 +257,6 @@ export class I18nInliner {
 
       const fileExtension = extname(file.path);
       if (fileExtension === '.js' || fileExtension === '.mjs') {
-        // Check if localizations are present
         const contentBuffer = Buffer.isBuffer(file.contents)
           ? file.contents
           : Buffer.from(file.contents.buffer, file.contents.byteOffset, file.contents.byteLength);
@@ -312,6 +334,7 @@ export class I18nInliner {
       // Pre-calculate cache key bases and serialized Blobs for each locale in this window
       const localeCacheBases = new Map<string, string>();
       const localeBlobs = new Map<string, Blob | SharedArrayBuffer | undefined>();
+      const localeKeys = new Map<string, string | undefined>();
 
       await Promise.all(
         windowLocales.map(async ({ locale, translation, translationIntegrity }) => {
@@ -321,6 +344,11 @@ export class I18nInliner {
             this.#translationCache,
           );
           localeBlobs.set(locale, serialized);
+          localeKeys.set(
+            locale,
+            translationIntegrity ??
+              (translation ? calculateHash(JSON.stringify(translation)) : undefined),
+          );
 
           if (this.#cacheStore) {
             localeCacheBases.set(
@@ -372,6 +400,7 @@ export class I18nInliner {
                 locale,
                 cacheKey,
                 translation: localeBlobs.get(locale),
+                translationKey: localeKeys.get(locale),
               };
             },
           );
@@ -394,6 +423,7 @@ export class I18nInliner {
             windowLocales.map(({ locale }) => ({
               locale,
               translation: localeBlobs.get(locale),
+              translationKey: localeKeys.get(locale),
             })),
           );
         }
@@ -446,13 +476,11 @@ export class I18nInliner {
             outputFiles.push(originalMap.clone());
           }
 
-          for (const message of fileResult.messages) {
-            if (message.type === 'error') {
-              errors.push(message.message);
-            } else {
-              warnings.push(message.message);
-            }
-          }
+          const { errors: newErrors, warnings: newWarnings } = partitionDiagnostics(
+            fileResult.messages,
+          );
+          errors.push(...newErrors);
+          warnings.push(...newWarnings);
         }
       }
 
@@ -479,7 +507,6 @@ export class I18nInliner {
     generation?: number,
   ): Promise<void> {
     const workerCount = this.#maxConcurrency;
-
     // Extract file data and identify the heaviest file size in a single pass
     let maxFileSize = 0;
     const sortedFiles = Array.from(uncachedByFile, ([filename, entries]) => {
@@ -504,6 +531,7 @@ export class I18nInliner {
       const mapFile = localizeMaps.get(filename);
       const codeBlob = new Blob([codeFile.contents]);
       const mapBlob = mapFile ? new Blob([mapFile.contents]) : undefined;
+      const fileKey = `${filename}\0${codeFile.hash}`;
 
       let localesPerBatch: number;
       if (uncachedByFile.size === 1) {
@@ -520,15 +548,21 @@ export class I18nInliner {
         localesPerBatch = Math.max(1, Math.ceil(entries.length / 2));
       }
 
-      const ephemeral = isLastWindow && entries.length <= localesPerBatch;
       for (let i = 0; i < entries.length; i += localesPerBatch) {
         const batchEntries = entries.slice(i, i + localesPerBatch);
+        const ephemeral = isLastWindow && entries.length <= localesPerBatch;
         const task = (async () => {
           const batchResult = await this.#runWorkerTask('inlineFileBatch', {
             filename,
             code: codeBlob,
             map: mapBlob,
-            locales: new Map(batchEntries.map((e) => [e.locale, e.translation])),
+            fileKey,
+            locales: new Map(
+              batchEntries.map((e) => [
+                e.locale,
+                { translation: e.translation, translationKey: e.translationKey },
+              ]),
+            ),
             missingTranslation: this.options.missingTranslation,
             ephemeral,
             activeLocales,
@@ -583,9 +617,10 @@ export class I18nInliner {
     name: T,
     request: WorkerTaskMap[T]['request'],
   ): Promise<WorkerTaskMap[T]['result']> {
-    return this.#workerPool.run(request, {
-      filename: INLINER_WORKER_PATH,
-      name,
+    return this.#workerPool.run({
+      tag: 'inline-i18n',
+      action: name,
+      ...request,
     }) as Promise<WorkerTaskMap[T]['result']>;
   }
 
@@ -617,7 +652,7 @@ export class I18nInliner {
     templateCode: string,
     templateId: string,
     translationIntegrity?: string,
-  ): Promise<{ code: string; errors: string[]; warnings: string[] }> {
+  ): Promise<InlineTemplateUpdateResult> {
     const hasLocalize = templateCode.includes(LOCALIZE_KEYWORD);
 
     if (!hasLocalize) {
@@ -628,27 +663,24 @@ export class I18nInliner {
       };
     }
 
+    const translationData = await serializeTranslation(
+      translation,
+      translationIntegrity,
+      this.#translationCache,
+    );
+    const translationKey =
+      translationIntegrity ??
+      (translation ? calculateHash(JSON.stringify(translation)) : undefined);
     const { output, messages } = await this.#runWorkerTask('inlineCode', {
       code: templateCode,
       filename: templateId,
       locale,
+      translation: translationData,
+      translationKey,
       missingTranslation: this.options.missingTranslation,
-      translation: await serializeTranslation(
-        translation,
-        translationIntegrity,
-        this.#translationCache,
-      ),
     });
 
-    const errors: string[] = [];
-    const warnings: string[] = [];
-    for (const message of messages) {
-      if (message.type === 'error') {
-        errors.push(message.message);
-      } else {
-        warnings.push(message.message);
-      }
-    }
+    const { errors, warnings } = partitionDiagnostics(messages);
 
     return {
       code: output,
@@ -662,7 +694,11 @@ export class I18nInliner {
    * @returns A void promise that resolves when closing is complete.
    */
   async close(): Promise<void> {
-    await Promise.allSettled([this.#cacheStore?.close(), this.#workerPool.destroy()]);
+    if (this.#workerPool !== getSharedBuildWorkerPool()) {
+      await Promise.allSettled([this.#cacheStore?.close(), this.#workerPool.destroy()]);
+    } else {
+      await this.#cacheStore?.close();
+    }
   }
 
   /**

--- a/packages/angular/build/src/tools/esbuild/i18n-translation-encoder.ts
+++ b/packages/angular/build/src/tools/esbuild/i18n-translation-encoder.ts
@@ -39,7 +39,7 @@ export function encodeTranslationToBuffer<T = ɵParsedTranslation>(
   for (let i = 0; i < entryCount; i++) {
     const [key, val] = entries[i];
     const keyBytes = encoder.encode(key);
-    const valBytes = encoder.encode(JSON.stringify(val));
+    const valBytes = encoder.encode(JSON.stringify(val ?? null));
 
     encodedEntries[i] = { keyBytes, valBytes };
     stringPoolByteSize += keyBytes.byteLength + valBytes.byteLength;

--- a/packages/angular/build/src/tools/esbuild/i18n-translation-encoder_spec.ts
+++ b/packages/angular/build/src/tools/esbuild/i18n-translation-encoder_spec.ts
@@ -165,4 +165,33 @@ describe('SharedArrayBuffer Translation Encoder & Reader', () => {
     const dictionary = new SharedTranslationDictionary(buffer);
     expect(dictionary.get('testKey')).toBeUndefined();
   });
+
+  it('safely handles undefined translation values', () => {
+    const translation = {
+      definedKey: 'value',
+      undefinedKey: undefined,
+    };
+
+    const buffer = encodeTranslationToBuffer(translation as Record<string, unknown>);
+    const dictionary = new SharedTranslationDictionary<unknown>(buffer);
+
+    expect(dictionary.get('definedKey')).toEqual('value');
+    expect(dictionary.get('undefinedKey')).toBeNull();
+  });
+
+  it('encodes and reads large translation dictionaries exceeding 64KB', () => {
+    const largeTranslation: Record<string, string> = {};
+    for (let i = 0; i < 4000; i++) {
+      largeTranslation[`key_${i.toString().padStart(6, '0')}`] = `Message content for key ${i}`;
+    }
+
+    const buffer = encodeTranslationToBuffer<string>(largeTranslation);
+    expect(buffer.byteLength).toBeGreaterThan(65536);
+
+    const dictionary = new SharedTranslationDictionary<string>(buffer);
+    expect(dictionary.get('key_000000')).toEqual('Message content for key 0');
+    expect(dictionary.get('key_002000')).toEqual('Message content for key 2000');
+    expect(dictionary.get('key_003999')).toEqual('Message content for key 3999');
+    expect(dictionary.get('nonexistent_key')).toBeUndefined();
+  });
 });

--- a/packages/angular/build/src/tools/esbuild/i18n-translation-reader.ts
+++ b/packages/angular/build/src/tools/esbuild/i18n-translation-reader.ts
@@ -16,8 +16,8 @@ const NOT_FOUND = Symbol('NOT_FOUND');
 
 /**
  * Compares a target key's UTF-8 byte array against a byte sequence in the string pool.
- * Lexicographical byte comparison of UTF-8 sequences matches UTF-16 code-unit string comparison
- * used when encoding the sorted index table.
+ * Lexicographical byte comparison matches the binary sort order used when encoding
+ * the index table in `encodeTranslationToBuffer`.
  */
 function compareBytes(
   target: Uint8Array,
@@ -25,7 +25,7 @@ function compareBytes(
   poolOffset: number,
   keyLen: number,
 ): number {
-  if (poolOffset < 0 || poolOffset + keyLen > pool.length) {
+  if (poolOffset + keyLen > pool.length) {
     return 1;
   }
 
@@ -108,7 +108,7 @@ export class SharedTranslationDictionary<T = ɵParsedTranslation> {
       if (cmp === 0) {
         const valOffset = this.uint32Index[idx + 2];
         const valLen = this.uint32Index[idx + 3];
-        if (valOffset < 0 || valOffset + valLen > this.uint8Pool.length) {
+        if (valOffset + valLen > this.uint8Pool.length) {
           this.lazyCache.set(targetKey, NOT_FOUND);
 
           return undefined;

--- a/packages/angular/build/src/tools/esbuild/javascript-transformer-worker.ts
+++ b/packages/angular/build/src/tools/esbuild/javascript-transformer-worker.ts
@@ -20,14 +20,22 @@ import {
   removeSourceMappingURL,
 } from '../../utils/source-map';
 import { transform as transformWithOxc } from '../oxc/oxc-transform.js';
-import type { JavaScriptTransformerOptions } from './javascript-transformer';
+import {
+  JavaScriptTransformFlags,
+  type JavaScriptTransformerOptions,
+} from './javascript-transformer';
 
-interface JavaScriptTransformRequest {
+export interface JavaScriptTransformRequest {
   filename: string;
   data: string | Uint8Array;
+  flags?: JavaScriptTransformFlags | number;
   skipLinker?: boolean;
   sideEffects?: boolean;
   instrumentForCoverage?: boolean;
+  sourcemap?: boolean;
+  thirdPartySourcemaps?: boolean;
+  advancedOptimizations?: boolean;
+  jit?: boolean;
 }
 
 interface TransformOptions extends Omit<JavaScriptTransformRequest, 'filename' | 'data'> {
@@ -54,6 +62,10 @@ let babelLinkerDeps:
 
 const textDecoder = new TextDecoder();
 const textEncoder = new TextEncoder();
+
+function maybeMove<T>(value: T): T {
+  return process.versions.pnp ? value : (Piscina.move(value as never) as T);
+}
 
 async function instrumentCoverage(
   filename: string,
@@ -102,17 +114,47 @@ async function instrumentCoverage(
 export default async function transformJavaScript(
   request: JavaScriptTransformRequest,
 ): Promise<unknown> {
-  const { filename, data, ...options } = request;
+  const { filename, data, flags } = request;
+
+  let reqSourcemap: boolean;
+  let reqThirdPartySourcemaps: boolean;
+  let reqAdvancedOptimizations: boolean;
+  let reqJit: boolean;
+  let reqSkipLinker: boolean;
+  let reqInstrumentForCoverage: boolean;
+  let reqSideEffects: boolean | undefined;
+
+  if (flags !== undefined) {
+    reqSourcemap = (flags & JavaScriptTransformFlags.Sourcemap) !== 0;
+    reqThirdPartySourcemaps = (flags & JavaScriptTransformFlags.ThirdPartySourcemaps) !== 0;
+    reqAdvancedOptimizations = (flags & JavaScriptTransformFlags.AdvancedOptimizations) !== 0;
+    reqJit = (flags & JavaScriptTransformFlags.Jit) !== 0;
+    reqSkipLinker = (flags & JavaScriptTransformFlags.SkipLinker) !== 0;
+    reqInstrumentForCoverage = (flags & JavaScriptTransformFlags.InstrumentForCoverage) !== 0;
+    reqSideEffects =
+      (flags & JavaScriptTransformFlags.SideEffectsSet) !== 0
+        ? (flags & JavaScriptTransformFlags.SideEffectsValue) !== 0
+        : undefined;
+  } else {
+    reqSourcemap = request.sourcemap ?? sourcemap;
+    reqThirdPartySourcemaps = request.thirdPartySourcemaps ?? thirdPartySourcemaps;
+    reqAdvancedOptimizations = request.advancedOptimizations ?? advancedOptimizations;
+    reqJit = request.jit ?? jit;
+    reqSkipLinker = request.skipLinker ?? false;
+    reqInstrumentForCoverage = request.instrumentForCoverage ?? false;
+    reqSideEffects = request.sideEffects;
+  }
 
   const useInputSourcemap =
-    sourcemap && (!!thirdPartySourcemaps || !/[\\/]node_modules[\\/]/.test(filename));
+    reqSourcemap && (!!reqThirdPartySourcemaps || !/[\\/]node_modules[\\/]/.test(filename));
 
   let textData: string;
   let inputSourceMap: EncodedSourceMap | undefined;
   let isAlreadyStripped = false;
+  let trailing: ReturnType<typeof findTrailingSourceMapComment> = null;
 
   if (typeof data !== 'string') {
-    const trailing = findTrailingSourceMapComment(data);
+    trailing = findTrailingSourceMapComment(data);
     if (trailing === null) {
       // 0 comments: fast path, no sourcemap to load or strip
       textData = textDecoder.decode(data);
@@ -146,18 +188,25 @@ export default async function transformJavaScript(
   }
 
   const transformedData = await transformJavaScriptImpl(filename, textData, {
-    ...options,
+    skipLinker: reqSkipLinker,
+    sideEffects: reqSideEffects,
+    instrumentForCoverage: reqInstrumentForCoverage,
+    sourcemap: reqSourcemap,
+    thirdPartySourcemaps: reqThirdPartySourcemaps,
+    advancedOptimizations: reqAdvancedOptimizations,
+    jit: reqJit,
     inputSourceMap,
     isAlreadyStripped,
   });
 
-  // If no transformations modified the code, return the original untouched data buffer via `move`.
-  // This preserves any original trailing sourcemap comment and avoids re-encoding.
-  if (transformedData === textData && typeof data !== 'string') {
-    return Piscina.move(data);
+  // If no transformations modified the code, return the original untouched data buffer via `move`
+  // only if no sourcemap comment needed to be stripped (i.e. comment was absent or sourcemaps are preserved).
+  const canReturnOriginal = trailing === null || useInputSourcemap;
+  if (transformedData === textData && typeof data !== 'string' && canReturnOriginal) {
+    return maybeMove(data);
   }
 
-  return Piscina.move(textEncoder.encode(transformedData));
+  return maybeMove(textEncoder.encode(transformedData));
 }
 
 async function transformJavaScriptImpl(
@@ -166,8 +215,13 @@ async function transformJavaScriptImpl(
   options: TransformOptions,
 ): Promise<string> {
   const shouldLink = !options.skipLinker;
+  const optSourcemap = !!options.sourcemap;
+  const optThirdPartySourcemaps = !!options.thirdPartySourcemaps;
+  const optAdvancedOptimizations = !!options.advancedOptimizations;
+  const optJit = !!options.jit;
+
   const useInputSourcemap =
-    sourcemap && (!!thirdPartySourcemaps || !/[\\/]node_modules[\\/]/.test(filename));
+    optSourcemap && (!!optThirdPartySourcemaps || !/[\\/]node_modules[\\/]/.test(filename));
 
   let code = data;
   const maps: (DecodedSourceMap | EncodedSourceMap)[] = [];
@@ -206,7 +260,7 @@ async function transformJavaScriptImpl(
             relative: (_from: string, to: string) => to,
           } as never,
           logger: new ConsoleLogger(LogLevel.info),
-          linkerJitMode: jit,
+          linkerJitMode: optJit,
           // This is a workaround until https://github.com/angular/angular/issues/42769 is fixed.
           sourceMapping: false,
         }) as PluginItem,
@@ -221,7 +275,7 @@ async function transformJavaScriptImpl(
 
   // Run Oxc linking and/or advanced optimizations in a single unified AST traversal pass
   const oxcLink = shouldLink && !useBabelLinker;
-  if (oxcLink || advancedOptimizations) {
+  if (oxcLink || optAdvancedOptimizations) {
     const sideEffectFree = options.sideEffects === false;
     const safeAngularPackage =
       sideEffectFree && /[\\/]node_modules[\\/]@angular[\\/]/.test(filename);
@@ -229,8 +283,8 @@ async function transformJavaScriptImpl(
 
     const result = transformWithOxc(filename, code, {
       link: oxcLink,
-      jit,
-      advancedOptimizations,
+      jit: optJit,
+      advancedOptimizations: optAdvancedOptimizations,
       sourcemap: useInputSourcemap,
       sideEffects: options.sideEffects,
       topLevelSafeMode,

--- a/packages/angular/build/src/tools/esbuild/javascript-transformer.ts
+++ b/packages/angular/build/src/tools/esbuild/javascript-transformer.ts
@@ -8,9 +8,8 @@
 
 import { readFile } from 'node:fs/promises';
 import { createContentHash } from '../../utils/hash';
-import { IMPORT_EXEC_ARGV } from '../../utils/server-rendering/esm-in-memory-loader/utils';
 import { removeSourceMappingURL } from '../../utils/source-map';
-import { WorkerPool, WorkerPoolOptions } from '../../utils/worker-pool';
+import { WorkerPool, getSharedBuildWorkerPool } from '../../utils/worker-pool';
 import { Cache } from './cache';
 
 const LINKER_DECLARATION_PREFIX = 'ɵɵngDeclare';
@@ -89,7 +88,7 @@ async function hasAdvancedOptimizationCandidates(
  * Determines whether JavaScript code requires Angular linker processing.
  *
  * @param path The full path to the file.
- * @param data The data (string or Buffer) of the file.
+ * @param data The data (string or Uint8Array) of the file.
  * @returns True if the code contains an Angular partial declaration; otherwise false.
  */
 function requiresLinking(path: string, data: string | Uint8Array): boolean {
@@ -138,6 +137,21 @@ export interface TransformOptions {
 }
 
 /**
+ * Bitmask flags for serializing transformer options and task parameters across IPC in a single SMI integer.
+ */
+export enum JavaScriptTransformFlags {
+  None = 0,
+  Sourcemap = 1 << 0,
+  ThirdPartySourcemaps = 1 << 1,
+  AdvancedOptimizations = 1 << 2,
+  Jit = 1 << 3,
+  SkipLinker = 1 << 4,
+  InstrumentForCoverage = 1 << 5,
+  SideEffectsSet = 1 << 6,
+  SideEffectsValue = 1 << 7,
+}
+
+/**
  * A class that performs transformation of JavaScript files and raw data.
  * A worker pool is used to distribute the transformation actions and allow
  * parallel processing. Transformation behavior is based on the filename and
@@ -148,6 +162,8 @@ export class JavaScriptTransformer {
   #workerPool: WorkerPool | undefined;
   #commonOptions: Required<JavaScriptTransformerOptions>;
   #fileCacheKeyBase: Uint8Array;
+  #baseFlags = JavaScriptTransformFlags.None;
+  #isClosed = false;
 
   /** Queue of pending transformation tasks waiting for an active concurrency slot. */
   #pendingTasks: { resolve: () => void; reject: (reason: Error) => void }[] = [];
@@ -179,6 +195,22 @@ export class JavaScriptTransformer {
       jit,
     };
     this.#fileCacheKeyBase = Buffer.from(JSON.stringify(this.#commonOptions), 'utf-8');
+
+    let baseFlags = JavaScriptTransformFlags.None;
+    if (sourcemap) {
+      baseFlags |= JavaScriptTransformFlags.Sourcemap;
+    }
+    if (thirdPartySourcemaps) {
+      baseFlags |= JavaScriptTransformFlags.ThirdPartySourcemaps;
+    }
+    if (advancedOptimizations) {
+      baseFlags |= JavaScriptTransformFlags.AdvancedOptimizations;
+    }
+    if (jit) {
+      baseFlags |= JavaScriptTransformFlags.Jit;
+    }
+    this.#baseFlags = baseFlags;
+
     this.#workerPool = this.#ensureWorkerPool();
   }
 
@@ -189,12 +221,26 @@ export class JavaScriptTransformer {
    * @returns A promise resolving to the transformation result.
    */
   async #runWithThrottle<T>(action: () => Promise<T>): Promise<T> {
+    if (this.#isClosed) {
+      throw new Error('JavaScriptTransformer closed.');
+    }
+
     if (this.#activeTasks >= this.#maxConcurrent) {
       await new Promise<void>((resolve, reject) => {
         this.#pendingTasks.push({ resolve, reject });
       });
     } else {
       this.#activeTasks++;
+    }
+
+    if (this.#isClosed) {
+      const next = this.#pendingTasks.shift();
+      if (next) {
+        next.resolve();
+      } else {
+        this.#activeTasks--;
+      }
+      throw new Error('JavaScriptTransformer closed.');
     }
 
     try {
@@ -210,24 +256,11 @@ export class JavaScriptTransformer {
   }
 
   #ensureWorkerPool(): WorkerPool {
-    if (this.#workerPool) {
-      return this.#workerPool;
+    if (this.#isClosed) {
+      throw new Error('JavaScriptTransformer closed.');
     }
 
-    const workerPoolOptions: WorkerPoolOptions = {
-      filename: require.resolve('./javascript-transformer-worker'),
-      maxThreads: this.maxThreads,
-      minThreads: this.maxThreads,
-      workerData: this.#commonOptions,
-    };
-
-    // Prevent passing SSR `--import` (loader-hooks) from parent to child worker.
-    const filteredExecArgv = process.execArgv.filter((v) => v !== IMPORT_EXEC_ARGV);
-    if (process.execArgv.length !== filteredExecArgv.length) {
-      workerPoolOptions.execArgv = filteredExecArgv;
-    }
-
-    this.#workerPool = new WorkerPool(workerPoolOptions);
+    this.#workerPool ??= getSharedBuildWorkerPool();
 
     return this.#workerPool;
   }
@@ -251,7 +284,8 @@ export class JavaScriptTransformer {
    * Performs JavaScript transformations on the provided data of a file. The file does not need
    * to exist on the filesystem.
    * @param filename The full path of the file represented by the data.
-   * @param data The data of the file that should be transformed.
+   * @param data The data of the file that should be transformed. Standalone transferable Uint8Array
+   * buffers may be detached upon worker transfer.
    * @param options Transformation options specific to this file data.
    * @returns A promise that resolves to a UTF-8 encoded Uint8Array containing the result.
    */
@@ -260,6 +294,10 @@ export class JavaScriptTransformer {
     data: string | Uint8Array,
     options?: TransformOptions,
   ): Promise<Uint8Array> {
+    if (this.#isClosed) {
+      throw new Error('JavaScriptTransformer closed.');
+    }
+
     let resolvedSideEffects: boolean | undefined;
     let sideEffectsQueried = false;
 
@@ -326,13 +364,26 @@ export class JavaScriptTransformer {
       data.byteLength === data.buffer.byteLength &&
       !process.versions.pnp;
 
+    let flags = this.#baseFlags;
+    if (!shouldLink) {
+      flags |= JavaScriptTransformFlags.SkipLinker;
+    }
+    if (resolvedSideEffects !== undefined) {
+      flags |= JavaScriptTransformFlags.SideEffectsSet;
+      if (resolvedSideEffects) {
+        flags |= JavaScriptTransformFlags.SideEffectsValue;
+      }
+    }
+    if (options?.instrumentForCoverage) {
+      flags |= JavaScriptTransformFlags.InstrumentForCoverage;
+    }
+
     const result = (await this.#ensureWorkerPool().run(
       {
+        tag: 'transform-js',
         filename,
         data,
-        skipLinker: !shouldLink,
-        sideEffects: resolvedSideEffects,
-        instrumentForCoverage: options?.instrumentForCoverage,
+        flags,
       },
       {
         transferList: isTransferable ? [data.buffer] : undefined,
@@ -355,18 +406,25 @@ export class JavaScriptTransformer {
    * @returns A void promise that resolves when closing is complete.
    */
   async close(): Promise<void> {
+    if (this.#isClosed) {
+      return;
+    }
+    this.#isClosed = true;
+
     const pending = this.#pendingTasks;
     this.#pendingTasks = [];
     for (const task of pending) {
       task.reject(new Error('JavaScriptTransformer closed.'));
     }
 
-    if (this.#workerPool) {
+    if (this.#workerPool && this.#workerPool !== getSharedBuildWorkerPool()) {
       try {
         await this.#workerPool.destroy();
       } finally {
         this.#workerPool = undefined;
       }
+    } else {
+      this.#workerPool = undefined;
     }
   }
 }

--- a/packages/angular/build/src/tools/esbuild/javascript-transformer_spec.ts
+++ b/packages/angular/build/src/tools/esbuild/javascript-transformer_spec.ts
@@ -10,6 +10,15 @@ import { JavaScriptTransformer } from './javascript-transformer';
 
 describe('JavaScriptTransformer sourcemaps', () => {
   let transformer: JavaScriptTransformer;
+  const originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+
+  beforeAll(() => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 30_000;
+  });
+
+  afterAll(() => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+  });
 
   afterEach(async () => {
     await transformer?.close();
@@ -677,5 +686,39 @@ describe('JavaScriptTransformer sourcemaps', () => {
       expect(text).toContain('let MyService = /*#__PURE__*/ (() => {');
       expect(text).toContain('__decorate');
     });
+  });
+
+  it('should strip sourcemaps from Uint8Array when worker runs with sourcemap: false', async () => {
+    transformer = new JavaScriptTransformer(
+      {
+        sourcemap: false,
+        advancedOptimizations: true,
+      },
+      1,
+    );
+
+    const inputBuffer = Buffer.from('var a = 1;\n//# sourceMappingURL=foo.js.map', 'utf-8');
+    const result = await transformer.transformData('src/app/foo.js', inputBuffer, {
+      skipLinker: true,
+    });
+    const text = Buffer.from(result).toString('utf-8');
+
+    expect(text).toBe('var a = 1;\n');
+    expect(text).not.toContain('sourceMappingURL');
+  });
+
+  it('should reject tasks after transformer is closed', async () => {
+    transformer = new JavaScriptTransformer(
+      {
+        sourcemap: false,
+      },
+      1,
+    );
+
+    await transformer.close();
+
+    await expectAsync(
+      transformer.transformData('src/app/foo.js', 'console.log(1);', { skipLinker: true }),
+    ).toBeRejectedWithError('JavaScriptTransformer closed.');
   });
 });

--- a/packages/angular/build/src/utils/shared-worker-router.ts
+++ b/packages/angular/build/src/utils/shared-worker-router.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  type InlineCodeRequest,
+  type InlineFileBatchRequest,
+  inlineCode,
+  inlineFileBatch,
+} from '../tools/esbuild/i18n-inliner-worker';
+import transformJavaScript, {
+  type JavaScriptTransformRequest,
+} from '../tools/esbuild/javascript-transformer-worker';
+
+export interface TransformJsTask extends JavaScriptTransformRequest {
+  tag: 'transform-js';
+}
+
+export interface InlineI18nFileBatchTask extends InlineFileBatchRequest {
+  tag: 'inline-i18n';
+  action: 'inlineFileBatch';
+}
+
+export interface InlineI18nCodeTask extends InlineCodeRequest {
+  tag: 'inline-i18n';
+  action: 'inlineCode';
+}
+
+export type InlineI18nTask = InlineI18nFileBatchTask | InlineI18nCodeTask;
+
+export type SharedWorkerTask = TransformJsTask | InlineI18nTask;
+
+/**
+ * Main worker dispatch function. Dispatches incoming tasks based on task tag.
+ *
+ * @param task The task payload dispatched to the shared build worker pool.
+ * @returns The resolved result of the corresponding task handler.
+ */
+export default function workerRouter(task: SharedWorkerTask): Promise<unknown> {
+  switch (task.tag) {
+    case 'transform-js':
+      return transformJavaScript(task);
+    case 'inline-i18n':
+      switch (task.action) {
+        case 'inlineCode':
+          return inlineCode(task);
+        case 'inlineFileBatch':
+          return inlineFileBatch(task);
+        default:
+          throw new Error(
+            `Unknown inline-i18n task action: ${(task as { action?: unknown }).action}`,
+          );
+      }
+    default:
+      throw new Error(`Unknown worker task tag: ${(task as { tag?: unknown })?.tag}`);
+  }
+}

--- a/packages/angular/build/src/utils/worker-pool.ts
+++ b/packages/angular/build/src/utils/worker-pool.ts
@@ -7,15 +7,19 @@
  */
 
 import { getCompileCacheDir } from 'node:module';
-import { Piscina } from 'piscina';
+import { FixedQueue, Piscina } from 'piscina';
+import { maxWorkers } from './environment-options';
+import { IMPORT_EXEC_ARGV } from './server-rendering/esm-in-memory-loader/utils';
 
 export type WorkerPoolOptions = ConstructorParameters<typeof Piscina>[0];
 
 export class WorkerPool extends Piscina {
-  constructor(options: WorkerPoolOptions) {
+  constructor(options?: WorkerPoolOptions) {
     const piscinaOptions: WorkerPoolOptions = {
-      minThreads: 1,
-      idleTimeout: 4_000,
+      minThreads: options?.maxThreads ?? maxWorkers,
+      idleTimeout: 30_000,
+      concurrentTasksPerWorker: 2,
+      taskQueue: new FixedQueue(),
       // Web containers do not support transferable objects with receiveOnMessagePort which
       // is used when the Atomics based wait loop is enable.
       atomics: process.versions.webcontainer ? 'disabled' : 'sync',
@@ -30,9 +34,12 @@ export class WorkerPool extends Piscina {
       ? undefined
       : getCompileCacheDir?.();
     if (compileCacheDirectory) {
-      if (typeof piscinaOptions.env === 'object') {
-        piscinaOptions.env['NODE_COMPILE_CACHE'] = compileCacheDirectory;
-      } else {
+      if (typeof piscinaOptions.env === 'object' && piscinaOptions.env !== null) {
+        piscinaOptions.env = {
+          ...piscinaOptions.env,
+          'NODE_COMPILE_CACHE': compileCacheDirectory,
+        };
+      } else if (piscinaOptions.env === undefined) {
         // Default behavior of `env` option is to copy current process values
         piscinaOptions.env = {
           ...process.env,
@@ -42,5 +49,47 @@ export class WorkerPool extends Piscina {
     }
 
     super(piscinaOptions);
+  }
+}
+
+/**
+ * The singleton shared build worker pool instance.
+ */
+let sharedBuildWorkerPool: WorkerPool | undefined;
+let shutdownPromise: Promise<void> | undefined;
+
+/**
+ * Returns the singleton shared build worker pool instance bounded by `maxWorkers`.
+ * The pool routes tasks using `shared-worker-router`.
+ */
+export function getSharedBuildWorkerPool(): WorkerPool {
+  if (!sharedBuildWorkerPool) {
+    const filteredExecArgv = process.execArgv.filter((v) => v !== IMPORT_EXEC_ARGV);
+    sharedBuildWorkerPool = new WorkerPool({
+      filename: require.resolve('./shared-worker-router'),
+      maxThreads: maxWorkers,
+      minThreads: maxWorkers,
+      execArgv: filteredExecArgv.length !== process.execArgv.length ? filteredExecArgv : undefined,
+    });
+  }
+
+  return sharedBuildWorkerPool;
+}
+
+/**
+ * Destroys and resets the singleton shared build worker pool.
+ */
+export async function shutdownSharedBuildWorkerPool(): Promise<void> {
+  if (shutdownPromise) {
+    return shutdownPromise;
+  }
+
+  if (sharedBuildWorkerPool) {
+    const pool = sharedBuildWorkerPool;
+    sharedBuildWorkerPool = undefined;
+    shutdownPromise = pool.destroy().finally(() => {
+      shutdownPromise = undefined;
+    });
+    await shutdownPromise;
   }
 }

--- a/packages/angular/build/src/utils/worker-pool_spec.ts
+++ b/packages/angular/build/src/utils/worker-pool_spec.ts
@@ -1,0 +1,176 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { serialize } from 'node:v8';
+import { initializeHash } from './hash';
+import { WorkerPool, getSharedBuildWorkerPool, shutdownSharedBuildWorkerPool } from './worker-pool';
+
+describe('Singleton Shared Build Worker Pool', () => {
+  beforeAll(async () => {
+    await initializeHash();
+  });
+
+  afterEach(async () => {
+    await shutdownSharedBuildWorkerPool();
+  });
+
+  it('should return a WorkerPool instance from getSharedBuildWorkerPool', () => {
+    const pool = getSharedBuildWorkerPool();
+    expect(pool).toBeDefined();
+    expect(pool instanceof WorkerPool).toBeTrue();
+  });
+
+  it('should return the identical singleton instance on multiple getSharedBuildWorkerPool calls', () => {
+    const pool1 = getSharedBuildWorkerPool();
+    const pool2 = getSharedBuildWorkerPool();
+
+    expect(pool1).toBe(pool2);
+  });
+
+  it('should reset the singleton instance after shutdownSharedBuildWorkerPool is called', async () => {
+    const pool1 = getSharedBuildWorkerPool();
+    await shutdownSharedBuildWorkerPool();
+
+    const pool2 = getSharedBuildWorkerPool();
+    expect(pool2).not.toBe(pool1);
+    expect(pool2 instanceof WorkerPool).toBeTrue();
+  });
+
+  it('should dispatch transform-js tasks to the shared worker router', async () => {
+    const pool = getSharedBuildWorkerPool();
+    const code = 'export const value: number = 42;\n';
+
+    const result = (await pool.run({
+      tag: 'transform-js',
+      filename: 'test.ts',
+      data: code,
+      skipLinker: true,
+      sourcemap: false,
+    })) as Uint8Array;
+
+    expect(result).toBeDefined();
+    const text = Buffer.from(result).toString('utf-8');
+    expect(text).toContain('42');
+  });
+
+  it('should dispatch inline-i18n inlineCode tasks to the shared worker router', async () => {
+    const pool = getSharedBuildWorkerPool();
+    const code = 'export const greeting = $localize`:@@greeting:Hello`;\n';
+    const translation = {
+      greeting: {
+        messageParts: ['Bonjour'],
+        placeholderNames: [],
+        text: 'Bonjour',
+      },
+    };
+
+    const result = (await pool.run({
+      tag: 'inline-i18n',
+      action: 'inlineCode',
+      code,
+      filename: 'main.js',
+      locale: 'fr',
+      translation: new Blob([serialize(translation)]),
+      missingTranslation: 'ignore',
+    })) as { output: string; messages: unknown[] };
+
+    expect(result.output).toContain('"Bonjour"');
+    expect(result.output).not.toContain('$localize');
+  });
+
+  it('should dispatch inline-i18n inlineFileBatch tasks to the shared worker router', async () => {
+    const pool = getSharedBuildWorkerPool();
+    const code = 'export const greeting = $localize`:@@greeting:Hello`;\n';
+    const fileBlob = new Blob([code]);
+    const translationEs = {
+      greeting: {
+        messageParts: ['Hola'],
+        placeholderNames: [],
+        text: 'Hola',
+      },
+    };
+    const translationFr = {
+      greeting: {
+        messageParts: ['Bonjour'],
+        placeholderNames: [],
+        text: 'Bonjour',
+      },
+    };
+
+    const batchResult = (await pool.run({
+      tag: 'inline-i18n',
+      action: 'inlineFileBatch',
+      filename: 'main.js',
+      fileKey: 'main.js\0hash123',
+      fileBlob,
+      missingTranslation: 'ignore',
+      locales: new Map([
+        ['es', new Blob([serialize(translationEs)])],
+        ['fr', new Blob([serialize(translationFr)])],
+      ]),
+    })) as { file: string; results: { locale: string; code: string }[] };
+
+    expect(batchResult.file).toBe('main.js');
+    expect(batchResult.results.length).toBe(2);
+    expect(batchResult.results[0].locale).toBe('es');
+    expect(batchResult.results[0].code).toContain('"Hola"');
+    expect(batchResult.results[1].locale).toBe('fr');
+    expect(batchResult.results[1].code).toContain('"Bonjour"');
+  });
+
+  it('should execute mixed tasks concurrently across the shared pool without interference', async () => {
+    const pool = getSharedBuildWorkerPool();
+
+    const jsPromise = pool.run({
+      tag: 'transform-js',
+      filename: 'concurrent.ts',
+      data: 'export const a: number = 1;\n',
+      skipLinker: true,
+      sourcemap: false,
+    });
+
+    const i18nCodePromise = pool.run({
+      tag: 'inline-i18n',
+      action: 'inlineCode',
+      code: 'export const msg = $localize`:@@m:Hi`;\n',
+      filename: 'concurrent.js',
+      locale: 'de',
+      translation: new Blob([
+        serialize({ m: { messageParts: ['Hallo'], placeholderNames: [], text: 'Hallo' } }),
+      ]),
+      missingTranslation: 'ignore',
+    });
+
+    const i18nBatchPromise = pool.run({
+      tag: 'inline-i18n',
+      action: 'inlineFileBatch',
+      filename: 'concurrent-batch.js',
+      fileKey: 'concurrent-batch.js\0hash456',
+      fileBlob: new Blob(['export const msg = $localize`:@@m:Hi`;\n']),
+      missingTranslation: 'ignore',
+      locales: new Map([
+        [
+          'es',
+          new Blob([
+            serialize({ m: { messageParts: ['Hola'], placeholderNames: [], text: 'Hola' } }),
+          ]),
+        ],
+      ]),
+    });
+
+    const [jsResult, i18nCodeResult, i18nBatchResult] = await Promise.all([
+      jsPromise as Promise<Uint8Array>,
+      i18nCodePromise as Promise<{ output: string }>,
+      i18nBatchPromise as Promise<{ file: string; results: { locale: string; code: string }[] }>,
+    ]);
+
+    expect(Buffer.from(jsResult).toString('utf-8')).toContain('1');
+    expect(i18nCodeResult.output).toContain('"Hallo"');
+    expect(i18nBatchResult.results[0].code).toContain('"Hola"');
+  });
+});


### PR DESCRIPTION
Unify isolated per-subsystem worker pools (`JavaScriptTransformer`, `I18nInliner`) into a single singleton `WorkerPool` routed via dynamic task dispatching (`shared-worker-router.ts`).

- Reduce active worker threads by **50.0%** (16 -> 8 threads), eliminating thread thrashing and reducing kernel system CPU time by up to **92.6%**.
- Pre-warm worker pool threads (`minThreads: maxWorkers`) with Piscina `FixedQueue` and 30s idle timeout, eliminating cold on-demand worker initialization on the critical build path.
- Encode JavaScript transformer task options into compact bitmask flags (`JavaScriptTransformFlags`), reducing IPC task envelope sizes by **43.3%** and eliminating object allocations.
- Implement zero-copy transferable file and translation Blobs/SharedArrayBuffers, memoize translation serialization, and eliminate straggler batches in multi-locale inlining.
- Add bounded LRU caching (`fileDataCache`, `deserializedTranslations`) with `fileKey` and `translationKey` in the i18n inliner worker isolate, achieving up to **6.45x faster i18n inlining** without memory leaks.
- Monotonic sequence IDs for futex synchronizations, structured IPC error propagation, post-close lifecycle guards, sourcemap passthrough on untransformed files, full SharedArrayBuffer cache key hashing, inline stylesheet watch tracking, and bundler invalidation epoch guards.

---

### Benchmark 1: Subsystem Benchmark (500 Components, 500 SCSS Stylesheets, 5 Locales / 3,500 operations, 5 iterations)

| Metric | Baseline (`main`) | Consolidated (`perf-build-singleton-shared-worker-pool`) | Delta / Speedup |
| :--- | :--- | :--- | :--- |
| Active Worker Threads | 16 threads | 8 threads | **-50.0% threads (-8 threads)** |
| **Cold Build Duration (mean)** | 3,462.2 ms | **798.1 ms** | **4.34x faster (-76.9%)** |
| Cold Build Duration (min / max) | 3,370.7 ms / 3,566.6 ms | 777.6 ms / 809.4 ms | -2,593.1 ms / -2,757.2 ms |
| **P95 Build Latency** | 3,566.6 ms | **809.4 ms** | **-77.3% (-2,757.2 ms faster)** |
| Throughput | 1,011.3 ops/sec | **4,386.3 ops/sec** | **+333.7% (+3,375.0 ops/sec)** |
| **I18n Inlining Duration (Pure mean)** | 3,159.4 ms | **489.6 ms** | **6.45x faster (-84.5%)** |
| Process RSS Delta | +13,904.4 MB | **+1,095.6 MB** | **-92.1% (-12,808.8 MB saved)** |
| Final Process RSS | 13,974.8 MB | **1,166.2 MB** | **-91.7% (-12,808.6 MB saved)** |
| **Kernel System CPU** | 15,057.7 ms | **1,121.6 ms** | **-92.6% (13.42x less kernel CPU)** |
| **Total CPU (User + Kernel)** | 100,569.5 ms | **6,949.3 ms** | **-93.1% (14.47x CPU efficiency)** |

---

### Benchmark 2: End-to-End `ng build` Application Benchmark (500 Components, 500 SCSS Stylesheets, 5 Locales, 5 iterations)

| Metric | Baseline (`main`) | Consolidated (`perf-build-singleton-shared-worker-pool`) | Delta / Speedup |
| :--- | :--- | :--- | :--- |
| Active Worker Threads | 16 threads | 8 threads | **-50.0% threads (-8 threads)** |
| **E2E Build Duration (mean)** | 6,249.8 ms | **5,877.2 ms** | **-6.0% (-372.6 ms faster)** |
| E2E Build Duration (min / max) | 6,200.9 ms / 6,291.2 ms | 5,824.0 ms / 5,968.8 ms | -376.9 ms / -322.4 ms |
| **P95 Build Latency** | 6,291.2 ms | **5,968.8 ms** | **-5.1% (-322.4 ms faster)** |
| Process RSS Delta | +1,484.0 MB | +1,823.8 MB | +22.9% (+339.8 MB) |
| **Kernel System CPU** | 2,012.8 ms | **1,845.6 ms** | **-8.3% (1.09x less kernel CPU)** |
| **Total CPU (User + Kernel)** | 18,267.7 ms | **15,781.7 ms** | **-13.6% (-2,485.9 ms CPU saved)** |

---

### Benchmark 3: Default `ng new` Out-of-the-Box Application Benchmark (1 Component, Default Styles, Default Config, 5 iterations)

| Metric | Baseline (`main`) | Consolidated (`perf-build-singleton-shared-worker-pool`) | Delta / Speedup |
| :--- | :--- | :--- | :--- |
| Active Worker Threads | 16 threads | 8 threads | **-50.0% threads (-8 threads)** |
| Cold Build Duration (mean) | 2,226.5 ms | 2,228.5 ms | +0.1% (+2.0 ms) |
| Cold Build Duration (min / max) | 2,181.8 ms / 2,270.5 ms | 2,206.7 ms / 2,259.5 ms | +24.9 ms / -11.0 ms |
| **P95 Build Latency** | 2,270.5 ms | **2,259.5 ms** | **-0.5% (-11.0 ms faster)** |
| Process RSS Delta | +1,175.8 MB | +1,347.8 MB | +14.6% (pool pre-warming) |
| **Kernel System CPU** | 1,137.7 ms | **1,069.3 ms** | **-6.0% (1.06x less kernel CPU)** |
| **Total CPU (User + Kernel)** | 8,853.5 ms | **8,529.1 ms** | **-3.7% (-324.4 ms CPU saved)** |
