### PR TITLE
fix(@angular/cli): isolate temporary package installations from parent Yarn workspace

### DIFF
--- a/packages/angular/cli/src/package-managers/package-manager.ts
+++ b/packages/angular/cli/src/package-managers/package-manager.ts
@@ -724,8 +724,15 @@ export class PackageManager {
       }
     }
 
+    // To prevent Yarn modern from traversing up the directory tree and failing because the temporary
+    // directory is not part of the project's workspace, write an empty `yarn.lock` to act as a project boundary.
+    if (this.name === 'yarn') {
+      await this.host.writeFile(join(workingDirectory, 'yarn.lock'), '');
+    }
+
     // Copy configuration files if the package manager requires it (e.g., bun, yarn).
     if (this.descriptor.copyConfigFromProject) {
+      let copiedYarnConfig = false;
       for (const configFile of this.descriptor.configFiles) {
         try {
           const configPath = join(this.cwd, configFile);
@@ -734,9 +741,19 @@ export class PackageManager {
             content = sanitizeYarnRc(content);
           }
           await this.host.writeFile(join(workingDirectory, configFile), content);
+          if (this.name === 'yarn') {
+            copiedYarnConfig = true;
+          }
         } catch {
           // Ignore missing config files.
         }
+      }
+
+      if (this.name === 'yarn' && !copiedYarnConfig) {
+        await this.host.writeFile(
+          join(workingDirectory, '.yarnrc.yml'),
+          'nodeLinker: node-modules\n',
+        );
       }
     }
 

--- a/packages/angular/cli/src/package-managers/package-manager_spec.ts
+++ b/packages/angular/cli/src/package-managers/package-manager_spec.ts
@@ -192,6 +192,10 @@ describe('PackageManager', () => {
         '/tmp/project/node_modules/angular-cli-tmp-packages-abc/pnpm-workspace.yaml',
         '',
       );
+      expect(writeFileSpy).not.toHaveBeenCalledWith(
+        '/tmp/project/node_modules/angular-cli-tmp-packages-abc/yarn.lock',
+        '',
+      );
     });
 
     it('should copy and sanitize .yarnrc.yml when package manager is yarn and it exists', async () => {
@@ -245,8 +249,51 @@ describe('PackageManager', () => {
       ].join('\n');
 
       expect(writeFileSpy).toHaveBeenCalledWith(
+        '/tmp/project/node_modules/angular-cli-tmp-packages-abc/yarn.lock',
+        '',
+      );
+      expect(writeFileSpy).toHaveBeenCalledWith(
         '/tmp/project/node_modules/angular-cli-tmp-packages-abc/.yarnrc.yml',
         expectedYarnRcContent,
+      );
+      expect(writeFileSpy).toHaveBeenCalledWith(
+        '/tmp/project/node_modules/angular-cli-tmp-packages-abc/package.json',
+        JSON.stringify({ packageManager: 'yarn@4.4.1' }, null, 2),
+      );
+    });
+
+    it('should write empty yarn.lock and default .yarnrc.yml when package manager is yarn and config does not exist', async () => {
+      const yarnDescriptor = SUPPORTED_PACKAGE_MANAGERS['yarn'];
+      const testHost = new MockHost({
+        '/tmp/project/node_modules': true,
+      });
+      const pm = new PackageManager(testHost, '/tmp/project', yarnDescriptor);
+
+      const createTempDirectorySpy = spyOn(testHost, 'createTempDirectory').and.resolveTo(
+        '/tmp/project/node_modules/angular-cli-tmp-packages-abc',
+      );
+      const writeFileSpy = spyOn(testHost, 'writeFile').and.resolveTo();
+
+      spyOn(testHost, 'readFile').and.callFake(async (filePath) => {
+        if (filePath.replace(/\\/g, '/').endsWith('package.json')) {
+          return JSON.stringify({ packageManager: 'yarn@4.4.1' });
+        }
+        throw new Error(`ENOENT: no such file or directory, open '${filePath}'`);
+      });
+      spyOn(testHost, 'runCommand').and.resolveTo({ stdout: '4.4.1', stderr: '' });
+
+      const { workingDirectory } = await pm.acquireTempPackage('foo@1.0.0');
+
+      expect(workingDirectory).toBe('/tmp/project/node_modules/angular-cli-tmp-packages-abc');
+      expect(createTempDirectorySpy).toHaveBeenCalledWith('/tmp/project/node_modules');
+
+      expect(writeFileSpy).toHaveBeenCalledWith(
+        '/tmp/project/node_modules/angular-cli-tmp-packages-abc/yarn.lock',
+        '',
+      );
+      expect(writeFileSpy).toHaveBeenCalledWith(
+        '/tmp/project/node_modules/angular-cli-tmp-packages-abc/.yarnrc.yml',
+        'nodeLinker: node-modules\n',
       );
       expect(writeFileSpy).toHaveBeenCalledWith(
         '/tmp/project/node_modules/angular-cli-tmp-packages-abc/package.json',


### PR DESCRIPTION
When installing a temporary CLI package during update command execution, the temporary directory is placed within the project tree (e.g. under node_modules). When using Yarn modern (v2+), Yarn searches upward for a yarn.lock file to locate the project root. Upon finding the parent project's yarn.lock, Yarn detects that the temporary directory contains a package.json but is not a declared workspace member, causing yarn add to fail with a Usage Error.

To resolve this, an empty yarn.lock file is written to the temporary directory when the package manager is Yarn modern. This creates a project boundary that prevents upward workspace traversal and ensures Yarn treats the directory as an independent project. Additionally, if the parent project does not define a .yarnrc.yml or .yarnrc.yaml, a default configuration specifying 'nodeLinker: node-modules' is written to ensure packages are installed into node_modules rather than PnP.

Fixes #33972