### PR TITLE
fix(@angular/build): avoid pure comment pattern in oxc transform

### DIFF
--- a/packages/angular/build/src/tools/oxc/oxc-transform.ts
+++ b/packages/angular/build/src/tools/oxc/oxc-transform.ts
@@ -599,7 +599,7 @@ export function transform(filename: string, code: string, options: OxcTransformO
           source.appendRight(classNode.start, `let ${classIdName} = /*#__PURE__*/ (() => {\n`);
           source.appendLeft(lastStatement.end, `\nreturn ${classIdName};\n})();`);
         } else if (isVariableClass) {
-          // Wrap class inside init: `/*#__PURE__*/ (() => { let ClassName = class ClassName {}; return ClassName; })()`
+          // 2. Wrap class inside init: `(() => { let ClassName = class ClassName {}; return ClassName; })()`
           source.appendRight(classNode.start, `/*#__PURE__*/ (() => {\nlet ${classIdName} = `);
           const terminator = activeWrapPaths.length === 0 ? ';' : '';
           const iifeClosing = activeWrapPaths.length === 0 ? '})()' : '})();';


### PR DESCRIPTION
In Bun 1.4.0, single-line comments containing `/*#__PURE__*/` immediately preceding a call expression cause Bun's lexer/transpiler to interpret the call as pure and drop it during dead code elimination when its return value is unused.

Sanitizing the comment avoids triggering this upstream Bun bug.

Fixes #33973