### PR TITLE
fix(@angular/build): ignore side-effect annotations in unit test builds

### DIFF
--- a/packages/angular/build/src/builders/unit-test/tests/behavior/vitest-barrel-side-effects_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/behavior/vitest-barrel-side-effects_spec.ts
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { execute } from '../../index';
+import { BASE_OPTIONS, describeBuilder, UNIT_TEST_BUILDER_INFO } from '../setup';
+
+describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
+  describe('Behavior: "Vitest barrel sideEffects"', () => {
+    // Regression test for https://github.com/angular/angular-cli/issues/33910.
+    it('should retain barrel-exported components when package.json has sideEffects: false', async () => {
+      harness.withBuilderTarget(
+        'build',
+        async () => ({ success: true }),
+        {
+          project: 'src/lib/ng-package.json',
+        },
+        {
+          builderName: '@angular/build:ng-packagr',
+        },
+      );
+
+      await harness.modifyFile('tsconfig.json', (content) => {
+        const tsconfig = JSON.parse(content);
+        tsconfig.compilerOptions ??= {};
+        tsconfig.compilerOptions.paths = {
+          '@lib': ['./src/lib/public-api.ts'],
+          '@lib/sub': ['./src/lib/sub/public-api.ts'],
+        };
+
+        return JSON.stringify(tsconfig);
+      });
+
+      await harness.writeFiles({
+        'src/lib/package.json': JSON.stringify({
+          name: '@lib',
+          version: '0.0.1',
+          sideEffects: false,
+        }),
+        'src/lib/ng-package.json': JSON.stringify({
+          lib: {
+            entryFile: 'public-api.ts',
+          },
+        }),
+        'src/lib/public-api.ts': `
+          export * from './components/public-api-components';
+          export * from './other/other.component';
+        `,
+        'src/lib/components/public-api-components.ts': `export * from './foo/foo.component';`,
+        'src/lib/components/foo/foo.component.ts': `
+          import { Component } from '@angular/core';
+
+          @Component({
+            selector: 'lib-foo',
+            standalone: true,
+            template: '<p>foo</p>',
+          })
+          export class FooComponent {}
+        `,
+        'src/lib/other/other.component.ts': `
+          import { Component } from '@angular/core';
+
+          @Component({
+            selector: 'lib-other',
+            standalone: true,
+            template: '<p>other</p>',
+          })
+          export class OtherComponent {}
+        `,
+        'src/lib/other/other.component.spec.ts': `
+          import { TestBed } from '@angular/core/testing';
+          import { describe, it, expect } from 'vitest';
+          import { OtherComponent } from '@lib';
+
+          describe('OtherComponent', () => {
+            it('creates', () => {
+              TestBed.configureTestingModule({
+                imports: [OtherComponent],
+              });
+              const fixture = TestBed.createComponent(OtherComponent);
+              expect(fixture).toBeTruthy();
+            });
+          });
+        `,
+        'src/lib/sub/ng-package.json': JSON.stringify({
+          lib: {
+            entryFile: 'public-api.ts',
+          },
+        }),
+        'src/lib/sub/public-api.ts': `export * from './bar/bar.component';`,
+        'src/lib/sub/bar/bar.component.ts': `
+          import { Component } from '@angular/core';
+          import { FooComponent } from '@lib';
+
+          @Component({
+            selector: 'lib-bar',
+            standalone: true,
+            imports: [FooComponent],
+            template: '<lib-foo></lib-foo>',
+          })
+          export class BarComponent {}
+        `,
+        'src/lib/sub/bar/bar.component.spec.ts': `
+          import { TestBed } from '@angular/core/testing';
+          import { describe, it, expect } from 'vitest';
+          import { BarComponent } from './bar.component';
+
+          describe('BarComponent', () => {
+            it('creates', () => {
+              TestBed.configureTestingModule({
+                imports: [BarComponent],
+              });
+              const fixture = TestBed.createComponent(BarComponent);
+              expect(fixture).toBeTruthy();
+            });
+          });
+        `,
+      });
+
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        include: ['lib/**/*.spec.ts'],
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBeTrue();
+    });
+  });
+});

--- a/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
@@ -75,6 +75,9 @@ export function createBrowserCodeBundleOptions(
       // Splitting emits shared chunks that are read across chunk boundaries as live ESM bindings,
       // which the unit-test runners' module loading does not reliably preserve.
       buildOptions.splitting = false;
+      // In unit test builds, package.json "sideEffects": false annotations can cause esbuild
+      // to incorrectly elide statically-referenced barrel module bodies across multiple entry points.
+      buildOptions.ignoreAnnotations = true;
     }
 
     buildOptions.plugins ??= [];


### PR DESCRIPTION
In libraries built with ng-packagr, `package.json` typically specifies `"sideEffects": false` so consumer applications can tree-shake unused code. However, when executing unit tests through `@angular/build:unit-test`, the test builder bundles workspace library source directly (via tsconfig paths).

Because esbuild tree-shaking respects `"sideEffects": false` annotations in the enclosing `package.json`, bundling multiple spec entry points without splitting can cause esbuild to prune module bodies (such as component definitions) from multi-level `export *` barrel graphs while retaining namespace re-export accessors. At runtime, accessing the exported symbols evaluates to `undefined`, causing failures such as `TypeError: Cannot read properties of undefined (reading 'ɵcmp')`.

Test bundles are executed locally in memory and never distributed over the wire, so side-effect annotations and pure call pruning are not required. Setting `ignoreAnnotations: true` when `disableCodeSplitting` is enabled ensures that statically reachable barrel exports in workspace code are retained without affecting production application or package builds.

Closes #33910