### PR TITLE
fix(@angular/build): preserve binary values in the SQLite cache store

### DIFF
--- a/packages/angular/build/src/tools/esbuild/sqlite-cache-store.ts
+++ b/packages/angular/build/src/tools/esbuild/sqlite-cache-store.ts
@@ -7,8 +7,17 @@
  */
 
 import { DatabaseSync, StatementSync } from 'node:sqlite';
+import { deserialize, serialize } from 'node:v8';
 import { Cache, PersistentCacheStore } from './cache';
 
+/**
+ * A persistent cache store backed by SQLite.
+ *
+ * Values are persisted with the V8 structured clone serialization API instead of JSON. Cached
+ * values include binary data such as the `Uint8Array` output of the JavaScript transformer and
+ * the `contents` of an esbuild load result. A JSON round-trip converts those into plain objects
+ * (`{"0":105,"1":109,...}`), which breaks consumers on any build that reads them back from disk.
+ */
 export class SqliteCacheStore implements PersistentCacheStore<unknown> {
   #db: DatabaseSync | undefined;
   #getStmt: StatementSync | undefined;
@@ -35,7 +44,7 @@ export class SqliteCacheStore implements PersistentCacheStore<unknown> {
       this.#db.exec('PRAGMA temp_store = MEMORY;');
       this.#db.exec('PRAGMA mmap_size = 268435456;');
       this.#db.exec(
-        'CREATE TABLE IF NOT EXISTS cache (key TEXT PRIMARY KEY, value TEXT, last_accessed INTEGER NOT NULL) WITHOUT ROWID;',
+        'CREATE TABLE IF NOT EXISTS cache (key TEXT PRIMARY KEY, value BLOB, last_accessed INTEGER NOT NULL) WITHOUT ROWID;',
       );
 
       this.#getStmt = this.#db.prepare('SELECT value FROM cache WHERE key = ?');
@@ -92,15 +101,18 @@ export class SqliteCacheStore implements PersistentCacheStore<unknown> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async get(key: string): Promise<any> {
     this.#ensureDb();
-    const row = this.#getStmt?.get(key) as { value: string } | undefined;
+    // SQLite column types are dynamic, so the stored value is only known at runtime.
+    const row = this.#getStmt?.get(key) as { value: unknown } | undefined;
 
     if (row) {
       this.#queueAccessUpdate(key);
 
-      try {
-        return JSON.parse(row.value);
-      } catch {
-        return undefined;
+      if (row.value instanceof Uint8Array) {
+        try {
+          return deserialize(row.value);
+        } catch {
+          // Treat corrupt or unparseable cached payloads as a cache miss.
+        }
       }
     }
 
@@ -116,7 +128,7 @@ export class SqliteCacheStore implements PersistentCacheStore<unknown> {
   async set(key: string, value: unknown): Promise<this> {
     this.#ensureDb();
     this.#pendingAccessedKeys.delete(key);
-    this.#setStmt?.run(key, JSON.stringify(value));
+    this.#setStmt?.run(key, serialize(value));
 
     return this;
   }

--- a/packages/angular/build/src/tools/esbuild/sqlite-cache-store_spec.ts
+++ b/packages/angular/build/src/tools/esbuild/sqlite-cache-store_spec.ts
@@ -36,6 +36,81 @@ describe('SqliteCacheStore', () => {
     expect(result).toEqual(data);
   });
 
+  it('should preserve binary values', async () => {
+    const data = new TextEncoder().encode('export const value = 1;\n');
+    await store.set('binary-key', data);
+
+    const result = await store.get('binary-key');
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result).toEqual(data);
+  });
+
+  it('should preserve binary values nested within an object', async () => {
+    const data = {
+      contents: new TextEncoder().encode('export const value = 1;\n'),
+      loader: 'js',
+      watchFiles: ['/some/file.js'],
+    };
+    await store.set('nested-binary-key', data);
+
+    const result = await store.get('nested-binary-key');
+    expect(result.contents).toBeInstanceOf(Uint8Array);
+    expect(result).toEqual(data);
+  });
+
+  it('should preserve binary values across store instances', async () => {
+    const data = new TextEncoder().encode('export const value = 1;\n');
+    await store.set('persisted-binary-key', data);
+    store.close();
+
+    const reopenedStore = new SqliteCacheStore(cachePath);
+    try {
+      const result = await reopenedStore.get('persisted-binary-key');
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(result).toEqual(data);
+    } finally {
+      reopenedStore.close();
+    }
+  });
+
+  it('should treat a corrupt payload as a cache miss', async () => {
+    await store.set('corrupt-key', 'value');
+    store.close();
+
+    // Simulate an entry with an invalid/corrupt payload that fails deserialization.
+    const { DatabaseSync } = await import('node:sqlite');
+    const directDb = new DatabaseSync(cachePath);
+    directDb
+      .prepare('UPDATE cache SET value = ? WHERE key = ?')
+      .run(new Uint8Array([0x00, 0x01, 0x02]), 'corrupt-key');
+    directDb.close();
+
+    const reopenedStore = new SqliteCacheStore(cachePath);
+    try {
+      expect(await reopenedStore.get('corrupt-key')).toBeUndefined();
+    } finally {
+      reopenedStore.close();
+    }
+  });
+
+  it('should treat a non-binary payload as a cache miss', async () => {
+    await store.set('text-key', 'value');
+    store.close();
+
+    // SQLite column types are dynamic, so a stored value is not guaranteed to be binary.
+    const { DatabaseSync } = await import('node:sqlite');
+    const directDb = new DatabaseSync(cachePath);
+    directDb.prepare('UPDATE cache SET value = ? WHERE key = ?').run('"value"', 'text-key');
+    directDb.close();
+
+    const reopenedStore = new SqliteCacheStore(cachePath);
+    try {
+      expect(await reopenedStore.get('text-key')).toBeUndefined();
+    } finally {
+      reopenedStore.close();
+    }
+  });
+
   it('should return undefined for non-existent key', async () => {
     const result = await store.get('missing-key');
     expect(result).toBeUndefined();
@@ -89,8 +164,8 @@ describe('SqliteCacheStore', () => {
     store.close();
 
     // Create a store with a tiny size limit (e.g. 25 bytes)
-    // Keys 'k1', 'k2', 'k3' are small (each is 10 bytes: key + JSON.stringify(value)).
-    // Total size of k1 + k2 + k3 is 30 bytes, which exceeds the 25 bytes limit.
+    // Keys 'k1', 'k2', 'k3' are small (each is 12 bytes: 2 byte key + 10 byte serialized value).
+    // Total size of k1 + k2 + k3 is 36 bytes, which exceeds the 25 bytes limit.
     const sizeStore = new SqliteCacheStore(cachePath, 25);
 
     // Set k1, then k2, then k3.


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #33841

`SqliteCacheStore` persists values with `JSON.stringify` / `JSON.parse`. Some cached values are binary:

- `JavaScriptTransformer` is constructed with `Cache<Uint8Array>` and stores the raw worker output under the `jstransformer` namespace.
- `CachedLoadResultEntry.contents` is typed `string | Uint8Array`.

A JSON round trip cannot represent a typed array, so those values come back from disk as plain objects:

```
key:   jstransformer:000e84ece3a6f3f24cd37f3c37b7f8e94942ee88c0b1dd1cfc660e5c3fd71b07
value: {"0":105,"1":109,"2":112,"3":111,"4":114,"5":116,…}
```

`createCachedLoad()` then returns that object as the result of `build.onLoad({ filter: /\.[cm]?js$/ }, …)` in `angular/compiler-plugin.ts`, and esbuild fails the build:

```
✘ [ERROR] "contents" must be a string or a Uint8Array [plugin angular-compiler]
```

The first build always succeeds — the value is served from the in-memory cache layer and is only corrupted once it has been read back from disk — so the failure starts on the second build against a warm cache.

`createPersistentCacheStore()` only reaches the SQLite store when LMDB fails to load, which is why this is not hit on most machines. The trigger I ran into is the prebuilt `@lmdb/lmdb-linux-x64@3.5.6` binary requiring `GLIBC_2.33` on a host with glibc 2.31 (Ubuntu 20.04); Debian 11 and RHEL/CentOS 8 have the same glibc. That matches the reports in #33841, which was closed as not reproducible — the team could not reproduce it because LMDB loads fine on newer distributions, and the reporter's "fix" was upgrading the build agent from Ubuntu 20.04 to Ubuntu 24.04, i.e. moving back onto the LMDB path.

Reproduction independent of the host, forcing the store through the existing environment option:

```bash
rm -rf .angular
NG_BUILD_CACHE_STORE=sqlite ng build   # ok
NG_BUILD_CACHE_STORE=sqlite ng build   # ✘ "contents" must be a string or a Uint8Array
```

## What is the new behavior?

Values are serialized with the V8 structured clone API (`serialize` / `deserialize` from `node:v8`), which supports typed arrays natively and matches how the LMDB store already behaves. `node:sqlite` accepts a `Uint8Array` parameter as a BLOB and returns a `Uint8Array`, so the round trip is lossless, and the `value` column is declared `BLOB` accordingly.

Old cache entries need no migration. They contain JSON text, `deserialize` throws on them, and the existing `catch` in `get()` already reports that as a cache miss, so those entries are recreated and overwritten. The cache path is also namespaced by package version (`.angular/cache/<VERSION>/`).

Added regression coverage in `sqlite-cache-store_spec.ts`: a `Uint8Array` round trip, a `Uint8Array` nested in an object (the shape of `CachedLoadResultEntry`), a round trip across two store instances (the on-disk path, which is where the bug actually shows), and a check that an entry which cannot be deserialized is treated as a cache miss. Binary round tripping was not covered before. All four fail on `main` and pass with this change.

The existing size-pruning test still passes unchanged — `length()` on a BLOB column returns the byte length, and the serialized payloads stay within the same 25 byte limit. I updated its comment to match the new byte counts.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Considered and rejected: keeping JSON with a replacer/reviver and base64. It inflates the cache by roughly a third and is easy to get wrong, since `Buffer.prototype.toJSON` runs before the replacer.

Separately, and not part of this PR: `createPersistentCacheStore()` swallows the LMDB load error entirely before falling back to SQLite. Logging the reason for the fallback would have made this much easier to diagnose — the build just fails later in an unrelated place. Happy to open a follow-up issue or PR for that if it is wanted.
