### PR TITLE
test: update e2e global npm version to 12.0.2

### DIFF
--- a/tests/e2e/setup/001-npm-sandbox.ts
+++ b/tests/e2e/setup/001-npm-sandbox.ts
@@ -35,6 +35,9 @@ export default async function () {
     process.env['NPM_CONFIG_legacy_peer_deps'] = 'true';
   }
 
+  // Allow github tarballs consumption.
+  process.env['NPM_CONFIG_allow_remote'] = 'all';
+
   // Configure the registry and prefix used within the test sandbox via rc files
   await writeFile(npmrc, `registry=${npmRegistry}\nprefix=${npmModulesPrefix}`);
   await writeFile(yarnrc, `registry ${npmRegistry}\nprefix ${yarnModulesPrefix}`);

--- a/tests/e2e/setup/100-global-cli.ts
+++ b/tests/e2e/setup/100-global-cli.ts
@@ -3,7 +3,7 @@ import { getActivePackageManager } from '../utils/packages';
 import { globalNpm } from '../utils/process';
 
 const PACKAGE_MANAGER_VERSION = {
-  'npm': '10.8.1',
+  'npm': '12.0.2',
   'yarn': '1.22.22',
   'pnpm': '10.17.1',
   'bun': '1.3.2',


### PR DESCRIPTION
Updates the npm version installed in the e2e test sandbox to 12.0.2 to avoid an upstream npm 10 Arborist crash when resolving optional peer dependencies (such as during Vitest installation).