### PR TITLE
refactor(@angular/build): optimize i18n locale polyfill data bundling per locale

### DIFF
--- a/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
@@ -697,20 +697,12 @@ function getEsBuildCommonPolyfillsOptions(
   }
 
   // Add Angular's global locale data if i18n options are present.
-  // Locale data should go first so that project provided polyfill code can augment if needed.
   let needLocaleDataPlugin = false;
   if (i18nOptions.shouldInline) {
     // Remove localize polyfill when i18n inline transformation have been applied to all the packages.
     polyfills = polyfills.filter((path) => !path.startsWith('@angular/localize'));
-
-    // Add locale data for all active locales
-    // TODO: Inject each individually within the inlining process itself
-    for (const locale of i18nOptions.inlineLocales) {
-      polyfills.unshift(`angular:locale/data:${locale}`);
-    }
-    needLocaleDataPlugin = true;
   } else if (i18nOptions.hasDefinedSourceLocale) {
-    // When not inlining and a source local is present, use the source locale data directly
+    // When not inlining and a source locale is present, use the source locale data directly
     polyfills.unshift(`angular:locale/data:${i18nOptions.sourceLocale}`);
     needLocaleDataPlugin = true;
   }
@@ -718,7 +710,7 @@ function getEsBuildCommonPolyfillsOptions(
     buildOptions.plugins.unshift(createAngularLocaleDataPlugin());
   }
 
-  if (polyfills.length === 0) {
+  if (polyfills.length === 0 && !i18nOptions.shouldInline && !i18nOptions.hasDefinedSourceLocale) {
     return;
   }
 

--- a/packages/angular/build/src/tools/esbuild/i18n-inliner-worker.ts
+++ b/packages/angular/build/src/tools/esbuild/i18n-inliner-worker.ts
@@ -13,6 +13,7 @@ import assert from 'node:assert';
 import { deserialize } from 'node:v8';
 import { workerData } from 'node:worker_threads';
 import { parseSync, visitorKeys } from 'oxc-parser';
+import { loadLocaleData } from './i18n-locale-plugin';
 import { createSharedTranslationProxy } from './i18n-translation-reader';
 
 /**
@@ -502,8 +503,22 @@ async function inlineLocalize(
     }
   }
 
-  for (const site of metadata.localeInsertSites) {
-    magicString.overwrite(site.start, site.end, JSON.stringify(locale));
+  if (metadata.localeInsertSites.length > 0) {
+    const localeData = await loadLocaleData(locale);
+    if (localeData.error) {
+      diagnostics.error(localeData.error);
+    } else if (localeData.warning) {
+      diagnostics.warn(localeData.warning);
+    }
+    let injected = false;
+    for (const site of metadata.localeInsertSites) {
+      magicString.overwrite(
+        site.start,
+        site.end,
+        JSON.stringify(locale) + (localeData.code && !injected ? `;\n${localeData.code}\n;` : ''),
+      );
+      injected = true;
+    }
   }
 
   for (const callSite of metadata.callSites) {

--- a/packages/angular/build/src/tools/esbuild/i18n-inliner_spec.ts
+++ b/packages/angular/build/src/tools/esbuild/i18n-inliner_spec.ts
@@ -544,4 +544,96 @@ describe('I18nInliner', () => {
       expect(findFile(localeResult?.outputFiles ?? [], 'main.js').text).toContain(`"Hello ${i}"`);
     }
   });
+
+  it('injects locale data alongside ___NG_LOCALE_INSERT___ for non-English locales', async () => {
+    const source = `(globalThis.$localize ??= {}).locale = "___NG_LOCALE_INSERT___";\n${GREETING_SOURCE}`;
+    const localeInliner = createInliner([browserFile('polyfills.js', source)]);
+
+    const results = await localeInliner.inlineAll([
+      { locale: 'fr', translation: { greeting: translationFor('Bonjour') } },
+      { locale: 'en-US', translation: undefined },
+    ]);
+
+    const fr = results.get('fr');
+    expect(fr?.errors).toEqual([]);
+    const frPolyfills = findFile(fr?.outputFiles ?? [], 'polyfills.js').text;
+    expect(frPolyfills).toContain('(globalThis.$localize ??= {}).locale = "fr";');
+    expect(frPolyfills).toContain('ng.common.locales');
+
+    const en = results.get('en-US');
+    expect(en?.errors).toEqual([]);
+    const enPolyfills = findFile(en?.outputFiles ?? [], 'polyfills.js').text;
+    expect(enPolyfills).toContain('(globalThis.$localize ??= {}).locale = "en-US";');
+    expect(enPolyfills).not.toContain('ng.common.locales');
+  });
+
+  it('warns and uses parent locale data when a subtag locale is not directly available', async () => {
+    const source = `(globalThis.$localize ??= {}).locale = "___NG_LOCALE_INSERT___";\n${GREETING_SOURCE}`;
+    const localeInliner = createInliner([browserFile('polyfills.js', source)]);
+
+    const results = await localeInliner.inlineAll([
+      { locale: 'fr-ZZ', translation: { greeting: translationFor('Bonjour') } },
+    ]);
+
+    const frZZ = results.get('fr-ZZ');
+    expect(frZZ?.errors).toEqual([]);
+    expect(frZZ?.warnings).toEqual([
+      "Locale data for 'fr-ZZ' cannot be found. Using locale data for 'fr'.",
+    ]);
+    const polyfills = findFile(frZZ?.outputFiles ?? [], 'polyfills.js').text;
+    expect(polyfills).toContain('(globalThis.$localize ??= {}).locale = "fr-ZZ";');
+    expect(polyfills).toContain('ng.common.locales');
+  });
+
+  it('warns and includes no locale data when locale data cannot be found', async () => {
+    const source = `(globalThis.$localize ??= {}).locale = "___NG_LOCALE_INSERT___";\n${GREETING_SOURCE}`;
+    const localeInliner = createInliner([browserFile('polyfills.js', source)]);
+
+    const results = await localeInliner.inlineAll([
+      { locale: 'xx-YY', translation: { greeting: translationFor('Test') } },
+    ]);
+
+    const xxYY = results.get('xx-YY');
+    expect(xxYY?.errors).toEqual([]);
+    expect(xxYY?.warnings).toEqual([
+      "Locale data for 'xx-YY' cannot be found. No locale data will be included for this locale.",
+    ]);
+    const polyfills = findFile(xxYY?.outputFiles ?? [], 'polyfills.js').text;
+    expect(polyfills).toContain('(globalThis.$localize ??= {}).locale = "xx-YY";');
+    expect(polyfills).not.toContain('ng.common.locales');
+  });
+
+  it('reports an error diagnostic when an invalid or unsupported locale is provided', async () => {
+    const source = `(globalThis.$localize ??= {}).locale = "___NG_LOCALE_INSERT___";\n${GREETING_SOURCE}`;
+    const localeInliner = createInliner([browserFile('polyfills.js', source)]);
+
+    const results = await localeInliner.inlineAll([
+      { locale: 'invalid locale tag', translation: { greeting: translationFor('Test') } },
+    ]);
+
+    const invalid = results.get('invalid locale tag');
+    expect(invalid?.errors).toEqual([
+      'Invalid or unsupported locale provided in configuration: "invalid locale tag"',
+    ]);
+  });
+
+  it('injects locale data script only once when multiple ___NG_LOCALE_INSERT___ sites are present', async () => {
+    const source =
+      `(globalThis.$localize ??= {}).locale = "___NG_LOCALE_INSERT___";\n` +
+      `const secondary = "___NG_LOCALE_INSERT___";\n${GREETING_SOURCE}`;
+    const localeInliner = createInliner([browserFile('polyfills.js', source)]);
+
+    const results = await localeInliner.inlineAll([
+      { locale: 'fr', translation: { greeting: translationFor('Bonjour') } },
+    ]);
+
+    const fr = results.get('fr');
+    expect(fr?.errors).toEqual([]);
+    const frPolyfills = findFile(fr?.outputFiles ?? [], 'polyfills.js').text;
+    expect(frPolyfills).toContain('(globalThis.$localize ??= {}).locale = "fr";');
+    expect(frPolyfills).toContain('const secondary = "fr";');
+
+    const iifeMatches = frPolyfills.match(/function\s*\(global/g);
+    expect(iifeMatches?.length).toBe(1);
+  });
 });

--- a/packages/angular/build/src/tools/esbuild/i18n-locale-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/i18n-locale-plugin.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import type { Plugin, ResolveResult } from 'esbuild';
+import type { Plugin } from 'esbuild';
+import { readFile } from 'node:fs/promises';
 import { createProjectResolver } from '../../utils/resolve-project';
 
 /**
@@ -20,6 +21,124 @@ export const LOCALE_DATA_NAMESPACE = 'angular:locale/data';
 export const LOCALE_DATA_BASE_MODULE = '@angular/common/locales/global';
 
 /**
+ * Result of resolving locale data for a given locale tag.
+ */
+export interface LocaleDataResolution {
+  path?: string;
+  warning?: string;
+  error?: string;
+}
+
+/**
+ * Result of loading locale data for a given locale tag.
+ */
+export interface LoadedLocaleData {
+  code?: string;
+  warning?: string;
+  error?: string;
+}
+
+const localeDataCache = new Map<string, Promise<LoadedLocaleData>>();
+
+/**
+ * Resolves the path to the Angular locale data file for a given locale tag.
+ *
+ * @param rawLocaleTag The raw locale identifier (e.g. "fr-CA", "de", "en-US").
+ * @param projectResolve A function that attempts to resolve a path string to an absolute file path.
+ * @returns Resolution result with file path, or warning/error diagnostics if applicable.
+ */
+export function resolveLocaleDataPath(
+  rawLocaleTag: string,
+  projectResolve: (potentialPath: string) => string | undefined,
+): LocaleDataResolution {
+  let partialLocaleTag: string;
+  try {
+    const locale = new Intl.Locale(rawLocaleTag);
+    partialLocaleTag = locale.baseName;
+  } catch {
+    return {
+      error: `Invalid or unsupported locale provided in configuration: "${rawLocaleTag}"`,
+    };
+  }
+
+  let exact = true;
+  while (partialLocaleTag) {
+    // Angular embeds the `en`/`en-US` locale into the framework and it does not need to be included again here.
+    if (partialLocaleTag === 'en' || partialLocaleTag === 'en-US') {
+      return {};
+    }
+
+    const potentialPath = `${LOCALE_DATA_BASE_MODULE}/${partialLocaleTag}`;
+    try {
+      const resolvedPath = projectResolve(potentialPath);
+      if (resolvedPath) {
+        return {
+          path: resolvedPath,
+          warning: exact
+            ? undefined
+            : `Locale data for '${rawLocaleTag}' cannot be found. Using locale data for '${partialLocaleTag}'.`,
+        };
+      }
+    } catch {}
+
+    // Remove the last subtag and try again with a less specific locale.
+    const parts = partialLocaleTag.split('-');
+    partialLocaleTag = parts.slice(0, -1).join('-');
+    exact = false;
+  }
+
+  return {
+    warning: `Locale data for '${rawLocaleTag}' cannot be found. No locale data will be included for this locale.`,
+  };
+}
+
+/**
+ * Loads the Angular global locale data script for a specified locale tag.
+ *
+ * @param rawLocaleTag The raw locale identifier (e.g. "fr-CA", "de", "en-US").
+ * @param projectRoot Optional project root for module resolution.
+ * @returns A promise resolving to the loaded locale data script code and any diagnostic warnings.
+ */
+export function loadLocaleData(
+  rawLocaleTag: string,
+  projectRoot?: string,
+): Promise<LoadedLocaleData> {
+  let cached = localeDataCache.get(rawLocaleTag);
+  if (!cached) {
+    cached = (async () => {
+      const projectResolve = createProjectResolver(projectRoot ?? process.cwd());
+      const resolution = resolveLocaleDataPath(rawLocaleTag, (potentialPath) => {
+        try {
+          return projectResolve(potentialPath);
+        } catch {
+          return undefined;
+        }
+      });
+
+      if (resolution.error) {
+        return { error: resolution.error };
+      }
+
+      if (resolution.path) {
+        try {
+          const code = await readFile(resolution.path, 'utf8');
+
+          return { code, warning: resolution.warning };
+        } catch (e) {
+          return { error: `Failed to read locale data file: ${(e as Error).message}` };
+        }
+      }
+
+      return { warning: resolution.warning };
+    })();
+
+    localeDataCache.set(rawLocaleTag, cached);
+  }
+
+  return cached;
+}
+
+/**
  * Creates an esbuild plugin that resolves Angular locale data files from `@angular/common`.
  *
  * @returns An esbuild plugin.
@@ -29,124 +148,44 @@ export function createAngularLocaleDataPlugin(): Plugin {
     name: 'angular-locale-data',
     setup(build): void {
       build.onResolve({ filter: /^angular:locale\/data:/ }, async ({ path }) => {
-        // Extract the locale from the path
         const rawLocaleTag = path.split(':', 3)[2];
+        const { absWorkingDir } = build.initialOptions;
+        let projectResolve: ((packageName: string) => string) | undefined;
 
-        // Extract and normalize the base name of the raw locale tag
-        let partialLocaleTag: string;
-        try {
-          const locale = new Intl.Locale(rawLocaleTag);
-          partialLocaleTag = locale.baseName;
-        } catch {
+        const resolution = resolveLocaleDataPath(rawLocaleTag, (potentialPath) => {
+          projectResolve ??= createProjectResolver(absWorkingDir ?? process.cwd());
+          try {
+            return projectResolve(potentialPath);
+          } catch {
+            return undefined;
+          }
+        });
+
+        if (resolution.error) {
           return {
             path: rawLocaleTag,
             namespace: LOCALE_DATA_NAMESPACE,
-            errors: [
-              {
-                text: `Invalid or unsupported locale provided in configuration: "${rawLocaleTag}"`,
-              },
-            ],
+            errors: [{ text: resolution.error }],
           };
         }
 
-        let exact = true;
-        let projectResolve: ((packageName: string) => string) | undefined;
-        while (partialLocaleTag) {
-          // Angular embeds the `en`/`en-US` locale into the framework and it does not need to be included again here.
-          // The onLoad hook below for the locale data namespace has an `empty` loader that will prevent inclusion.
-          // Angular does not contain exact locale data for `en-US` but `en` is equivalent.
-          if (partialLocaleTag === 'en' || partialLocaleTag === 'en-US') {
-            return {
-              path: rawLocaleTag,
-              namespace: LOCALE_DATA_NAMESPACE,
-            };
-          }
-
-          // Attempt to resolve the locale tag data within the Angular base module location
-          const potentialPath = `${LOCALE_DATA_BASE_MODULE}/${partialLocaleTag}`;
-
-          // If packages are configured to be external then leave the original angular locale import path.
-          // This happens when using the development server with caching enabled to allow Vite prebundling to work.
-          // There currently is no option on the esbuild resolve function to resolve while disabling the option.
-          // NOTE: If esbuild eventually allows controlling the external package options in a build.resolve call, this
-          // workaround can be removed.
-          let result: ResolveResult | undefined;
-          const { packages, absWorkingDir } = build.initialOptions;
-          if (packages === 'external' && absWorkingDir) {
-            projectResolve ??= createProjectResolver(absWorkingDir);
-
-            try {
-              projectResolve(potentialPath);
-
-              result = {
-                errors: [],
-                warnings: [],
-                external: true,
-                sideEffects: true,
-                namespace: '',
-                suffix: '',
-                pluginData: undefined,
-                path: potentialPath,
-              };
-            } catch {}
-          } else {
-            result = await build.resolve(potentialPath, {
-              kind: 'import-statement',
-              resolveDir: absWorkingDir,
-            });
-            if (result && result.external && absWorkingDir) {
-              projectResolve ??= createProjectResolver(absWorkingDir);
-              try {
-                const resolvedPath = projectResolve(potentialPath);
-                result = {
-                  ...result,
-                  external: false,
-                  path: resolvedPath,
-                };
-              } catch {}
-            }
-          }
-
-          if (result?.path) {
-            if (exact) {
-              return result;
-            } else {
-              return {
-                ...result,
-                warnings: [
-                  ...result.warnings,
-                  {
-                    location: null,
-                    text: `Locale data for '${rawLocaleTag}' cannot be found. Using locale data for '${partialLocaleTag}'.`,
-                  },
-                ],
-              };
-            }
-          }
-
-          // Remove the last subtag and try again with a less specific locale.
-          // Usually the match is exact so the string splitting here is not done until actually needed after the exact
-          // match fails to resolve.
-          const parts = partialLocaleTag.split('-');
-          partialLocaleTag = parts.slice(0, -1).join('-');
-          exact = false;
+        if (!resolution.path) {
+          return {
+            path: rawLocaleTag,
+            namespace: LOCALE_DATA_NAMESPACE,
+            warnings: resolution.warning
+              ? [{ location: null, text: resolution.warning }]
+              : undefined,
+          };
         }
 
-        // Not found so issue a warning and use an empty loader. Framework built-in `en-US` data will be used.
-        // This retains existing behavior as in the Webpack-based builder.
         return {
-          path: rawLocaleTag,
-          namespace: LOCALE_DATA_NAMESPACE,
-          warnings: [
-            {
-              location: null,
-              text: `Locale data for '${rawLocaleTag}' cannot be found. No locale data will be included for this locale.`,
-            },
-          ],
+          path: resolution.path,
+          warnings: resolution.warning ? [{ location: null, text: resolution.warning }] : undefined,
         };
       });
 
-      // Locales that cannot be found will be loaded as empty content with a warning from the resolve step
+      // Locales that cannot be found or are en/en-US will be loaded as empty content
       build.onLoad({ filter: /./, namespace: LOCALE_DATA_NAMESPACE }, () => ({
         contents: '',
         loader: 'empty',


### PR DESCRIPTION
Inject global Angular locale data scripts on-demand into each locale's polyfill bundle during inlining instead of bundling all active locale datasets into a single shared polyfill output file.

The `loadLocaleData` utility resolves and caches `@angular/common/locales/global` data per locale. During inlining, `i18n-inliner-worker` injects the specific locale data script alongside `___NG_LOCALE_INSERT___` in the polyfill bundle. This eliminates cross-locale bundle bloat so users download only the exact locale data needed for their targeted locale.