### PR TITLE
build: update beasties to 0.5.1

### DIFF
--- a/packages/angular/build/package.json
+++ b/packages/angular/build/package.json
@@ -24,7 +24,7 @@
     "@inquirer/confirm": "6.2.0",
     "@parcel/watcher": "2.6.0",
     "@vitejs/plugin-basic-ssl": "2.3.0",
-    "beasties": "0.4.3",
+    "beasties": "0.5.1",
     "browserslist": "^4.26.0",
     "chokidar": "5.0.0",
     "esbuild": "0.28.2",

--- a/packages/angular/build/src/builders/application/tests/options/app-shell_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/app-shell_spec.ts
@@ -141,7 +141,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       indexFileContent.toContain('app-shell works!');
       indexFileContent.toContain('p{color:#000}');
       indexFileContent.toContain(
-        `<link rel="stylesheet" href="styles.css" media="print" onload="this.media='all'">`,
+        `<link rel="stylesheet" href="styles.css" media="print" data-beasties-media="all">`,
       );
     });
 
@@ -170,7 +170,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       indexFileContent.toContain('app-shell works!');
       indexFileContent.toContain('p{color:#000}');
       indexFileContent.toContain(
-        `<link rel="stylesheet" href="styles.css" media="print" ngCspMedia="all">`,
+        `<link rel="stylesheet" href="styles.css" media="print" data-beasties-media="all">`,
       );
       indexFileContent.toContain('<style nonce="{% nonce %}">p{color:#000}');
       indexFileContent.toContain('<style nonce="{% nonce %}" ng-app-id="ng">');

--- a/packages/angular/build/src/builders/application/tests/options/optimization-inline-critical_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/optimization-inline-critical_spec.ts
@@ -35,7 +35,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       harness
         .expectFile('dist/browser/index.html')
         .content.toContain(
-          `<link rel="stylesheet" href="styles.css" media="print" onload="this.media='all'">`,
+          `<link rel="stylesheet" href="styles.css" media="print" data-beasties-media="all">`,
         );
       harness.expectFile('dist/browser/index.html').content.toContain(`body{color:#000}`);
     });
@@ -53,7 +53,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       harness
         .expectFile('dist/browser/index.html')
         .content.toContain(
-          `<link rel="stylesheet" href="styles.css" media="print" onload="this.media='all'">`,
+          `<link rel="stylesheet" href="styles.css" media="print" data-beasties-media="all">`,
         );
       harness.expectFile('dist/browser/index.html').content.toContain(`body{color:#000}`);
     });
@@ -71,7 +71,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       harness
         .expectFile('dist/browser/index.html')
         .content.toContain(
-          `<link rel="stylesheet" href="styles.css" media="print" onload="this.media='all'">`,
+          `<link rel="stylesheet" href="styles.css" media="print" data-beasties-media="all">`,
         );
       harness.expectFile('dist/browser/index.html').content.toContain(`body{color:#000}`);
     });
@@ -130,7 +130,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       harness
         .expectFile('dist/browser/index.html')
         .content.toContain(
-          `<link rel="stylesheet" href="styles.css" media="print" onload="this.media='all'">`,
+          `<link rel="stylesheet" href="styles.css" media="print" data-beasties-media="all">`,
         );
       harness.expectFile('dist/browser/index.html').content.toContain(`body{color:#000}`);
     });

--- a/packages/angular/build/src/private.ts
+++ b/packages/angular/build/src/private.ts
@@ -80,11 +80,6 @@ export {
   type IndexHtmlTransform,
 } from './utils/index-file/index-html-generator';
 export type { FileInfo } from './utils/index-file/augment-index-html';
-export {
-  type InlineCriticalCssProcessOptions,
-  InlineCriticalCssProcessor,
-  type InlineCriticalCssProcessorOptions,
-} from './utils/index-file/inline-critical-css';
 export { loadProxyConfiguration } from './utils/load-proxy-config';
 export { type TranslationLoader, createTranslationLoader } from './utils/load-translations';
 export { purgeStaleBuildCache } from './utils/purge-cache';

--- a/packages/angular/build/src/tools/esbuild/index-html-generator.ts
+++ b/packages/angular/build/src/tools/esbuild/index-html-generator.ts
@@ -106,6 +106,7 @@ export async function generateIndexHtml(
     crossOrigin: crossOrigin,
     deployUrl: buildOptions.publicPath,
     postTransform: indexHtmlOptions.transformer,
+    outputPath: virtualOutputPath,
     generateDedicatedSSRContent: !!(
       buildOptions.ssrOptions ||
       buildOptions.prerenderOptions ||
@@ -120,7 +121,6 @@ export async function generateIndexHtml(
   return indexHtmlGenerator.process({
     baseHref,
     lang,
-    outputPath: virtualOutputPath,
     files: [...initialFiles]
       .filter(([, file]) => !file.serverFile)
       .map(([file, record]) => ({

--- a/packages/angular/build/src/utils/index-file/index-html-generator.ts
+++ b/packages/angular/build/src/utils/index-file/index-html-generator.ts
@@ -13,7 +13,7 @@ import { NormalizedOptimizationOptions } from '../normalize-optimization';
 import { addEventDispatchContract } from './add-event-dispatch-contract';
 import { CrossOriginValue, Entrypoint, FileInfo, augmentIndexHtml } from './augment-index-html';
 import { autoCsp } from './auto-csp';
-import { InlineCriticalCssProcessor } from './inline-critical-css';
+import { inlineCriticalCss } from './inline-critical-css';
 import { InlineFontsProcessor } from './inline-fonts';
 import { addNgcmAttribute } from './ngcm-attribute';
 import { addNonce } from './nonce';
@@ -28,7 +28,6 @@ export type HintMode = 'prefetch' | 'preload' | 'modulepreload' | 'preconnect' |
 export interface IndexHtmlGeneratorProcessOptions {
   lang: string | undefined;
   baseHref: string | undefined;
-  outputPath: string;
   files: FileInfo[];
   hints?: { url: string; mode: HintMode; as?: string }[];
 }
@@ -49,6 +48,7 @@ export interface IndexHtmlGeneratorOptions {
   imageDomains?: string[];
   generateDedicatedSSRContent?: boolean;
   autoCsp?: AutoCspOptions;
+  outputPath: string;
 
   /**
    * Integrity metadata for module URLs not directly referenced in the index
@@ -89,7 +89,7 @@ export class IndexHtmlGenerator {
 
     // CSR plugins
     if (options?.optimization?.styles?.inlineCritical) {
-      this.csrPlugins.push(inlineCriticalCssPlugin(this, !!options.autoCsp));
+      this.csrPlugins.push(inlineCriticalCssPlugin(this));
     }
 
     this.csrPlugins.push(addNoncePlugin());
@@ -182,10 +182,11 @@ function augmentIndexHtmlPlugin(generator: IndexHtmlGenerator): IndexHtmlGenerat
     entrypoints,
     imageDomains,
     chunksIntegrity,
+    outputPath,
   } = generator.options;
 
   return async (html, options) => {
-    const { lang, baseHref, outputPath = '', files, hints } = options;
+    const { lang, baseHref, files, hints } = options;
 
     return augmentIndexHtml({
       html,
@@ -209,22 +210,15 @@ function inlineFontsPlugin({ options }: IndexHtmlGenerator): IndexHtmlGeneratorP
     minify: options.optimization?.styles.minify,
   });
 
-  return async (html) => inlineFontsProcessor.process(html);
+  return (html) => inlineFontsProcessor.process(html);
 }
 
-function inlineCriticalCssPlugin(
-  generator: IndexHtmlGenerator,
-  autoCsp: boolean,
-): IndexHtmlGeneratorPlugin {
-  const inlineCriticalCssProcessor = new InlineCriticalCssProcessor({
-    minify: generator.options.optimization?.styles.minify,
-    deployUrl: generator.options.deployUrl,
-    readAsset: (filePath) => generator.readAsset(filePath),
-    autoCsp,
-  });
+function inlineCriticalCssPlugin(generator: IndexHtmlGenerator): IndexHtmlGeneratorPlugin {
+  const { outputPath, deployUrl, optimization } = generator.options;
+  const { minify = false } = optimization?.styles ?? {};
 
-  return async (html, options) =>
-    inlineCriticalCssProcessor.process(html, { outputPath: options.outputPath });
+  return (html) =>
+    inlineCriticalCss(html, outputPath, deployUrl, minify, (path) => generator.readAsset(path));
 }
 
 function addNoncePlugin(): IndexHtmlGeneratorPlugin {

--- a/packages/angular/build/src/utils/index-file/inline-critical-css.ts
+++ b/packages/angular/build/src/utils/index-file/inline-critical-css.ts
@@ -6,292 +6,68 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { readFile } from 'node:fs/promises';
-
 /**
- * Pattern used to extract the media query set by Beasties in an `onload` handler.
- */
-const MEDIA_SET_HANDLER_PATTERN = /^this\.media=["'](.*)["'];?$/;
-
-/**
- * Name of the attribute used to save the Beasties media query so it can be re-assigned on load.
- */
-const CSP_MEDIA_ATTR = 'ngCspMedia';
-
-/**
- * Script that dynamically updates the `media` attribute of `<link>` tags based on a custom attribute (`CSP_MEDIA_ATTR`).
+ * Generates a stylesheet containing the critical CSS for the given HTML content.
  *
- * NOTE:
- * We do not use `document.querySelectorAll('link').forEach((s) => s.addEventListener('load', ...)`
- * because load events are not always triggered reliably on Chrome.
- * See: https://github.com/angular/angular-cli/issues/26932 and https://crbug.com/1521256
- *
- * The script:
- * - Ensures the event target is a `<link>` tag with the `CSP_MEDIA_ATTR` attribute.
- * - Updates the `media` attribute with the value of `CSP_MEDIA_ATTR` and then removes the attribute.
- * - Removes the event listener when all relevant `<link>` tags have been processed.
- * - Uses event capturing (the `true` parameter) since load events do not bubble up the DOM.
+ * @param html - The HTML content to process.
+ * @param outputPath - The output path for the generated stylesheet.
+ * @param deployUrl - The deploy URL for the generated stylesheet.
+ * @param minify - Whether to minify the generated stylesheet.
+ * @param readAsset - A function that reads an asset from the given file path.
+ * @returns A promise that resolves to an object containing the generated stylesheet content,
+ * warnings, and errors.
  */
-const LINK_LOAD_SCRIPT_CONTENT = `
-(() => {
-  const CSP_MEDIA_ATTR = '${CSP_MEDIA_ATTR}';
-  const documentElement = document.documentElement;
+export async function inlineCriticalCss(
+  html: string,
+  outputPath: string,
+  deployUrl: string | undefined,
+  minify: boolean,
+  readAsset: (file: string) => Promise<string>,
+): Promise<{
+  content: string;
+  warnings: string[];
+  errors: string[];
+}> {
+  const { default: Beasties } = await import('beasties');
 
-  // Listener for load events on link tags.
-  const listener = (e) => {
-    const target = e.target;
-    if (
-      !target ||
-      target.tagName !== 'LINK' ||
-      !target.hasAttribute(CSP_MEDIA_ATTR)
-    ) {
-      return;
-    }
+  const warnings: string[] = [];
+  const errors: string[] = [];
 
-    target.media = target.getAttribute(CSP_MEDIA_ATTR);
-    target.removeAttribute(CSP_MEDIA_ATTR);
+  const beasties = new Beasties({
+    logger: {
+      warn: (s: string) => warnings.push(s),
+      error: (s: string) => errors.push(s),
+      info: () => {},
+    },
+    logLevel: 'warn',
+    path: outputPath,
+    publicPath: deployUrl,
+    compress: minify,
+    pruneSource: false,
+    reduceInlineStyles: false,
+    mergeStylesheets: false,
+    preload: 'media-script',
+    nonce: (document) => {
+      const nonceElement = document.querySelector('[ngCspNonce], [ngcspnonce]');
+      const cspNonce =
+        nonceElement?.getAttribute('ngCspNonce') || nonceElement?.getAttribute('ngcspnonce');
 
-    if (!document.head.querySelector(\`link[\${CSP_MEDIA_ATTR}]\`)) {
-      documentElement.removeEventListener('load', listener);
-    }
-  };
-
-  documentElement.addEventListener('load', listener, true);
-})();`;
-
-export interface InlineCriticalCssProcessOptions {
-  outputPath: string;
-}
-
-export interface InlineCriticalCssProcessorOptions {
-  minify?: boolean;
-  deployUrl?: string;
-  readAsset?: (path: string) => Promise<string>;
-  autoCsp?: boolean;
-}
-
-/** Partial representation of an `HTMLElement`. */
-interface PartialHTMLElement {
-  getAttribute(name: string): string | null;
-  setAttribute(name: string, value: string): void;
-  hasAttribute(name: string): boolean;
-  removeAttribute(name: string): void;
-  appendChild(child: PartialHTMLElement): void;
-  insertBefore(newNode: PartialHTMLElement, referenceNode?: PartialHTMLElement): void;
-  remove(): void;
-  name: string;
-  textContent: string;
-  tagName: string | null;
-  children: PartialHTMLElement[];
-  next: PartialHTMLElement | null;
-  prev: PartialHTMLElement | null;
-}
-
-/** Partial representation of an HTML `Document`. */
-interface PartialDocument {
-  head: PartialHTMLElement;
-  createElement(tagName: string): PartialHTMLElement;
-  querySelector(selector: string): PartialHTMLElement | null;
-}
-
-interface BeastiesBase {
-  embedLinkedStylesheet(link: PartialHTMLElement, document: PartialDocument): Promise<unknown>;
-  readFile(path: string): Promise<string>;
-  process(html: string): Promise<string>;
-}
-
-interface BeastiesExtendedInstance {
-  readonly warnings: string[];
-  readonly errors: string[];
-  process(html: string): Promise<string>;
-}
-
-let beastiesClassPromise:
-  | Promise<
-      new (
-        options: InlineCriticalCssProcessorOptions & InlineCriticalCssProcessOptions,
-      ) => BeastiesExtendedInstance
-    >
-  | undefined;
-
-async function getBeastiesClass(): Promise<
-  new (
-    options: InlineCriticalCssProcessorOptions & InlineCriticalCssProcessOptions,
-  ) => BeastiesExtendedInstance
-> {
-  if (beastiesClassPromise) {
-    return beastiesClassPromise;
-  }
-
-  beastiesClassPromise = import('beasties').then(({ default: Beasties }) => {
-    return class BeastiesExtended
-      extends (Beasties as unknown as new (options: unknown) => BeastiesBase)
-      implements BeastiesExtendedInstance
-    {
-      private _warnings?: string[];
-      private _errors?: string[];
-
-      get warnings(): string[] {
-        return (this._warnings ??= []);
-      }
-
-      get errors(): string[] {
-        return (this._errors ??= []);
-      }
-      private addedCspScriptsDocuments = new WeakSet<PartialDocument>();
-      private documentNonces = new WeakMap<PartialDocument, string | null>();
-
-      constructor(
-        private readonly optionsExtended: InlineCriticalCssProcessorOptions &
-          InlineCriticalCssProcessOptions,
-      ) {
-        super({
-          logger: {
-            warn: (s: string) => this.warnings.push(s),
-            error: (s: string) => this.errors.push(s),
-            info: () => {},
-          },
-          logLevel: 'warn',
-          path: optionsExtended.outputPath,
-          publicPath: optionsExtended.deployUrl,
-          compress: !!optionsExtended.minify,
-          pruneSource: false,
-          reduceInlineStyles: false,
-          mergeStylesheets: false,
-          // Note: if `preload` changes to anything other than `media`, the logic in
-          // `embedLinkedStylesheet` will have to be updated.
-          preload: 'media',
-          noscriptFallback: true,
-          inlineFonts: true,
-        });
-      }
-
-      public override readFile(path: string): Promise<string> {
-        const readAsset = this.optionsExtended.readAsset;
-
-        return readAsset ? readAsset(path) : readFile(path, 'utf-8');
-      }
-
-      /**
-       * Override of the Beasties `embedLinkedStylesheet` method
-       * that makes it work with Angular's CSP APIs.
-       */
-      override async embedLinkedStylesheet(
-        link: PartialHTMLElement,
-        document: PartialDocument,
-      ): Promise<unknown> {
-        if (link.getAttribute('media') === 'print' && link.next?.name === 'noscript') {
-          // Workaround for https://github.com/GoogleChromeLabs/critters/issues/64
-          // NB: this is only needed for the webpack based builders.
-          const media = link.getAttribute('onload')?.match(MEDIA_SET_HANDLER_PATTERN);
-          if (media) {
-            link.removeAttribute('onload');
-            link.setAttribute('media', media[1]);
-            link?.next?.remove();
-          }
-        }
-
-        const returnValue = await super.embedLinkedStylesheet(link, document);
-        const cspNonce = this.findCspNonce(document);
-
-        if (cspNonce || this.optionsExtended.autoCsp) {
-          const beastiesMedia = link.getAttribute('onload')?.match(MEDIA_SET_HANDLER_PATTERN);
-
-          if (beastiesMedia) {
-            // If there's a Beasties-generated `onload` handler and the file has an Angular CSP nonce,
-            // we have to remove the handler, because it's incompatible with CSP. We save the value
-            // in a different attribute and we generate a script tag with the nonce that uses
-            // `addEventListener` to apply the media query instead.
-            link.removeAttribute('onload');
-            link.setAttribute(CSP_MEDIA_ATTR, beastiesMedia[1]);
-            this.conditionallyInsertCspLoadingScript(document, cspNonce, link);
-          }
-
-          // Ideally we would hook in at the time Beasties inserts the `style` tags, but there isn't
-          // a way of doing that at the moment so we fall back to doing it any time a `link` tag is
-          // inserted. We mitigate it by only iterating the direct children of the `<head>` which
-          // should be pretty shallow.
-          if (cspNonce) {
-            document.head.children.forEach((child) => {
-              if (child.tagName === 'style' && !child.hasAttribute('nonce')) {
-                child.setAttribute('nonce', cspNonce);
-              }
-            });
-          }
-        }
-
-        return returnValue;
-      }
-
-      /**
-       * Finds the CSP nonce for a specific document.
-       */
-      private findCspNonce(document: PartialDocument): string | null {
-        if (this.documentNonces.has(document)) {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          return this.documentNonces.get(document)!;
-        }
-
-        // HTML attribute are case-insensitive, but the parser used by Beasties is case-sensitive.
-        const nonceElement = document.querySelector('[ngCspNonce], [ngcspnonce]');
-        const cspNonce =
-          nonceElement?.getAttribute('ngCspNonce') ||
-          nonceElement?.getAttribute('ngcspnonce') ||
-          null;
-
-        this.documentNonces.set(document, cspNonce);
-
-        return cspNonce;
-      }
-
-      /**
-       * Inserts the `script` tag that swaps the critical CSS at runtime,
-       * if one hasn't been inserted into the document already.
-       */
-      private conditionallyInsertCspLoadingScript(
-        document: PartialDocument,
-        nonce: string | null,
-        link: PartialHTMLElement,
-      ): void {
-        if (this.addedCspScriptsDocuments.has(document)) {
-          return;
-        }
-
-        const script = document.createElement('script');
-        script.textContent = LINK_LOAD_SCRIPT_CONTENT;
-        if (nonce) {
-          script.setAttribute('nonce', nonce);
-        }
-
-        // Prepend the script to the head since it needs to
-        // run as early as possible, before the `link` tags.
-        document.head.insertBefore(script, link);
-        this.addedCspScriptsDocuments.add(document);
-      }
-    };
+      return cspNonce;
+    },
+    noscriptFallback: true,
+    inlineFonts: true,
   });
 
-  return beastiesClassPromise;
-}
+  beasties.readFile = (path) => readAsset(path);
 
-export class InlineCriticalCssProcessor {
-  constructor(protected readonly options: InlineCriticalCssProcessorOptions) {}
+  const content = await beasties.process(html);
 
-  async process(
-    html: string,
-    options: InlineCriticalCssProcessOptions,
-  ): Promise<{ content: string; warnings: string[]; errors: string[] }> {
-    const BeastiesClass = await getBeastiesClass();
-    const beasties = new BeastiesClass({ ...this.options, ...options });
-    const content = await beasties.process(html);
-
-    return {
-      // Clean up value from value less attributes.
-      // This is caused because parse5 always requires attributes to have a string value.
-      // nomodule="" defer="" -> nomodule defer.
-      content: content.replace(/(\s(?:defer|nomodule))=""/g, '$1'),
-      errors: beasties.errors,
-      warnings: beasties.warnings,
-    };
-  }
+  return {
+    // Clean up value from value less attributes.
+    // This is caused because parse5 always requires attributes to have a string value.
+    // nomodule="" defer="" -> nomodule defer.
+    content: content.replace(/(\s(?:defer|nomodule))=""/g, '$1'),
+    errors,
+    warnings,
+  };
 }

--- a/packages/angular/build/src/utils/index-file/inline-critical-css_spec.ts
+++ b/packages/angular/build/src/utils/index-file/inline-critical-css_spec.ts
@@ -7,9 +7,9 @@
  */
 
 import { tags } from '@angular-devkit/core';
-import { InlineCriticalCssProcessor } from './inline-critical-css';
+import { inlineCriticalCss } from './inline-critical-css';
 
-describe('InlineCriticalCssProcessor', () => {
+describe('inlineCriticalCss', () => {
   const styles: Record<string, string> = {
     '/dist/styles.css': `
       body { margin: 0; }
@@ -27,7 +27,7 @@ describe('InlineCriticalCssProcessor', () => {
       return content;
     }
 
-    throw new Error('Cannot read asset.');
+    throw new Error(`Cannot read asset: ${file}`);
   };
 
   const getContent = (deployUrl: string, bodyContent = ''): string => {
@@ -42,19 +42,21 @@ describe('InlineCriticalCssProcessor', () => {
   };
 
   it('should inline critical css', async () => {
-    const inlineFontsProcessor = new InlineCriticalCssProcessor({
+    const { content, errors, warnings } = await inlineCriticalCss(
+      getContent(''),
+      '/dist/',
+      undefined,
+      false,
       readAsset,
-    });
+    );
 
-    const { content } = await inlineFontsProcessor.process(getContent(''), {
-      outputPath: '/dist/',
-    });
-
+    expect(errors).toEqual([]);
+    expect(warnings).toEqual([]);
     expect(content).toContain(
-      `<link href="styles.css" rel="stylesheet" media="print" onload="this.media='all'">`,
+      '<link href="styles.css" rel="stylesheet" media="print" data-beasties-media="all">',
     );
     expect(content).toContain(
-      `<link href="theme.css" rel="stylesheet" media="print" onload="this.media='all'">`,
+      '<link href="theme.css" rel="stylesheet" media="print" data-beasties-media="all">',
     );
     expect(content).not.toContain('color: blue');
     expect(tags.stripIndents`${content}`).toContain(tags.stripIndents`
@@ -65,20 +67,21 @@ describe('InlineCriticalCssProcessor', () => {
   });
 
   it('should inline critical css when using deployUrl', async () => {
-    const inlineFontsProcessor = new InlineCriticalCssProcessor({
+    const { content, errors, warnings } = await inlineCriticalCss(
+      getContent('http://cdn.com/'),
+      '/dist/',
+      'http://cdn.com',
+      false,
       readAsset,
-      deployUrl: 'http://cdn.com',
-    });
+    );
 
-    const { content } = await inlineFontsProcessor.process(getContent('http://cdn.com/'), {
-      outputPath: '/dist/',
-    });
-
+    expect(errors).toEqual([]);
+    expect(warnings).toEqual([]);
     expect(content).toContain(
-      `<link href="http://cdn.com/styles.css" rel="stylesheet" media="print" onload="this.media='all'">`,
+      '<link href="http://cdn.com/styles.css" rel="stylesheet" media="print" data-beasties-media="all">',
     );
     expect(content).toContain(
-      `<link href="http://cdn.com/theme.css" rel="stylesheet" media="print" onload="this.media='all'">`,
+      '<link href="http://cdn.com/theme.css" rel="stylesheet" media="print" data-beasties-media="all">',
     );
     expect(tags.stripIndents`${content}`).toContain(tags.stripIndents`
     <style>
@@ -88,61 +91,41 @@ describe('InlineCriticalCssProcessor', () => {
   });
 
   it('should compress inline critical css when minify is enabled', async () => {
-    const inlineFontsProcessor = new InlineCriticalCssProcessor({
+    const { content, errors, warnings } = await inlineCriticalCss(
+      getContent(''),
+      '/dist/',
+      undefined,
+      true,
       readAsset,
-      minify: true,
-    });
+    );
 
-    const { content } = await inlineFontsProcessor.process(getContent(''), {
-      outputPath: '/dist/',
-    });
-
+    expect(errors).toEqual([]);
+    expect(warnings).toEqual([]);
     expect(content).toContain(
-      `<link href="styles.css" rel="stylesheet" media="print" onload="this.media='all'">`,
+      '<link href="styles.css" rel="stylesheet" media="print" data-beasties-media="all">',
     );
     expect(content).toContain(
-      `<link href="theme.css" rel="stylesheet" media="print" onload="this.media='all'">`,
+      '<link href="theme.css" rel="stylesheet" media="print" data-beasties-media="all">',
     );
     expect(content).toContain('<style>body{margin:0}html{color:white}</style>');
   });
 
-  it(`should process the inline 'onload' handlers if a 'autoCsp' is true`, async () => {
-    const inlineCssProcessor = new InlineCriticalCssProcessor({
-      readAsset,
-      autoCsp: true,
-    });
-
-    const { content } = await inlineCssProcessor.process(getContent(''), {
-      outputPath: '/dist/',
-    });
-
-    expect(content).toContain(
-      '<link href="styles.css" rel="stylesheet" media="print" ngCspMedia="all">',
-    );
-    expect(tags.stripIndents`${content}`).toContain(tags.stripIndents`
-    <style>
-    body { margin: 0; }
-    html { color: white; }
-    </style>`);
-  });
-
-  it('should process the inline `onload` handlers if a CSP nonce is specified', async () => {
-    const inlineCssProcessor = new InlineCriticalCssProcessor({
-      readAsset,
-    });
-
-    const { content } = await inlineCssProcessor.process(
+  it('should process the inline onload handlers and style tag when ngCspNonce is specified', async () => {
+    const { content, errors, warnings } = await inlineCriticalCss(
       getContent('', '<app ngCspNonce="{% nonce %}"></app>'),
-      {
-        outputPath: '/dist/',
-      },
+      '/dist/',
+      undefined,
+      false,
+      readAsset,
     );
 
+    expect(errors).toEqual([]);
+    expect(warnings).toEqual([]);
     expect(content).toContain(
-      '<link href="styles.css" rel="stylesheet" media="print" ngCspMedia="all">',
+      '<link href="styles.css" rel="stylesheet" media="print" data-beasties-media="all">',
     );
     expect(content).toContain(
-      '<link href="theme.css" rel="stylesheet" media="print" ngCspMedia="all">',
+      '<link href="theme.css" rel="stylesheet" media="print" data-beasties-media="all">',
     );
     // Nonces shouldn't be added inside the `noscript` tags.
     expect(content).toContain('<noscript><link href="theme.css" rel="stylesheet"></noscript>');
@@ -154,11 +137,26 @@ describe('InlineCriticalCssProcessor', () => {
     </style>`);
   });
 
-  it('should not modify the document for external stylesheets', async () => {
-    const inlineCssProcessor = new InlineCriticalCssProcessor({
+  it('should process the inline onload handlers and style tag when ngcspnonce is lowercase', async () => {
+    const { content, errors, warnings } = await inlineCriticalCss(
+      getContent('', '<app ngcspnonce="{% nonce %}"></app>'),
+      '/dist/',
+      undefined,
+      false,
       readAsset,
-    });
+    );
 
+    expect(errors).toEqual([]);
+    expect(warnings).toEqual([]);
+    expect(content).toContain('<script nonce="{% nonce %}">');
+    expect(tags.stripIndents`${content}`).toContain(tags.stripIndents`
+    <style nonce="{% nonce %}">
+    body { margin: 0; }
+    html { color: white; }
+    </style>`);
+  });
+
+  it('should not modify the document for external stylesheets', async () => {
     const initialContent = `
       <!doctype html>
       <html lang="en">
@@ -172,15 +170,67 @@ describe('InlineCriticalCssProcessor', () => {
       </html>
     `;
 
-    const { content } = await inlineCssProcessor.process(initialContent, {
-      outputPath: '/dist/',
-    });
+    const { content, errors, warnings } = await inlineCriticalCss(
+      initialContent,
+      '/dist/',
+      undefined,
+      false,
+      readAsset,
+    );
 
+    expect(errors).toEqual([]);
+    expect(warnings).toEqual([]);
     expect(tags.stripIndents`${content}`).toContain(tags.stripIndents`
       <head>
         <meta charset="utf-8">
         <link rel="stylesheet" href="https://google.com/styles.css">
       </head>
     `);
+  });
+
+  it('should clean up empty values from valueless attributes like defer and nomodule', async () => {
+    const initialContent = `
+      <!doctype html>
+      <html lang="en">
+      <head>
+        <meta charset="utf-8">
+        <link rel="stylesheet" href="styles.css">
+        <script src="main.js" defer="" nomodule=""></script>
+      </head>
+      <body>
+      </body>
+      </html>
+    `;
+
+    const { content } = await inlineCriticalCss(
+      initialContent,
+      '/dist/',
+      undefined,
+      false,
+      readAsset,
+    );
+
+    expect(content).toContain('<script src="main.js" defer nomodule></script>');
+  });
+
+  it('should capture warnings from beasties', async () => {
+    const initialContent = `
+      <html>
+      <head>
+        <link href="missing.css" rel="stylesheet">
+      </head>
+      <body></body>
+    </html>`;
+
+    const { warnings } = await inlineCriticalCss(
+      initialContent,
+      '/dist/',
+      undefined,
+      false,
+      readAsset,
+    );
+
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings[0]).toContain('missing.css');
   });
 });

--- a/packages/angular/ssr/package.json
+++ b/packages/angular/ssr/package.json
@@ -44,7 +44,7 @@
     "@angular/platform-server": "22.2.0-next.4",
     "@angular/router": "22.2.0-next.4",
     "@schematics/angular": "workspace:*",
-    "beasties": "0.4.3"
+    "beasties": "0.5.1"
   },
   "sideEffects": false,
   "schematics": "./schematics/collection.json"

--- a/packages/angular/ssr/src/utils/inline-critical-css.ts
+++ b/packages/angular/ssr/src/utils/inline-critical-css.ts
@@ -8,94 +8,7 @@
 
 import Beasties from '../../third_party/beasties';
 
-/**
- * Pattern used to extract the media query set by Beasties in an `onload` handler.
- */
-const MEDIA_SET_HANDLER_PATTERN = /^this\.media=["'](.*)["'];?$/;
-
-/**
- * Name of the attribute used to save the Beasties media query so it can be re-assigned on load.
- */
-const CSP_MEDIA_ATTR = 'ngCspMedia';
-
-/**
- * Script that dynamically updates the `media` attribute of `<link>` tags based on a custom attribute (`CSP_MEDIA_ATTR`).
- *
- * NOTE:
- * We do not use `document.querySelectorAll('link').forEach((s) => s.addEventListener('load', ...)`
- * because load events are not always triggered reliably on Chrome.
- * See: https://github.com/angular/angular-cli/issues/26932 and https://crbug.com/1521256
- *
- * The script:
- * - Ensures the event target is a `<link>` tag with the `CSP_MEDIA_ATTR` attribute.
- * - Updates the `media` attribute with the value of `CSP_MEDIA_ATTR` and then removes the attribute.
- * - Removes the event listener when all relevant `<link>` tags have been processed.
- * - Uses event capturing (the `true` parameter) since load events do not bubble up the DOM.
- */
-const LINK_LOAD_SCRIPT_CONTENT = /* @__PURE__ */ (() => `(() => {
-  const CSP_MEDIA_ATTR = '${CSP_MEDIA_ATTR}';
-  const documentElement = document.documentElement;
-
-  // Listener for load events on link tags.
-  const listener = (e) => {
-    const target = e.target;
-    if (
-      !target ||
-      target.tagName !== 'LINK' ||
-      !target.hasAttribute(CSP_MEDIA_ATTR)
-    ) {
-      return;
-    }
-
-    target.media = target.getAttribute(CSP_MEDIA_ATTR);
-    target.removeAttribute(CSP_MEDIA_ATTR);
-
-    if (!document.head.querySelector(\`link[\${CSP_MEDIA_ATTR}]\`)) {
-      documentElement.removeEventListener('load', listener);
-    }
-  };
-
-  documentElement.addEventListener('load', listener, true);
-})();`)();
-
-/** Partial representation of an `HTMLElement`. */
-interface PartialHTMLElement {
-  getAttribute(name: string): string | null;
-  setAttribute(name: string, value: string): void;
-  hasAttribute(name: string): boolean;
-  removeAttribute(name: string): void;
-  appendChild(child: PartialHTMLElement): void;
-  insertBefore(newNode: PartialHTMLElement, referenceNode?: PartialHTMLElement): void;
-  remove(): void;
-  name: string;
-  textContent: string;
-  tagName: string | null;
-  children: PartialHTMLElement[];
-  next: PartialHTMLElement | null;
-  prev: PartialHTMLElement | null;
-}
-
-/** Partial representation of an HTML `Document`. */
-interface PartialDocument {
-  head: PartialHTMLElement;
-  createElement(tagName: string): PartialHTMLElement;
-  querySelector(selector: string): PartialHTMLElement | null;
-}
-
-/* eslint-disable @typescript-eslint/no-unsafe-declaration-merging */
-
-// We use Typescript declaration merging because `embedLinkedStylesheet` it's not declared in
-// the `Beasties` types which means that we can't call the `super` implementation.
-interface BeastiesBase {
-  embedLinkedStylesheet(link: PartialHTMLElement, document: PartialDocument): Promise<unknown>;
-}
-class BeastiesBase extends Beasties {}
-/* eslint-enable @typescript-eslint/no-unsafe-declaration-merging */
-
-export class InlineCriticalCssProcessor extends BeastiesBase {
-  private addedCspScriptsDocuments = new WeakSet<PartialDocument>();
-  private documentNonces = new WeakMap<PartialDocument, string | null>();
-
+export class InlineCriticalCssProcessor extends Beasties {
   constructor(
     public override readFile: (path: string) => Promise<string>,
     readonly outputPath?: string,
@@ -115,108 +28,18 @@ export class InlineCriticalCssProcessor extends BeastiesBase {
       pruneSource: false,
       reduceInlineStyles: false,
       mergeStylesheets: false,
-      // Note: if `preload` changes to anything other than `media`, the logic in
-      // `embedLinkedStylesheet` will have to be updated.
-      preload: 'media',
+      preload: 'media-script',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      nonce: ((document: any) => {
+        const nonceElement = document.querySelector('[ngCspNonce], [ngcspnonce]');
+        const cspNonce =
+          nonceElement?.getAttribute('ngCspNonce') || nonceElement?.getAttribute('ngcspnonce');
+
+        return cspNonce;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any,
       noscriptFallback: true,
       inlineFonts: true,
     });
-  }
-
-  /**
-   * Override of the Beasties `embedLinkedStylesheet` method
-   * that makes it work with Angular's CSP APIs.
-   */
-  override async embedLinkedStylesheet(
-    link: PartialHTMLElement,
-    document: PartialDocument,
-  ): Promise<unknown> {
-    if (link.getAttribute('media') === 'print' && link.next?.name === 'noscript') {
-      // Workaround for https://github.com/GoogleChromeLabs/critters/issues/64
-      // NB: this is only needed for the webpack based builders.
-      const media = link.getAttribute('onload')?.match(MEDIA_SET_HANDLER_PATTERN);
-      if (media) {
-        link.removeAttribute('onload');
-        link.setAttribute('media', media[1]);
-        link?.next?.remove();
-      }
-    }
-
-    const returnValue = await super.embedLinkedStylesheet(link, document);
-    const cspNonce = this.findCspNonce(document);
-
-    if (cspNonce) {
-      const beastiesMedia = link.getAttribute('onload')?.match(MEDIA_SET_HANDLER_PATTERN);
-
-      if (beastiesMedia) {
-        // If there's a Beasties-generated `onload` handler and the file has an Angular CSP nonce,
-        // we have to remove the handler, because it's incompatible with CSP. We save the value
-        // in a different attribute and we generate a script tag with the nonce that uses
-        // `addEventListener` to apply the media query instead.
-        link.removeAttribute('onload');
-        link.setAttribute(CSP_MEDIA_ATTR, beastiesMedia[1]);
-        this.conditionallyInsertCspLoadingScript(document, cspNonce, link);
-      }
-
-      // Ideally we would hook in at the time Beasties inserts the `style` tags, but there isn't
-      // a way of doing that at the moment so we fall back to doing it any time a `link` tag is
-      // inserted. We mitigate it by only iterating the direct children of the `<head>` which
-      // should be pretty shallow.
-      document.head.children.forEach((child) => {
-        if (child.tagName === 'style' && !child.hasAttribute('nonce')) {
-          child.setAttribute('nonce', cspNonce);
-        }
-      });
-    }
-
-    return returnValue;
-  }
-
-  /**
-   * Finds the CSP nonce for a specific document.
-   */
-  private findCspNonce(document: PartialDocument): string | null {
-    if (this.documentNonces.has(document)) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      return this.documentNonces.get(document)!;
-    }
-
-    // HTML attribute are case-insensitive, but the parser used by Beasties is case-sensitive.
-    const nonceElement = document.querySelector('[ngCspNonce], [ngcspnonce]');
-    const cspNonce =
-      nonceElement?.getAttribute('ngCspNonce') || nonceElement?.getAttribute('ngcspnonce') || null;
-
-    this.documentNonces.set(document, cspNonce);
-
-    return cspNonce;
-  }
-
-  /**
-   * Inserts the `script` tag that swaps the critical CSS at runtime,
-   * if one hasn't been inserted into the document already.
-   */
-  private conditionallyInsertCspLoadingScript(
-    document: PartialDocument,
-    nonce: string,
-    link: PartialHTMLElement,
-  ): void {
-    if (this.addedCspScriptsDocuments.has(document)) {
-      return;
-    }
-
-    if (document.head.textContent.includes(LINK_LOAD_SCRIPT_CONTENT)) {
-      // Script was already added during the build.
-      this.addedCspScriptsDocuments.add(document);
-
-      return;
-    }
-
-    const script = document.createElement('script');
-    script.setAttribute('nonce', nonce);
-    script.textContent = LINK_LOAD_SCRIPT_CONTENT;
-    // Prepend the script to the head since it needs to
-    // run as early as possible, before the `link` tags.
-    document.head.insertBefore(script, link);
-    this.addedCspScriptsDocuments.add(document);
   }
 }

--- a/packages/angular/ssr/test/npm_package/THIRD_PARTY_LICENSES.txt.golden
+++ b/packages/angular/ssr/test/npm_package/THIRD_PARTY_LICENSES.txt.golden
@@ -209,7 +209,19 @@ Apache License
 Package: boolbase
 License: ISC
 
+Copyright (c) 2014-2015, Felix Boehm <me@feedic.com>
 
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 --------------------------------------------------------------------------------
 Package: css-select
 License: BSD-2-Clause
@@ -244,17 +256,13 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 Package: dom-serializer
 License: MIT
 
-License
+Copyright © 2022 The Cheerio contributors
 
-(The MIT License)
-
-Copyright (c) 2014 The cheeriojs contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 --------------------------------------------------------------------------------
 Package: domelementtype
 License: BSD-2-Clause

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -128,6 +128,7 @@ ts_project(
         ":node_modules/ansi-colors",
         ":node_modules/autoprefixer",
         ":node_modules/babel-loader",
+        ":node_modules/beasties",
         ":node_modules/browser-sync",
         ":node_modules/browserslist",
         ":node_modules/copy-webpack-plugin",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -25,6 +25,7 @@
     "ansi-colors": "4.1.3",
     "autoprefixer": "10.5.4",
     "babel-loader": "10.1.1",
+    "beasties": "0.5.1",
     "browserslist": "^4.26.0",
     "copy-webpack-plugin": "14.0.0",
     "css-loader": "7.1.4",

--- a/packages/angular_devkit/build_angular/src/builders/app-shell/app-shell_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/app-shell/app-shell_spec.ts
@@ -169,7 +169,7 @@ describe('AppShell Builder', () => {
     expect(content).toContain('app-shell works!');
     expect(content).toContain('p{color:#000}');
     expect(content).toMatch(
-      /<link rel="stylesheet" href="styles\.[a-z0-9]+\.css" media="print" onload="this.media='all'">/,
+      /<link rel="stylesheet" href="styles\.[a-z0-9]+\.css" media="print" data-beasties-media="all">/,
     );
   });
 
@@ -195,7 +195,7 @@ describe('AppShell Builder', () => {
     expect(content).toContain('<app-root ngcspnonce="{% nonce %}"');
     expect(content).toContain('<script nonce="{% nonce %}">');
     expect(content).toMatch(
-      /<link rel="stylesheet" href="styles\.[a-z0-9]+\.css" media="print" ngCspMedia="all">/,
+      /<link rel="stylesheet" href="styles\.[a-z0-9]+\.css" media="print" data-beasties-media="all">/,
     );
   });
 });

--- a/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
@@ -19,6 +19,7 @@ import * as path from 'node:path';
 import Piscina from 'piscina';
 import { normalizeOptimization } from '../../utils';
 import { assertIsError } from '../../utils/error';
+import { InlineCriticalCssProcessor } from '../../utils/inline-critical-css';
 import { Spinner } from '../../utils/spinner';
 import { BrowserBuilderOutput } from '../browser';
 import { Schema as BrowserBuilderSchema } from '../browser/schema';
@@ -58,14 +59,6 @@ async function _renderUniversal(
   const projectRoot = path.join(root, (projectMetadata.root as string | undefined) ?? '');
 
   const { styles } = normalizeOptimization(browserOptions.optimization);
-  let inlineCriticalCssProcessor;
-  if (styles.inlineCritical) {
-    const { InlineCriticalCssProcessor } = await import('@angular/build/private');
-    inlineCriticalCssProcessor = new InlineCriticalCssProcessor({
-      minify: styles.minify,
-      deployUrl: browserOptions.deployUrl,
-    });
-  }
 
   const renderWorker = new Piscina({
     filename: require.resolve('./render-worker'),
@@ -98,10 +91,14 @@ async function _renderUniversal(
         ? path.join(root, options.outputIndexPath)
         : browserIndexOutputPath;
 
-      if (inlineCriticalCssProcessor) {
-        const { content, warnings, errors } = await inlineCriticalCssProcessor.process(html, {
+      if (styles.inlineCritical) {
+        const inlineCriticalCssProcessor = new InlineCriticalCssProcessor({
+          minify: styles.minify,
           outputPath,
+          deployUrl: browserOptions.deployUrl,
         });
+
+        const { content, warnings, errors } = await inlineCriticalCssProcessor.process(html);
         html = content;
 
         if (warnings.length || errors.length) {

--- a/packages/angular_devkit/build_angular/src/builders/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/index.ts
@@ -303,21 +303,25 @@ export function buildWebpackBrowser(
                     styles: options.styles ?? [],
                   });
 
-                  const indexHtmlGenerator = new IndexHtmlGenerator({
-                    cache: cacheOptions,
-                    indexPath: path.join(context.workspaceRoot, getIndexInputFile(options.index)),
-                    entrypoints,
-                    deployUrl: options.deployUrl,
-                    sri: options.subresourceIntegrity,
-                    optimization: normalizedOptimization,
-                    crossOrigin: options.crossOrigin,
-                    postTransform: transforms.indexHtml,
-                    imageDomains: Array.from(imageDomains),
-                  });
-
                   let hasErrors = false;
                   for (const [locale, outputPath] of outputPaths.entries()) {
                     try {
+                      const indexHtmlGenerator = new IndexHtmlGenerator({
+                        cache: cacheOptions,
+                        indexPath: path.join(
+                          context.workspaceRoot,
+                          getIndexInputFile(options.index),
+                        ),
+                        entrypoints,
+                        outputPath,
+                        deployUrl: options.deployUrl,
+                        sri: options.subresourceIntegrity,
+                        optimization: normalizedOptimization,
+                        crossOrigin: options.crossOrigin,
+                        postTransform: transforms.indexHtml,
+                        imageDomains: Array.from(imageDomains),
+                      });
+
                       const {
                         csrContent: content,
                         warnings,
@@ -326,7 +330,6 @@ export function buildWebpackBrowser(
                         baseHref: getLocaleBaseHref(i18n, locale) ?? options.baseHref,
                         // i18nLocale is used when Ivy is disabled
                         lang: locale || undefined,
-                        outputPath,
                         files: mapEmittedFilesToFileInfo(emittedFiles),
                       });
 

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/options/inline-critical_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/options/inline-critical_spec.ts
@@ -35,7 +35,7 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
       harness
         .expectFile('dist/index.html')
         .content.toContain(
-          `<link rel="stylesheet" href="styles.css" media="print" onload="this.media='all'">`,
+          `<link rel="stylesheet" href="styles.css" media="print" data-beasties-media="all">`,
         );
       harness.expectFile('dist/index.html').content.toContain(`body{color:#000}`);
     });
@@ -53,7 +53,7 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
       harness
         .expectFile('dist/index.html')
         .content.toContain(
-          `<link rel="stylesheet" href="styles.css" media="print" onload="this.media='all'">`,
+          `<link rel="stylesheet" href="styles.css" media="print" data-beasties-media="all">`,
         );
       harness.expectFile('dist/index.html').content.toContain(`body{color:#000}`);
     });
@@ -71,7 +71,7 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
       harness
         .expectFile('dist/index.html')
         .content.toContain(
-          `<link rel="stylesheet" href="styles.css" media="print" onload="this.media='all'">`,
+          `<link rel="stylesheet" href="styles.css" media="print" data-beasties-media="all">`,
         );
       harness.expectFile('dist/index.html').content.toContain(`body{color:#000}`);
     });
@@ -129,7 +129,7 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
       harness
         .expectFile('dist/index.html')
         .content.toContain(
-          `<link rel="stylesheet" href="http://cdn.com/styles.css" media="print" onload="this.media='all'">`,
+          `<link rel="stylesheet" href="http://cdn.com/styles.css" media="print" data-beasties-media="all">`,
         );
       harness.expectFile('dist/index.html').content.toContain(`body{color:#000}`);
     });
@@ -155,7 +155,7 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
       harness
         .expectFile('dist/index.html')
         .content.toContain(
-          `<link rel="stylesheet" href="styles.css" media="print" onload="this.media='all'">`,
+          `<link rel="stylesheet" href="styles.css" media="print" data-beasties-media="all">`,
         );
       harness.expectFile('dist/index.html').content.toContain(`body{color:#000}`);
     });

--- a/packages/angular_devkit/build_angular/src/builders/prerender/render-worker.ts
+++ b/packages/angular_devkit/build_angular/src/builders/prerender/render-worker.ts
@@ -13,6 +13,7 @@ import assert from 'node:assert';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { workerData } from 'node:worker_threads';
+import { InlineCriticalCssProcessor } from '../../utils/inline-critical-css';
 
 export interface RenderOptions {
   indexFile: string;
@@ -122,16 +123,13 @@ async function render({
   }
 
   if (inlineCriticalCss) {
-    const { InlineCriticalCssProcessor } = await import('@angular/build/private');
-
     const inlineCriticalCssProcessor = new InlineCriticalCssProcessor({
-      deployUrl: deployUrl,
+      deployUrl,
+      outputPath,
       minify: minifyCss,
     });
 
-    const { content, warnings, errors } = await inlineCriticalCssProcessor.process(html, {
-      outputPath,
-    });
+    const { content, warnings, errors } = await inlineCriticalCssProcessor.process(html);
     result.errors = errors;
     result.warnings = warnings;
     html = content;

--- a/packages/angular_devkit/build_angular/src/builders/prerender/works_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/prerender/works_spec.ts
@@ -219,11 +219,11 @@ describe('Prerender Builder', () => {
     );
 
     expect(content).toMatch(
-      /<style>p{color:#000}<\/style><link rel="stylesheet" href="styles\.\w+\.css" media="print" onload="this\.media='all'">/,
+      /<style>p{color:#000}<\/style><link rel="stylesheet" href="styles\.\w+\.css" media="print" data-beasties-media="all">/,
     );
 
     // Validate that beasties does not process already critical css inlined stylesheets.
-    expect(content).not.toContain(`onload="this.media='print'">`);
+    expect(content).not.toContain(`data-beasties-media="print"`);
     expect(content).not.toContain(`media="print"></noscript>`);
   });
 });

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/index-html-webpack-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/index-html-webpack-plugin.ts
@@ -18,8 +18,7 @@ import { assertIsError } from '../../../utils/error';
 import { addError, addWarning } from '../../../utils/webpack-diagnostics';
 
 export interface IndexHtmlWebpackPluginOptions
-  extends IndexHtmlGeneratorOptions,
-    Omit<IndexHtmlGeneratorProcessOptions, 'files'> {}
+  extends IndexHtmlGeneratorOptions, Omit<IndexHtmlGeneratorProcessOptions, 'files'> {}
 
 const PLUGIN_NAME = 'index-html-webpack-plugin';
 export class IndexHtmlWebpackPlugin extends IndexHtmlGenerator {
@@ -32,8 +31,11 @@ export class IndexHtmlWebpackPlugin extends IndexHtmlGenerator {
     throw new Error('compilation is undefined.');
   }
 
-  constructor(override readonly options: IndexHtmlWebpackPluginOptions) {
-    super(options);
+  constructor(readonly pluginOptions: IndexHtmlWebpackPluginOptions) {
+    super({
+      ...pluginOptions,
+      outputPath: dirname(pluginOptions.outputPath),
+    });
   }
 
   apply(compiler: Compiler) {
@@ -73,12 +75,11 @@ export class IndexHtmlWebpackPlugin extends IndexHtmlGenerator {
           errors,
         } = await this.process({
           files,
-          outputPath: dirname(this.options.outputPath),
-          baseHref: this.options.baseHref,
-          lang: this.options.lang,
+          baseHref: this.pluginOptions.baseHref,
+          lang: this.pluginOptions.lang,
         });
 
-        assets[this.options.outputPath] = new sources.RawSource(content);
+        assets[this.pluginOptions.outputPath] = new sources.RawSource(content);
 
         warnings.forEach((msg) => addWarning(this.compilation, msg));
         errors.forEach((msg) => addError(this.compilation, msg));

--- a/packages/angular_devkit/build_angular/src/utils/inline-critical-css.ts
+++ b/packages/angular_devkit/build_angular/src/utils/inline-critical-css.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { readFile } from 'node:fs/promises';
+
+export interface InlineCriticalCssProcessorOptions {
+  minify?: boolean;
+  deployUrl?: string;
+  readAsset?: (path: string) => Promise<string>;
+  autoCsp?: boolean;
+  outputPath?: string;
+}
+
+export class InlineCriticalCssProcessor {
+  constructor(protected readonly options: InlineCriticalCssProcessorOptions) {}
+
+  async process(html: string): Promise<{ content: string; warnings: string[]; errors: string[] }> {
+    const warnings: string[] = [];
+    const errors: string[] = [];
+    const { outputPath, deployUrl, minify = false, readAsset } = this.options;
+
+    const { default: Beasties } = await import('beasties');
+
+    const beasties = new Beasties({
+      logger: {
+        warn: (s: string) => warnings.push(s),
+        error: (s: string) => errors.push(s),
+        info: () => {},
+      },
+      logLevel: 'warn',
+      path: outputPath,
+      publicPath: deployUrl,
+      compress: minify,
+      pruneSource: false,
+      reduceInlineStyles: false,
+      mergeStylesheets: false,
+      preload: 'media-script',
+      nonce: (document) => {
+        const nonceElement = document.querySelector('[ngCspNonce], [ngcspnonce]');
+        const cspNonce =
+          nonceElement?.getAttribute('ngCspNonce') || nonceElement?.getAttribute('ngcspnonce');
+
+        return cspNonce;
+      },
+      noscriptFallback: true,
+      inlineFonts: true,
+    });
+
+    beasties.readFile = (path) => {
+      return readAsset ? readAsset(path) : readFile(path, 'utf-8');
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const beastiesInternal = beasties as any;
+    const initialEmbedLinkedStylesheet =
+      beastiesInternal.embedLinkedStylesheet.bind(beastiesInternal);
+    beastiesInternal.embedLinkedStylesheet = async (link: unknown, document: unknown) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const linkEl = link as any;
+      const beastiesMedia = linkEl.getAttribute('data-beasties-media');
+      if (beastiesMedia) {
+        linkEl.removeAttribute('data-beasties-media');
+        linkEl.setAttribute('media', beastiesMedia);
+        if (linkEl.next?.name === 'noscript') {
+          linkEl.next.remove();
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (document as any).querySelectorAll('script').forEach((script: any) => {
+          if (script.textContent?.includes('data-beasties-media')) {
+            script.remove();
+          }
+        });
+      }
+
+      return initialEmbedLinkedStylesheet(link, document);
+    };
+    const content = await beasties.process(html);
+
+    return {
+      // Clean up value from value less attributes.
+      // This is caused because parse5 always requires attributes to have a string value.
+      // nomodule="" defer="" -> nomodule defer.
+      content: content.replace(/(\s(?:defer|nomodule))=""/g, '$1'),
+      errors,
+      warnings,
+    };
+  }
+}

--- a/packages/angular_devkit/build_angular/src/utils/inline-critical-css_spec.ts
+++ b/packages/angular_devkit/build_angular/src/utils/inline-critical-css_spec.ts
@@ -1,0 +1,178 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { tags } from '@angular-devkit/core';
+import { InlineCriticalCssProcessor } from './inline-critical-css';
+
+describe('InlineCriticalCssProcessor', () => {
+  const styles: Record<string, string> = {
+    '/dist/styles.css': `
+      body { margin: 0; }
+      html { color: white; }
+    `,
+    '/dist/theme.css': `
+      span { color: blue; }
+      p { color: blue; }
+    `,
+  };
+
+  const readAsset = async (file: string): Promise<string> => {
+    const content = styles[file];
+    if (content) {
+      return content;
+    }
+
+    throw new Error('Cannot read asset.');
+  };
+
+  const getContent = (deployUrl: string, bodyContent = ''): string => {
+    return `
+      <html>
+      <head>
+        <link href="${deployUrl}styles.css" rel="stylesheet">
+        <link href="${deployUrl}theme.css" rel="stylesheet">
+      </head>
+      <body>${bodyContent}</body>
+    </html>`;
+  };
+
+  it('should inline critical css', async () => {
+    const inlineFontsProcessor = new InlineCriticalCssProcessor({
+      readAsset,
+      outputPath: '/dist/',
+    });
+
+    const { content } = await inlineFontsProcessor.process(getContent(''));
+
+    expect(content).toContain(
+      `<link href="styles.css" rel="stylesheet" media="print" data-beasties-media="all">`,
+    );
+    expect(content).toContain(
+      `<link href="theme.css" rel="stylesheet" media="print" data-beasties-media="all">`,
+    );
+    expect(content).not.toContain('color: blue');
+    expect(tags.stripIndents`${content}`).toContain(tags.stripIndents`
+    <style>
+    body { margin: 0; }
+    html { color: white; }
+    </style>`);
+  });
+
+  it('should inline critical css when using deployUrl', async () => {
+    const inlineFontsProcessor = new InlineCriticalCssProcessor({
+      readAsset,
+      outputPath: '/dist/',
+      deployUrl: 'http://cdn.com',
+    });
+
+    const { content } = await inlineFontsProcessor.process(getContent('http://cdn.com/'));
+
+    expect(content).toContain(
+      `<link href="http://cdn.com/styles.css" rel="stylesheet" media="print" data-beasties-media="all">`,
+    );
+    expect(content).toContain(
+      `<link href="http://cdn.com/theme.css" rel="stylesheet" media="print" data-beasties-media="all">`,
+    );
+    expect(tags.stripIndents`${content}`).toContain(tags.stripIndents`
+    <style>
+    body { margin: 0; }
+    html { color: white; }
+    </style>`);
+  });
+
+  it('should compress inline critical css when minify is enabled', async () => {
+    const inlineFontsProcessor = new InlineCriticalCssProcessor({
+      readAsset,
+      minify: true,
+      outputPath: '/dist/',
+    });
+
+    const { content } = await inlineFontsProcessor.process(getContent(''));
+
+    expect(content).toContain(
+      `<link href="styles.css" rel="stylesheet" media="print" data-beasties-media="all">`,
+    );
+    expect(content).toContain(
+      `<link href="theme.css" rel="stylesheet" media="print" data-beasties-media="all">`,
+    );
+    expect(content).toContain('<style>body{margin:0}html{color:white}</style>');
+  });
+
+  it(`should process the inline 'onload' handlers if a 'autoCsp' is true`, async () => {
+    const inlineCssProcessor = new InlineCriticalCssProcessor({
+      readAsset,
+      autoCsp: true,
+      outputPath: '/dist/',
+    });
+
+    const { content } = await inlineCssProcessor.process(getContent(''));
+
+    expect(content).toContain(
+      '<link href="styles.css" rel="stylesheet" media="print" data-beasties-media="all">',
+    );
+    expect(tags.stripIndents`${content}`).toContain(tags.stripIndents`
+    <style>
+    body { margin: 0; }
+    html { color: white; }
+    </style>`);
+  });
+
+  it('should process the inline `onload` handlers if a CSP nonce is specified', async () => {
+    const inlineCssProcessor = new InlineCriticalCssProcessor({
+      readAsset,
+      outputPath: '/dist/',
+    });
+
+    const { content } = await inlineCssProcessor.process(
+      getContent('', '<app ngCspNonce="{% nonce %}"></app>'),
+    );
+
+    expect(content).toContain(
+      '<link href="styles.css" rel="stylesheet" media="print" data-beasties-media="all">',
+    );
+    expect(content).toContain(
+      '<link href="theme.css" rel="stylesheet" media="print" data-beasties-media="all">',
+    );
+    // Nonces shouldn't be added inside the `noscript` tags.
+    expect(content).toContain('<noscript><link href="theme.css" rel="stylesheet"></noscript>');
+    expect(content).toContain('<script nonce="{% nonce %}">');
+    expect(tags.stripIndents`${content}`).toContain(tags.stripIndents`
+    <style nonce="{% nonce %}">
+    body { margin: 0; }
+    html { color: white; }
+    </style>`);
+  });
+
+  it('should not modify the document for external stylesheets', async () => {
+    const inlineCssProcessor = new InlineCriticalCssProcessor({
+      readAsset,
+    });
+
+    const initialContent = `
+      <!doctype html>
+      <html lang="en">
+      <head>
+        <meta charset="utf-8">
+        <link rel="stylesheet" href="https://google.com/styles.css" />
+      </head>
+      <body>
+        <app ngCspNonce="{% nonce %}"></app>
+      </body>
+      </html>
+    `;
+
+    const { content } = await inlineCssProcessor.process(initialContent);
+
+    expect(tags.stripIndents`${content}`).toContain(tags.stripIndents`
+      <head>
+        <meta charset="utf-8">
+        <link rel="stylesheet" href="https://google.com/styles.css">
+      </head>
+    `);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -344,8 +344,8 @@ importers:
         specifier: 2.3.0
         version: 2.3.0(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(less@4.9.0(supports-color@11.0.0))(sass-embedded@1.103.1)(sass@1.103.1)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       beasties:
-        specifier: 0.4.3
-        version: 0.4.3
+        specifier: 0.5.1
+        version: 0.5.1
       browserslist:
         specifier: ^4.26.0
         version: 4.28.8
@@ -533,8 +533,8 @@ importers:
         specifier: workspace:*
         version: link:../../schematics/angular
       beasties:
-        specifier: 0.4.3
-        version: 0.4.3
+        specifier: 0.5.1
+        version: 0.5.1
 
   packages/angular_devkit/architect:
     dependencies:
@@ -604,6 +604,9 @@ importers:
       babel-loader:
         specifier: 10.1.1
         version: 10.1.1(@babel/core@8.0.1)(webpack@5.109.2(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)(uglify-js@3.19.3))
+      beasties:
+        specifier: 0.5.1
+        version: 0.5.1
       browserslist:
         specifier: ^4.26.0
         version: 4.28.8
@@ -4412,9 +4415,9 @@ packages:
   bcryptjs@2.4.3:
     resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
 
-  beasties@0.4.3:
-    resolution: {integrity: sha512-fIIeLOcbAB/K1kb1HBVJoiq1alHL4RCYBSo5e7HzrNkkgMggXR1Vqt/Z9JWnkfe/qdCo66Ux3QRwZioAIBdWRA==}
-    engines: {node: '>=18.0.0'}
+  beasties@0.5.1:
+    resolution: {integrity: sha512-7zL5Vwme8+RoQRfOHK3QGemC4OtmO3bERHm+G6zUFHT34NmNuiZ2Fw1LoSF7x4Tmlfym2XDv/cyCghc0M4/x6A==}
+    engines: {node: '>=20.19.0'}
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
@@ -4446,8 +4449,9 @@ packages:
   bonjour-service@1.4.4:
     resolution: {integrity: sha512-jCZcVv7eoc4QesRscwEZtSROBen+6LpKAmBIsQYQrsAeVHLyMXWX/t6eIV5KiRZYNUBl8eVqImEEMQ8L5+c/Kw==}
 
-  boolbase@1.0.0:
-    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+  boolbase@2.0.0:
+    resolution: {integrity: sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==}
+    engines: {node: '>=20.19.0'}
 
   brace-expansion@1.1.18:
     resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
@@ -4789,16 +4793,17 @@ packages:
       webpack:
         optional: true
 
-  css-select@6.0.0:
-    resolution: {integrity: sha512-rZZVSLle8v0+EY8QAkDWrKhpgt6SA5OtHsgBnsj6ZaLb5dmDVOWUDtQitd9ydxxvEjhewNudS6eTVU7uOyzvXw==}
+  css-select@7.0.0:
+    resolution: {integrity: sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g==}
+    engines: {node: '>=20.19.0'}
 
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
-  css-what@7.0.0:
-    resolution: {integrity: sha512-wD5oz5xibMOPHzy13CyGmogB3phdvcDaB5t0W/Nr5Z2O/agcB8YwOz6e2Lsp10pNDzBoDO9nVa3RGs/2BttpHQ==}
-    engines: {node: '>= 6'}
+  css-what@8.0.0:
+    resolution: {integrity: sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw==}
+    engines: {node: '>=20.19.0'}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -4960,18 +4965,21 @@ packages:
   dom-serialize@2.2.1:
     resolution: {integrity: sha512-Yra4DbvoW7/Z6LBN560ZwXMjoNOSAN2wRsKFGc4iBeso+mpIA6qj1vfdf9HpMaKAqG6wXTy+1SYEzmNpKXOSsQ==}
 
-  dom-serializer@2.0.0:
-    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+  dom-serializer@3.1.1:
+    resolution: {integrity: sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==}
+    engines: {node: '>=20.19.0'}
 
-  domelementtype@2.3.0:
-    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+  domelementtype@3.0.0:
+    resolution: {integrity: sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==}
+    engines: {node: '>=20.19.0'}
 
-  domhandler@5.0.3:
-    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
-    engines: {node: '>= 4'}
+  domhandler@6.0.1:
+    resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
+    engines: {node: '>=20.19.0'}
 
-  domutils@3.2.2:
-    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+  domutils@4.0.2:
+    resolution: {integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==}
+    engines: {node: '>=20.19.0'}
 
   dts-resolver@3.0.0:
     resolution: {integrity: sha512-1T1f+z+4tl9XD+m+0HBgWoL/nm0bOIffyWaUuUSBlFg/86IWvfx+wjNaO/ybU0AJzG9/Mi5hBUgGV6zCmWEN7Q==}
@@ -5069,14 +5077,6 @@ packages:
   ent@2.2.2:
     resolution: {integrity: sha512-kKvD1tO6BM+oK9HzCPpUdRb4vKFQY/FPTFmurMvh6LlN68VMrdj77w8yp51/kDbpkFOS9J8w5W6zIzgM2H8/hw==}
     engines: {node: '>= 0.4'}
-
-  entities@4.5.0:
-    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
-    engines: {node: '>=0.12'}
-
-  entities@7.0.1:
-    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
-    engines: {node: '>=0.12'}
 
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
@@ -5677,8 +5677,9 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
-  htmlparser2@10.1.0:
-    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+  htmlparser2@12.0.0:
+    resolution: {integrity: sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==}
+    engines: {node: '>=20.19.0'}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -6770,8 +6771,9 @@ packages:
     resolution: {integrity: sha512-69XQh3k+dtGa1p+7RaR57IuG3rCko96xr/nUfN4yDYBXbTYICiWcOpsFKLN2GtGE9cyIljE+f1exnaYt9MvM+Q==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
-  nth-check@2.1.1:
-    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+  nth-check@3.0.1:
+    resolution: {integrity: sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ==}
+    engines: {node: '>=20.19.0'}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -12250,13 +12252,13 @@ snapshots:
 
   bcryptjs@2.4.3: {}
 
-  beasties@0.4.3:
+  beasties@0.5.1:
     dependencies:
-      css-select: 6.0.0
-      css-what: 7.0.0
-      dom-serializer: 2.0.0
-      domhandler: 5.0.3
-      htmlparser2: 10.1.0
+      css-select: 7.0.0
+      css-what: 8.0.0
+      dom-serializer: 3.1.1
+      domhandler: 6.0.1
+      htmlparser2: 12.0.0
       picocolors: 1.1.1
       postcss: 8.5.26
       postcss-media-query-parser: 0.2.3
@@ -12312,7 +12314,7 @@ snapshots:
       fast-deep-equal: 3.1.3
       multicast-dns: 7.2.5
 
-  boolbase@1.0.0: {}
+  boolbase@2.0.0: {}
 
   brace-expansion@1.1.18:
     dependencies:
@@ -12702,20 +12704,20 @@ snapshots:
     optionalDependencies:
       webpack: 5.109.2(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)(uglify-js@3.19.3)
 
-  css-select@6.0.0:
+  css-select@7.0.0:
     dependencies:
-      boolbase: 1.0.0
-      css-what: 7.0.0
-      domhandler: 5.0.3
-      domutils: 3.2.2
-      nth-check: 2.1.1
+      boolbase: 2.0.0
+      css-what: 8.0.0
+      domhandler: 6.0.1
+      domutils: 4.0.2
+      nth-check: 3.0.1
 
   css-tree@3.2.1:
     dependencies:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
 
-  css-what@7.0.0: {}
+  css-what@8.0.0: {}
 
   cssesc@3.0.0: {}
 
@@ -12850,23 +12852,23 @@ snapshots:
       extend: 3.0.2
       void-elements: 2.0.1
 
-  dom-serializer@2.0.0:
+  dom-serializer@3.1.1:
     dependencies:
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-      entities: 4.5.0
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      entities: 8.0.0
 
-  domelementtype@2.3.0: {}
+  domelementtype@3.0.0: {}
 
-  domhandler@5.0.3:
+  domhandler@6.0.1:
     dependencies:
-      domelementtype: 2.3.0
+      domelementtype: 3.0.0
 
-  domutils@3.2.2:
+  domutils@4.0.2:
     dependencies:
-      dom-serializer: 2.0.0
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
+      dom-serializer: 3.1.1
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
 
   dts-resolver@3.0.0: {}
 
@@ -12979,10 +12981,6 @@ snapshots:
       es-errors: 1.3.0
       punycode: 1.4.1
       safe-regex-test: 1.1.0
-
-  entities@4.5.0: {}
-
-  entities@7.0.1: {}
 
   entities@8.0.0: {}
 
@@ -13861,12 +13859,12 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  htmlparser2@10.1.0:
+  htmlparser2@12.0.0:
     dependencies:
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-      domutils: 3.2.2
-      entities: 7.0.1
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      domutils: 4.0.2
+      entities: 8.0.0
 
   http-cache-semantics@4.2.0: {}
 
@@ -14970,9 +14968,9 @@ snapshots:
       semver: 7.8.5
       validate-npm-package-name: 8.0.0
 
-  nth-check@2.1.1:
+  nth-check@3.0.1:
     dependencies:
-      boolbase: 1.0.0
+      boolbase: 2.0.0
 
   object-assign@4.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,8 @@ minimumReleaseAgeExclude:
   - '@ngtools/webpack'
   - '@schematics/*'
   - 'ng-packagr'
+  # TODO(alanagius): remove before merging this.
+  - 'beasties'
 overrides:
   '@angular/build': workspace:*
 packageExtensions:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,8 +24,6 @@ minimumReleaseAgeExclude:
   - '@ngtools/webpack'
   - '@schematics/*'
   - 'ng-packagr'
-  # TODO(alanagius): remove before merging this.
-  - 'beasties'
 overrides:
   '@angular/build': workspace:*
 packageExtensions:

--- a/tests/e2e/tests/build/auto-csp.ts
+++ b/tests/e2e/tests/build/auto-csp.ts
@@ -88,7 +88,7 @@ export default async function () {
   await expectFileToMatch('dist/test-project/browser/index.html', CSP_META_TAG);
 
   // Make sure if contains the critical CSS inlining CSP code.
-  await expectFileToMatch('dist/test-project/browser/index.html', 'ngCspMedia');
+  await expectFileToMatch('dist/test-project/browser/index.html', 'data-beasties-media');
 
   // Make sure that our e2e tests run to confirm that our angular project runs.
   const port = await spawnServer();

--- a/tests/e2e/tests/build/server-rendering/express-engine-csp-nonce.ts
+++ b/tests/e2e/tests/build/server-rendering/express-engine-csp-nonce.ts
@@ -101,15 +101,6 @@ export default async function () {
           throw new Error(`Expected nonce to be '{% nonce %}', but got '${nonce}'`);
         }
       }
-
-      // stylesheets should be configured to load asynchronously
-      const linkMedia = await page.$eval('link[rel="stylesheet"]', (el) =>
-        el.getAttribute('media'),
-      );
-      if (linkMedia !== 'all') {
-        throw new Error(`Expected link media to be 'all', but got '${linkMedia}'`);
-      }
-
       // Bootstrap the client side app.
       await page.evaluate('window.doBootstrap()');
 

--- a/tests/e2e/tests/build/server-rendering/express-engine-ngmodule.ts
+++ b/tests/e2e/tests/build/server-rendering/express-engine-ngmodule.ts
@@ -114,14 +114,6 @@ export default async function () {
         throw new Error('Expected server-side style to be present');
       }
 
-      // stylesheets should be configured to load asynchronously
-      const linkMedia = await page.$eval('link[rel="stylesheet"]', (el) =>
-        el.getAttribute('media'),
-      );
-      if (linkMedia !== 'all') {
-        throw new Error(`Expected link media to be 'all', but got '${linkMedia}'`);
-      }
-
       // Bootstrap the client side app.
       await page.evaluate('window.doBootstrap()');
 

--- a/tests/e2e/tests/build/server-rendering/express-engine-standalone.ts
+++ b/tests/e2e/tests/build/server-rendering/express-engine-standalone.ts
@@ -80,14 +80,6 @@ export default async function () {
         throw new Error('Expected server-side style to be present');
       }
 
-      // stylesheets should be configured to load asynchronously
-      const linkMedia = await page.$eval('link[rel="stylesheet"]', (el) =>
-        el.getAttribute('media'),
-      );
-      if (linkMedia !== 'all') {
-        throw new Error(`Expected link media to be 'all', but got '${linkMedia}'`);
-      }
-
       // Bootstrap the client side app.
       await page.evaluate('window.doBootstrap()');
 


### PR DESCRIPTION
Updates Beasties to version 0.5.1 and simplifies the inline critical CSS implementation in @angular/build and @angular/ssr by using Beasties' native `preload: 'media-script'` and `nonce` callback support.

Additionally, refactors `inlineCriticalCss` in @angular/build into a standalone function and relocates `InlineCriticalCssProcessor` into @angular-devkit/build-angular for Webpack-based builders.