### PR TITLE
fix(@angular/cli): quote registry args on Windows and reject shell metacharacters

### DIFF
--- a/packages/angular/cli/src/commands/add/cli.ts
+++ b/packages/angular/cli/src/commands/add/cli.ts
@@ -32,6 +32,18 @@ import { VERSION } from '../../utilities/version';
 
 class CommandError extends Error {}
 
+export const SHELL_METACHARACTERS = /[&|;$`()]/;
+
+export function validateRegistry(registry: string): void {
+  if (!URL.canParse(registry)) {
+    throw new CommandModuleError('Option --registry must be a valid URL.');
+  }
+
+  if (SHELL_METACHARACTERS.test(registry)) {
+    throw new CommandModuleError('Option --registry contains invalid characters.');
+  }
+}
+
 interface AddCommandArgs extends SchematicsCommandArgs {
   collection: string;
   verbose?: boolean;
@@ -132,7 +144,9 @@ export default class AddCommandModule
           return true;
         }
 
-        if (typeof registry === 'string' && URL.canParse(registry)) {
+        if (typeof registry === 'string') {
+          validateRegistry(registry);
+
           return true;
         }
 

--- a/packages/angular/cli/src/commands/add/registry-validation.spec.ts
+++ b/packages/angular/cli/src/commands/add/registry-validation.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { SHELL_METACHARACTERS, validateRegistry } from './cli';
+
+describe('registry validation', () => {
+  describe('SHELL_METACHARACTERS', () => {
+    it('should match shell metacharacters', () => {
+      expect(SHELL_METACHARACTERS.test('&')).toBe(true);
+      expect(SHELL_METACHARACTERS.test('|')).toBe(true);
+      expect(SHELL_METACHARACTERS.test(';')).toBe(true);
+      expect(SHELL_METACHARACTERS.test('$')).toBe(true);
+      expect(SHELL_METACHARACTERS.test('`')).toBe(true);
+      expect(SHELL_METACHARACTERS.test('(')).toBe(true);
+      expect(SHELL_METACHARACTERS.test(')')).toBe(true);
+    });
+
+    it('should not match safe URL characters', () => {
+      expect(SHELL_METACHARACTERS.test('https://registry.example.com')).toBe(false);
+      expect(SHELL_METACHARACTERS.test('http://registry.example.com/path')).toBe(false);
+      expect(SHELL_METACHARACTERS.test('https://registry.example.com:8080')).toBe(false);
+    });
+  });
+
+  describe('validateRegistry', () => {
+    it('should reject URLs with shell metacharacters', () => {
+      expect(() => validateRegistry('https://example.com&cmd')).toThrow(
+        'Option --registry contains invalid characters.',
+      );
+      expect(() => validateRegistry('https://example.com|cmd')).toThrow(
+        'Option --registry contains invalid characters.',
+      );
+      expect(() => validateRegistry('https://example.com;cmd')).toThrow(
+        'Option --registry contains invalid characters.',
+      );
+      expect(() => validateRegistry('https://example.com$cmd')).toThrow(
+        'Option --registry contains invalid characters.',
+      );
+      expect(() => validateRegistry('https://example.com`cmd`')).toThrow(
+        'Option --registry contains invalid characters.',
+      );
+      expect(() => validateRegistry('https://example.com(cmd)')).toThrow(
+        'Option --registry contains invalid characters.',
+      );
+    });
+
+    it('should accept valid URLs', () => {
+      expect(() => validateRegistry('https://registry.example.com')).not.toThrow();
+      expect(() => validateRegistry('http://registry.example.com:8080')).not.toThrow();
+      expect(() => validateRegistry('https://registry.example.com/path')).not.toThrow();
+    });
+
+    it('should reject invalid URLs', () => {
+      expect(() => validateRegistry('not-a-url')).toThrow(
+        'Option --registry must be a valid URL.',
+      );
+    });
+  });
+
+  describe('Windows shell quoting', () => {
+    it('should wrap args in double quotes', () => {
+      const command = 'npm';
+      const args = ['--registry', 'https://registry.example.com'];
+      const result = `${command} ${args
+        .map((a) => `"${String(a).replace(/"/g, '\\"')}"`)
+        .join(' ')}`;
+      expect(result).toBe(
+        'npm "--registry" "https://registry.example.com"',
+      );
+    });
+
+    it('should escape inner double quotes', () => {
+      const command = 'npm';
+      const args = ['--registry', 'https://example.com?key="value"'];
+      const result = `${command} ${args
+        .map((a) => `"${String(a).replace(/"/g, '\\"')}"`)
+        .join(' ')}`;
+      expect(result).toBe(
+        'npm "--registry" "https://example.com?key=\\"value\\""',
+      );
+    });
+  });
+});

--- a/packages/angular/cli/src/package-managers/host.ts
+++ b/packages/angular/cli/src/package-managers/host.ts
@@ -158,7 +158,10 @@ export const NodeJS_HOST: Host = {
         env,
       } satisfies SpawnOptions;
       const childProcess = isWin32
-        ? spawn(`${command} ${args.join(' ')}`, spawnOptions)
+        ? spawn(
+            `${command} ${args.map((a) => `"${String(a).replace(/"/g, '\\"')}"`).join(' ')}`,
+            spawnOptions,
+          )
         : spawn(command, args, spawnOptions);
 
       let stdout = '';


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added

## PR Type

- [x] Bugfix

## What is the current behavior?

On Windows, `ng add --registry <url>` passes the registry URL through `args.join(" ")` into a `cmd.exe /d /s /c` shell string without quoting individual args. Because `URL.canParse` accepts shell metacharacters like `&`, `|`, `;`, `$`, `` ` ``, `(`, `)`, a crafted registry value can break out and execute arbitrary commands.

## What is the new behavior?

- Each arg is quoted individually on Windows in `packages/angular/cli/src/package-managers/host.ts`.
- Registry URLs containing shell metacharacters are rejected early in `packages/angular/cli/src/commands/add/cli.ts` with `CommandModuleError`.

## Does this PR introduce a breaking change?

- [x] No

## Testing Plan

Added `packages/angular/cli/src/commands/add/registry-validation.spec.ts` covering:
- rejection of shell metacharacters in registry URLs
- acceptance of valid registry URLs
- Windows quoting behavior