### PR TITLE
test(@angular/build): ensure hash init in i18n inliner tests

### DIFF
--- a/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
@@ -19,7 +19,6 @@ import {
   SERVER_APP_MANIFEST_FILENAME,
   SERVER_GENERATED_EXTERNALS,
 } from '../../utils/server-rendering/manifest';
-import { AngularCompilation, NoopCompilation } from '../angular/compilation';
 import { AngularCompilationContext } from './angular/compilation-state';
 import { createCompilerPlugin } from './angular/compiler-plugin';
 import { ComponentStylesheetBundler } from './angular/component-stylesheets';

--- a/packages/angular/build/src/tools/esbuild/i18n-inliner_spec.ts
+++ b/packages/angular/build/src/tools/esbuild/i18n-inliner_spec.ts
@@ -10,6 +10,7 @@ import { transform } from 'esbuild';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { initializeHash } from '../../utils/hash';
 import { type BuildOutputFile, BuildOutputFileType, createOutputFile } from './bundler-files';
 import { I18nInliner } from './i18n-inliner';
 
@@ -50,6 +51,10 @@ describe('I18nInliner', () => {
 
     return inliner;
   }
+
+  beforeAll(async () => {
+    await initializeHash();
+  });
 
   afterEach(async () => {
     await inliner?.close();


### PR DESCRIPTION
The i18n inliner hashes output files which requires the hash utility to be initialized prior to execution. This adds `initializeHash()` to `beforeAll` in `i18n-inliner_spec.ts`. Also removes an unused import in `application-code-bundle.ts`.