### PR TITLE
perf(@angular/build): implement SharedArrayBuffer translation dictionaries for zero-copy worker access

### DIFF
--- a/packages/angular/build/src/tools/esbuild/i18n-inliner-worker.ts
+++ b/packages/angular/build/src/tools/esbuild/i18n-inliner-worker.ts
@@ -13,6 +13,7 @@ import assert from 'node:assert';
 import { deserialize } from 'node:v8';
 import { workerData } from 'node:worker_threads';
 import { parseSync, visitorKeys } from 'oxc-parser';
+import { createSharedTranslationProxy } from './i18n-translation-reader';
 
 /**
  * The options passed to the inliner for each file request
@@ -31,10 +32,10 @@ interface InlineFileRequest {
 
   /**
    * The serialized translation messages for the locale that should be used during the inlining
-   * process of the file. A Blob is used so that the messages are shared with the Worker by
-   * reference instead of being copied into it for every request.
+   * process of the file. A SharedArrayBuffer or Blob is used so that the messages are shared with
+   * the Worker by reference instead of being copied into it for every request.
    */
-  translation?: Blob;
+  translation?: Blob | SharedArrayBuffer;
 }
 
 /**
@@ -58,10 +59,10 @@ interface InlineCodeRequest {
 
   /**
    * The serialized translation messages for the locale that should be used during the inlining
-   * process of the file. A Blob is used so that the messages are shared with the Worker by
-   * reference instead of being copied into it for every request.
+   * process of the file. A SharedArrayBuffer or Blob is used so that the messages are shared with
+   * the Worker by reference instead of being copied into it for every request.
    */
-  translation?: Blob;
+  translation?: Blob | SharedArrayBuffer;
 }
 
 /**
@@ -77,7 +78,7 @@ interface InlineFileBatchRequest {
   /**
    * The locale specifiers or locale objects that should be used during the inlining process of the file.
    */
-  locales: (string | { locale: string; translation?: Blob })[];
+  locales: (string | { locale: string; translation?: Blob | SharedArrayBuffer })[];
 
   /**
    * Whether the file data should be treated as ephemeral and not cached long-term in the Worker.
@@ -114,7 +115,7 @@ interface InlineFileBatchResult {
 const { files, missingTranslation, translations } = (workerData || {}) as {
   files: ReadonlyMap<string, Blob>;
   missingTranslation: 'error' | 'warning' | 'ignore';
-  translations?: ReadonlyMap<string, Blob>;
+  translations?: ReadonlyMap<string, Blob | SharedArrayBuffer>;
 };
 
 /**
@@ -172,30 +173,34 @@ function loadFileData(filename: string, cache = true): Promise<CachedFileData> {
 }
 
 /**
- * Deserializes the translation messages for a locale, reusing the result for any
+ * Deserializes or wraps the translation messages for a locale, reusing the result for any
  * subsequent request that targets the same locale.
  * @param locale The locale identifier.
- * @param translation Optional serialized translation messages. If omitted, workerData.translations is used.
+ * @param translation Optional serialized translation messages (SharedArrayBuffer or Blob).
  * @returns The translation messages, or undefined if the locale has no translations.
  */
 function loadTranslation(
   locale: string,
-  translation?: Blob,
+  translation?: Blob | SharedArrayBuffer,
 ): Promise<Record<string, unknown>> | undefined {
-  const translationBlob = translation ?? translations?.get(locale);
-  if (!translationBlob) {
+  const translationData = translation ?? translations?.get(locale);
+  if (!translationData) {
     return undefined;
   }
 
   let messagesPromise = deserializedTranslations.get(locale);
   if (!messagesPromise) {
-    messagesPromise = translationBlob
-      .arrayBuffer()
-      .then((buffer) => deserialize(new Uint8Array(buffer)) as Record<string, unknown>)
-      .catch((error) => {
-        deserializedTranslations.delete(locale);
-        throw error;
-      });
+    if (translationData instanceof Blob) {
+      messagesPromise = translationData
+        .arrayBuffer()
+        .then((buffer) => deserialize(new Uint8Array(buffer)) as Record<string, unknown>)
+        .catch((error) => {
+          deserializedTranslations.delete(locale);
+          throw error;
+        });
+    } else {
+      messagesPromise = Promise.resolve(createSharedTranslationProxy(translationData));
+    }
     deserializedTranslations.set(locale, messagesPromise);
   }
 

--- a/packages/angular/build/src/tools/esbuild/i18n-inliner.ts
+++ b/packages/angular/build/src/tools/esbuild/i18n-inliner.ts
@@ -13,6 +13,7 @@ import { calculateHash, createContentHash, initializeHash } from '../../utils/ha
 import { WorkerPool } from '../../utils/worker-pool';
 import { type BuildOutputFile, BuildOutputFileType, createOutputFile } from './bundler-files';
 import { type Cache, type PersistentCacheStore, createPersistentCacheStore } from './cache';
+import { encodeTranslationToBuffer } from './i18n-translation-encoder';
 
 /**
  * A keyword used to indicate if a JavaScript file may require inlining of translations.
@@ -29,15 +30,25 @@ const DEFAULT_LOCALE_WINDOW_SIZE = 8;
 /**
  * Serializes the translation messages for a locale for transfer to an inliner Worker.
  *
- * A Blob is used because cloning one shares its data by reference, whereas sending the messages
- * themselves copies them into a Worker for every request that carries them. A locale can contain
- * tens of thousands of messages, which makes that copy the dominant cost of inlining a locale.
+ * A SharedArrayBuffer is preferred because it enables zero-copy shared memory access
+ * and on-demand string decoding across all worker threads. Falls back to a Blob when
+ * SharedArrayBuffer is unavailable.
  *
  * @param translation The translation messages for a locale, if the locale has any.
- * @returns A Blob containing the serialized messages, or undefined if the locale has none.
+ * @returns A SharedArrayBuffer or Blob containing the serialized messages, or undefined if none.
  */
-function serializeTranslation(translation: Record<string, unknown> | undefined): Blob | undefined {
-  return translation && new Blob([serialize(translation)]);
+function serializeTranslation(
+  translation: Record<string, unknown> | undefined,
+): SharedArrayBuffer | Blob | undefined {
+  if (!translation) {
+    return undefined;
+  }
+
+  if (typeof SharedArrayBuffer !== 'undefined') {
+    return encodeTranslationToBuffer(translation);
+  }
+
+  return new Blob([serialize(translation)]);
 }
 
 /**
@@ -49,7 +60,7 @@ export interface I18nInlinerOptions {
   shouldOptimize?: boolean;
   persistentCachePath?: string;
   localizeVersion?: string;
-  translations?: ReadonlyMap<string, Blob>;
+  translations?: ReadonlyMap<string, Blob | SharedArrayBuffer>;
 }
 
 /**
@@ -114,6 +125,15 @@ interface CacheCheckItem {
    * A promise that resolves to the cached transform result, or null if uncached or on lookup failure.
    */
   cachedResult: Promise<TransformedFileResult | null>;
+}
+
+/**
+ * An uncached transformation request entry for a file within a specific locale.
+ */
+interface UncachedLocaleEntry {
+  locale: string;
+  cacheKey?: string;
+  translation?: Blob | SharedArrayBuffer;
 }
 
 /**
@@ -237,7 +257,7 @@ export class I18nInliner {
 
       // Pre-calculate cache key bases and serialized Blobs for each locale in this window
       const localeCacheBases = new Map<string, string>();
-      const localeBlobs = new Map<string, Blob | undefined>();
+      const localeBlobs = new Map<string, Blob | SharedArrayBuffer | undefined>();
 
       for (const { locale, translation, translationIntegrity } of windowLocales) {
         localeBlobs.set(locale, serializeTranslation(translation));
@@ -302,10 +322,7 @@ export class I18nInliner {
       );
 
       // Group uncached items by filename for this window
-      const uncachedByFile = new Map<
-        string,
-        Array<{ locale: string; cacheKey?: string; translation?: Blob }>
-      >();
+      const uncachedByFile = new Map<string, UncachedLocaleEntry[]>();
 
       for (const item of resolvedChecks) {
         if (item.result) {
@@ -386,7 +403,7 @@ export class I18nInliner {
   }
 
   async #processUncachedBatches(
-    uncachedByFile: Map<string, Array<{ locale: string; cacheKey?: string; translation?: Blob }>>,
+    uncachedByFile: Map<string, UncachedLocaleEntry[]>,
     localeCount: number,
     fileResultsByLocale: Map<string, Map<string, TransformedFileResult>>,
     activeLocales?: string[],

--- a/packages/angular/build/src/tools/esbuild/i18n-translation-encoder.ts
+++ b/packages/angular/build/src/tools/esbuild/i18n-translation-encoder.ts
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+/**
+ * Magic header identifier for i18n SharedArrayBuffer translation tables ('I18N').
+ */
+export const I18N_MAGIC_ID = 0x4931384e;
+
+/**
+ * Encodes a JavaScript translation dictionary into a contiguous SharedArrayBuffer.
+ * The buffer contains a header, a sorted index table (by key for fast O(log N) binary search),
+ * and a UTF-8 string pool.
+ *
+ * @param translation The translation dictionary object.
+ * @returns A SharedArrayBuffer containing the binary encoded translation catalog.
+ */
+export function encodeTranslationToBuffer(translation: Record<string, unknown>): SharedArrayBuffer {
+  const encoder = new TextEncoder();
+  const entries = Object.entries(translation);
+  const entryCount = entries.length;
+
+  // Pre-encode string keys and JSON-serialized string values
+  const encodedEntries: {
+    keyBytes: Uint8Array;
+    valBytes: Uint8Array;
+  }[] = new Array(entryCount);
+
+  let stringPoolByteSize = 0;
+
+  for (let i = 0; i < entryCount; i++) {
+    const [key, val] = entries[i];
+    const keyBytes = encoder.encode(key);
+    const valBytes = encoder.encode(JSON.stringify(val));
+
+    encodedEntries[i] = { keyBytes, valBytes };
+    stringPoolByteSize += keyBytes.byteLength + valBytes.byteLength;
+  }
+
+  // Sort entries lexicographically by UTF-8 byte comparison.
+  // Lexicographical byte comparison matches the binary search reader's byte comparison,
+  // ensuring deterministic and zero-allocation lookups across all runtimes regardless of UTF-16 surrogate pairs.
+  encodedEntries.sort((a, b) => {
+    const aBytes = a.keyBytes;
+    const bBytes = b.keyBytes;
+    const minLen = Math.min(aBytes.length, bBytes.length);
+
+    for (let i = 0; i < minLen; i++) {
+      const diff = aBytes[i] - bBytes[i];
+      if (diff !== 0) {
+        return diff;
+      }
+    }
+
+    return aBytes.length - bBytes.length;
+  });
+
+  const indexByteSize = entryCount * 16;
+  const headerByteSize = 16;
+  const stringPoolOffset = headerByteSize + indexByteSize;
+
+  const totalByteSize = stringPoolOffset + stringPoolByteSize;
+  const buffer = new SharedArrayBuffer(totalByteSize);
+
+  // Set up views over the SharedArrayBuffer
+  const uint32Header = new Uint32Array(buffer, 0, 4);
+  const uint32Index = new Uint32Array(buffer, headerByteSize, entryCount * 4);
+  const uint8Pool = new Uint8Array(buffer, stringPoolOffset);
+
+  // Write Header: Magic, EntryCount, IndexOffset, StringPoolOffset
+  uint32Header[0] = I18N_MAGIC_ID;
+  uint32Header[1] = entryCount;
+  uint32Header[2] = headerByteSize;
+  uint32Header[3] = stringPoolOffset;
+
+  // Write Index Table and String Pool entries
+  let currentPoolOffset = 0;
+
+  for (let i = 0; i < entryCount; i++) {
+    const { keyBytes, valBytes } = encodedEntries[i];
+
+    const keyOffset = currentPoolOffset;
+    const keyLen = keyBytes.byteLength;
+    uint8Pool.set(keyBytes, keyOffset);
+    currentPoolOffset += keyLen;
+
+    const valOffset = currentPoolOffset;
+    const valLen = valBytes.byteLength;
+    uint8Pool.set(valBytes, valOffset);
+    currentPoolOffset += valLen;
+
+    // Index entry format (4 uint32 words / 16 bytes):
+    // [0]: keyOffset (uint32)
+    // [1]: keyLength (uint32)
+    // [2]: valOffset (uint32)
+    // [3]: valLength (uint32)
+    const idx = i * 4;
+    uint32Index[idx] = keyOffset;
+    uint32Index[idx + 1] = keyLen;
+    uint32Index[idx + 2] = valOffset;
+    uint32Index[idx + 3] = valLen;
+  }
+
+  return buffer;
+}

--- a/packages/angular/build/src/tools/esbuild/i18n-translation-encoder_spec.ts
+++ b/packages/angular/build/src/tools/esbuild/i18n-translation-encoder_spec.ts
@@ -1,0 +1,168 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { encodeTranslationToBuffer } from './i18n-translation-encoder';
+import {
+  SharedTranslationDictionary,
+  createSharedTranslationProxy,
+} from './i18n-translation-reader';
+
+describe('SharedArrayBuffer Translation Encoder & Reader', () => {
+  it('encodes and reads simple key-value translations', () => {
+    const translation = {
+      greeting: 'Hello',
+      farewell: 'Goodbye',
+      numberKey: 42,
+      arrayKey: ['part1', 'part2'],
+    };
+
+    const buffer = encodeTranslationToBuffer(translation);
+    const dictionary = new SharedTranslationDictionary(buffer);
+
+    expect(dictionary.get('greeting')).toEqual('Hello');
+    expect(dictionary.get('farewell')).toEqual('Goodbye');
+    expect(dictionary.get('numberKey')).toEqual(42);
+    expect(dictionary.get('arrayKey')).toEqual(['part1', 'part2']);
+    expect(dictionary.get('nonexistent')).toBeUndefined();
+  });
+
+  it('works with Proxy wrapper and "in" operator', () => {
+    const translation = {
+      msg1: 'Message 1',
+      msg2: 'Message 2',
+    };
+
+    const buffer = encodeTranslationToBuffer(translation);
+    const proxy = createSharedTranslationProxy(buffer);
+
+    expect(proxy['msg1']).toEqual('Message 1');
+    expect(proxy['msg2']).toEqual('Message 2');
+    expect(proxy['unknown']).toBeUndefined();
+    expect('msg1' in proxy).toBeTrue();
+    expect('msg2' in proxy).toBeTrue();
+    expect('unknown' in proxy).toBeFalse();
+  });
+
+  it('supports Object.prototype.hasOwnProperty and Object.getOwnPropertyDescriptor on Proxy', () => {
+    const translation = {
+      msg1: 'Message 1',
+    };
+
+    const buffer = encodeTranslationToBuffer(translation);
+    const proxy = createSharedTranslationProxy(buffer);
+
+    expect(Object.prototype.hasOwnProperty.call(proxy, 'msg1')).toBeTrue();
+    expect(Object.prototype.hasOwnProperty.call(proxy, 'unknown')).toBeFalse();
+
+    const desc = Object.getOwnPropertyDescriptor(proxy, 'msg1');
+    expect(desc).toBeDefined();
+    expect(desc?.value).toEqual('Message 1');
+    expect(desc?.enumerable).toBeTrue();
+
+    const missingDesc = Object.getOwnPropertyDescriptor(proxy, 'unknown');
+    expect(missingDesc).toBeUndefined();
+
+    // Verify standard Object.prototype methods work and don't throw
+    expect(typeof proxy.toString).toBe('function');
+    expect(proxy.toString()).toEqual('[object Object]');
+    expect(typeof proxy.valueOf).toBe('function');
+    expect('toString' in proxy).toBeTrue();
+    expect(String(proxy)).toEqual('[object Object]');
+  });
+
+  it('handles non-BMP Unicode surrogate pairs and high BMP keys correctly', () => {
+    const translation = {
+      '😀': 'emoji message',
+      '\uE000': 'uE000 message',
+      'abc': 'abc message',
+    };
+
+    const buffer = encodeTranslationToBuffer(translation);
+    const dictionary = new SharedTranslationDictionary(buffer);
+
+    expect(dictionary.get('😀')).toEqual('emoji message');
+    expect(dictionary.get('\uE000')).toEqual('uE000 message');
+    expect(dictionary.get('abc')).toEqual('abc message');
+  });
+
+  it('handles empty translation dictionaries', () => {
+    const buffer = encodeTranslationToBuffer({});
+    const dictionary = new SharedTranslationDictionary(buffer);
+
+    expect(dictionary.get('anyKey')).toBeUndefined();
+  });
+
+  it('caches missing translation lookups efficiently', () => {
+    const translation = {
+      msg1: 'Message 1',
+    };
+
+    const buffer = encodeTranslationToBuffer(translation);
+    const dictionary = new SharedTranslationDictionary(buffer);
+
+    // First lookup for missing key
+    expect(dictionary.get('missingKey')).toBeUndefined();
+    // Second lookup for missing key (should hit lazyCache NOT_FOUND sentinel)
+    expect(dictionary.get('missingKey')).toBeUndefined();
+  });
+
+  it('validates header size and offsets on initialization', () => {
+    // Buffer too small
+    const smallSab = new SharedArrayBuffer(8);
+    expect(() => new SharedTranslationDictionary(smallSab)).toThrowError(
+      'Invalid SharedArrayBuffer translation header: buffer too small.',
+    );
+
+    // Invalid magic header
+    const badMagicSab = new SharedArrayBuffer(16);
+    expect(() => new SharedTranslationDictionary(badMagicSab)).toThrowError(
+      'Invalid SharedArrayBuffer translation header magic identifier.',
+    );
+
+    // Out-of-bounds offset values
+    const invalidOffsetsSab = new SharedArrayBuffer(16);
+    const view = new Uint32Array(invalidOffsetsSab);
+    view[0] = 0x4931384e; // I18N_MAGIC_ID
+    view[1] = 100; // entryCount = 100 entries requiring 1600 bytes
+    view[2] = 16;
+    view[3] = 16;
+    expect(() => new SharedTranslationDictionary(invalidOffsetsSab)).toThrowError(
+      'Invalid SharedArrayBuffer translation header offsets.',
+    );
+
+    // Unaligned header size
+    const unalignedHeaderSab = new SharedArrayBuffer(32);
+    const unalignedView = new Uint32Array(unalignedHeaderSab);
+    unalignedView[0] = 0x4931384e;
+    unalignedView[1] = 0;
+    unalignedView[2] = 17; // unaligned header byte size
+    unalignedView[3] = 17;
+    expect(() => new SharedTranslationDictionary(unalignedHeaderSab)).toThrowError(
+      'Invalid SharedArrayBuffer translation header offsets.',
+    );
+  });
+
+  it('safely handles corrupted index offsets within a valid header', () => {
+    // 1 entry: header (16 bytes) + index (16 bytes) + pool (10 bytes) = 42 bytes
+    const buffer = new SharedArrayBuffer(48);
+    const uint32 = new Uint32Array(buffer);
+    uint32[0] = 0x4931384e; // Magic
+    uint32[1] = 1; // 1 entry
+    uint32[2] = 16; // header size
+    uint32[3] = 32; // string pool offset
+
+    // Corrupted entry: keyOffset points past pool length
+    uint32[4] = 100; // keyOffset = 100
+    uint32[5] = 5; // keyLen = 5
+    uint32[6] = 0; // valOffset = 0
+    uint32[7] = 5; // valLen = 5
+
+    const dictionary = new SharedTranslationDictionary(buffer);
+    expect(dictionary.get('testKey')).toBeUndefined();
+  });
+});

--- a/packages/angular/build/src/tools/esbuild/i18n-translation-reader.ts
+++ b/packages/angular/build/src/tools/esbuild/i18n-translation-reader.ts
@@ -1,0 +1,193 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { I18N_MAGIC_ID } from './i18n-translation-encoder';
+
+/**
+ * Sentinel value used to cache non-existent message key lookups in lazyCache.
+ */
+const NOT_FOUND = Symbol('NOT_FOUND');
+
+/**
+ * Compares a target key's UTF-8 byte array against a byte sequence in the string pool.
+ * Lexicographical byte comparison of UTF-8 sequences matches UTF-16 code-unit string comparison
+ * used when encoding the sorted index table.
+ */
+function compareBytes(
+  target: Uint8Array,
+  pool: Uint8Array,
+  poolOffset: number,
+  keyLen: number,
+): number {
+  if (poolOffset < 0 || poolOffset + keyLen > pool.length) {
+    return 1;
+  }
+
+  const minLen = Math.min(target.length, keyLen);
+  for (let i = 0; i < minLen; i++) {
+    const diff = target[i] - pool[poolOffset + i];
+    if (diff !== 0) {
+      return diff;
+    }
+  }
+
+  return target.length - keyLen;
+}
+
+/**
+ * A zero-copy reader that queries translation messages directly from a SharedArrayBuffer
+ * using binary search over a sorted key index.
+ */
+export class SharedTranslationDictionary {
+  private readonly entryCount: number;
+  private readonly uint32Index: Uint32Array;
+  private readonly uint8Pool: Uint8Array;
+  private readonly decoder = new TextDecoder();
+  private readonly encoder = new TextEncoder();
+  private readonly lazyCache = new Map<string, unknown>();
+
+  constructor(buffer: SharedArrayBuffer) {
+    if (buffer.byteLength < 16) {
+      throw new Error('Invalid SharedArrayBuffer translation header: buffer too small.');
+    }
+
+    const uint32Header = new Uint32Array(buffer, 0, 4);
+    if (uint32Header[0] !== I18N_MAGIC_ID) {
+      throw new Error('Invalid SharedArrayBuffer translation header magic identifier.');
+    }
+
+    this.entryCount = uint32Header[1];
+    const headerByteSize = uint32Header[2];
+    const stringPoolOffset = uint32Header[3];
+
+    if (
+      headerByteSize < 16 ||
+      headerByteSize % 4 !== 0 ||
+      headerByteSize + this.entryCount * 16 > buffer.byteLength ||
+      stringPoolOffset < headerByteSize + this.entryCount * 16 ||
+      stringPoolOffset > buffer.byteLength
+    ) {
+      throw new Error('Invalid SharedArrayBuffer translation header offsets.');
+    }
+
+    this.uint32Index = new Uint32Array(buffer, headerByteSize, this.entryCount * 4);
+    this.uint8Pool = new Uint8Array(buffer, stringPoolOffset);
+  }
+
+  /**
+   * Looks up a translation message by key.
+   * Performs a binary search over the index table if not previously cached in the lazy cache.
+   *
+   * @param targetKey The message key ID to search for.
+   * @returns The parsed translation message, or undefined if not found.
+   */
+  get(targetKey: string): unknown | undefined {
+    const cached = this.lazyCache.get(targetKey);
+    if (cached !== undefined) {
+      return cached === NOT_FOUND ? undefined : cached;
+    }
+
+    const targetBytes = this.encoder.encode(targetKey);
+    let low = 0;
+    let high = this.entryCount - 1;
+
+    while (low <= high) {
+      const mid = (low + high) >>> 1;
+      const idx = mid * 4;
+
+      const keyOffset = this.uint32Index[idx];
+      const keyLen = this.uint32Index[idx + 1];
+
+      const cmp = compareBytes(targetBytes, this.uint8Pool, keyOffset, keyLen);
+      if (cmp === 0) {
+        const valOffset = this.uint32Index[idx + 2];
+        const valLen = this.uint32Index[idx + 3];
+        if (valOffset < 0 || valOffset + valLen > this.uint8Pool.length) {
+          this.lazyCache.set(targetKey, NOT_FOUND);
+
+          return undefined;
+        }
+
+        const valBytes = this.uint8Pool.subarray(valOffset, valOffset + valLen);
+        const valJson = this.decoder.decode(valBytes);
+
+        try {
+          const val = JSON.parse(valJson);
+          this.lazyCache.set(targetKey, val);
+
+          return val;
+        } catch {
+          this.lazyCache.set(targetKey, NOT_FOUND);
+
+          return undefined;
+        }
+      } else if (cmp < 0) {
+        high = mid - 1;
+      } else {
+        low = mid + 1;
+      }
+    }
+
+    this.lazyCache.set(targetKey, NOT_FOUND);
+
+    return undefined;
+  }
+}
+
+/**
+ * Creates a JavaScript object Proxy wrapping a SharedTranslationDictionary so it can be passed
+ * directly to `@angular/localize` inliner functions as a standard translation Record.
+ *
+ * Traps `get`, `has`, and `getOwnPropertyDescriptor` to fulfill all `@angular/localize` `translate()`
+ * lookup requirements (`translations[id]`, `translations[legacyId]`, `Object.hasOwn(translations, id)`).
+ * The `ownKeys` trap is intentionally omitted so keys are not eagerly decoded upfront upon reflection.
+ *
+ * @param buffer The SharedArrayBuffer containing binary encoded translation catalog.
+ * @returns A Proxy object that intercepts property reads and queries the SharedTranslationDictionary.
+ */
+export function createSharedTranslationProxy(buffer: SharedArrayBuffer): Record<string, unknown> {
+  const dictionary = new SharedTranslationDictionary(buffer);
+
+  return new Proxy(
+    {},
+    {
+      get(target, prop: string | symbol) {
+        if (typeof prop === 'string') {
+          const value = dictionary.get(prop);
+          if (value !== undefined) {
+            return value;
+          }
+        }
+
+        return Reflect.get(target, prop);
+      },
+      has(target, prop: string | symbol) {
+        if (typeof prop === 'string' && dictionary.get(prop) !== undefined) {
+          return true;
+        }
+
+        return Reflect.has(target, prop);
+      },
+      getOwnPropertyDescriptor(target, prop: string | symbol) {
+        if (typeof prop === 'string') {
+          const val = dictionary.get(prop);
+          if (val !== undefined) {
+            return {
+              enumerable: true,
+              configurable: true,
+              writable: false,
+              value: val,
+            };
+          }
+        }
+
+        return Reflect.getOwnPropertyDescriptor(target, prop);
+      },
+    },
+  );
+}


### PR DESCRIPTION
Translation catalogs are encoded into a contiguous SharedArrayBuffer containing a binary header, sorted index table with lexicographical string keys, and UTF-8 string pool via encodeTranslationToBuffer. Lookups perform zero-copy binary search over shared memory pages with on-demand string decoding through a Proxy wrapper compatible with @angular/localize.

I18nInliner and worker tasks prefer SharedArrayBuffer over V8 serialized Blobs for windowed locale translation passing, eliminating Structured Clone heap duplication across worker threads. Serialized Blobs are retained as a fallback for environments such as WebContainers that do not support SharedArrayBuffer.