### PR TITLE
fix(@angular/build): encode script type in auto-CSP loader

### DIFF
--- a/packages/angular/build/src/utils/index-file/auto-csp.ts
+++ b/packages/angular/build/src/utils/index-file/auto-csp.ts
@@ -270,8 +270,10 @@ function createLoaderScript(srcList: SrcScriptTag[], enableTrustedTypes = false)
     .map((s) => {
       // URI encoding means value can't escape string, JS, or HTML context.
       const srcAttr = encodeURI(s.src).replaceAll("'", "\\'");
-      // Can only be 'module' or a JS MIME type or an empty string.
-      const typeAttr = s.type ? "'" + s.type + "'" : "''";
+      // 'module', a JS MIME type, or an empty string. A JS MIME type may carry
+      // parameters after a ';', which isJavascriptMimeType() does not constrain,
+      // so encode this the same way as integrity and crossOrigin below.
+      const typeAttr = JSON.stringify(s.type ?? '').replaceAll('<', '\\u003c');
       const asyncAttr = !!s.async;
       const deferAttr = !!s.defer;
       const integrityAttr = JSON.stringify(s.integrity ?? null).replaceAll('<', '\\u003c');

--- a/packages/angular/build/src/utils/index-file/auto-csp_spec.ts
+++ b/packages/angular/build/src/utils/index-file/auto-csp_spec.ts
@@ -58,7 +58,7 @@ describe('auto-csp', () => {
     const csps = getCsps(result);
     expect(csps).toHaveSize(1);
     expect(csps[0]).toMatch(CSP_SINGLE_HASH_REGEX);
-    expect(result).toContain(`const scripts = [['./main.js', '', false, false, null, null]];`);
+    expect(result).toContain(`const scripts = [['./main.js', "", false, false, null, null]];`);
   });
 
   it('should rewrite a single source script in place', async () => {
@@ -78,7 +78,7 @@ describe('auto-csp', () => {
     expect(csps[0]).toMatch(CSP_SINGLE_HASH_REGEX);
     // Our loader script appears after the HTML text content.
     expect(result).toMatch(
-      /Some text<\/div>\s*<script>\(\(\) => {\s*const scripts = \[\['.\/main.js', '', false, false, null, null\]\];/,
+      /Some text<\/div>\s*<script>\(\(\) => {\s*const scripts = \[\['.\/main.js', "", false, false, null, null\]\];/,
     );
   });
 
@@ -103,7 +103,7 @@ describe('auto-csp', () => {
     expect(csps[0]).toMatch(CSP_TWO_HASHES_REGEX);
     expect(result).toContain(
       // eslint-disable-next-line max-len
-      `const scripts = [['./main1.js', '', false, false, null, null],['./main2.js', '', true, false, null, null],['./main3.js', 'module', true, true, null, null]];`,
+      `const scripts = [['./main1.js', "", false, false, null, null],['./main2.js', "", true, false, null, null],['./main3.js', "module", true, true, null, null]];`,
     );
     // Head loader script is in the head.
     expect(result).toContain(`</script></head>`);
@@ -166,12 +166,12 @@ describe('auto-csp', () => {
     // Loader script for main.js and main2.js appear after 'foo' and before 'bar'.
     expect(result).toMatch(
       // eslint-disable-next-line max-len
-      /console.log\('foo'\);<\/script>\s*<script>\(\(\) => {\s*const scripts = \[\['.\/main.js', '', false, false, null, null\],\['.\/main2.js', '', false, false, null, null\]\];[\s\S]*console.log\('bar'\);/,
+      /console.log\('foo'\);<\/script>\s*<script>\(\(\) => {\s*const scripts = \[\['.\/main.js', "", false, false, null, null\],\['.\/main2.js', "", false, false, null, null\]\];[\s\S]*console.log\('bar'\);/,
     );
     // Loader script for main3.js and main4.js appear after 'bar'.
     expect(result).toMatch(
       // eslint-disable-next-line max-len
-      /console.log\('bar'\);<\/script>\s*<script>\(\(\) => {\s*const scripts = \[\['.\/main3.js', '', false, false, null, null\],\['.\/main4.js', '', false, false, null, null\]\];/,
+      /console.log\('bar'\);<\/script>\s*<script>\(\(\) => {\s*const scripts = \[\['.\/main3.js', "", false, false, null, null\],\['.\/main4.js', "", false, false, null, null\]\];/,
     );
     // Exactly 4 scripts should be left.
     expect(Array.from(result.matchAll(/<script>/gi)).length).toEqual(4);
@@ -238,7 +238,7 @@ describe('auto-csp', () => {
     expect(csps).toHaveSize(1);
     expect(csps[0]).toMatch(CSP_SINGLE_HASH_REGEX);
     expect(result).toContain(
-      `const scripts = [['./main.js', 'module', false, false, "sha384-xyz123", "anonymous"]];`,
+      `const scripts = [['./main.js', "module", false, false, "sha384-xyz123", "anonymous"]];`,
     );
   });
 
@@ -258,7 +258,7 @@ describe('auto-csp', () => {
     expect(csps).toHaveSize(1);
     expect(csps[0]).toMatch(CSP_SINGLE_HASH_REGEX);
     expect(result).toContain(
-      `const scripts = [['./main.js', '', false, false, "sha384-xyz123", null]];`,
+      `const scripts = [['./main.js', "", false, false, "sha384-xyz123", null]];`,
     );
   });
 
@@ -278,7 +278,45 @@ describe('auto-csp', () => {
     expect(csps).toHaveSize(1);
     expect(csps[0]).toMatch(CSP_SINGLE_HASH_REGEX);
     expect(result).toContain(
-      `const scripts = [['./main.js', '', false, false, null, "anonymous"]];`,
+      `const scripts = [['./main.js', "", false, false, null, "anonymous"]];`,
     );
+  });
+
+  it('should encode a script type that carries MIME parameters', async () => {
+    const result = await autoCsp(`
+      <html>
+        <head>
+        </head>
+        <body>
+          <script src="./main.js" type="text/javascript;']];var x=1;var junk=[['a','b"></script>
+        </body>
+      </html>
+    `);
+
+    const csps = getCsps(result);
+    expect(csps).toHaveSize(1);
+    expect(csps[0]).toMatch(CSP_SINGLE_HASH_REGEX);
+    // The type stays inside its string literal.
+    expect(result).toContain(
+      `const scripts = [['./main.js', "text/javascript;']];var x=1;var junk=[['a','b", false, false, null, null]];`,
+    );
+  });
+
+  it('should encode a script type that contains a closing script tag', async () => {
+    const result = await autoCsp(`
+      <html>
+        <head>
+        </head>
+        <body>
+          <script src="./main.js" type="text/javascript;</script><script>x</script>"></script>
+        </body>
+      </html>
+    `);
+
+    const csps = getCsps(result);
+    expect(csps).toHaveSize(1);
+    expect(csps[0]).toMatch(CSP_SINGLE_HASH_REGEX);
+    // Only the loader element is emitted.
+    expect(Array.from(result.matchAll(/<script/gi)).length).toEqual(1);
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: N/A

`createLoaderScript()` in the auto-CSP generator interpolates four `<script>` attributes
into the generated loader source. Three are encoded; `type` is not:

```ts
const srcAttr         = encodeURI(s.src).replaceAll("'", "\\'");
const typeAttr        = s.type ? "'" + s.type + "'" : "''";
const integrityAttr   = JSON.stringify(s.integrity ?? null).replaceAll('<', '\\u003c');
const crossOriginAttr = JSON.stringify(s.crossOrigin ?? null).replaceAll('<', '\\u003c');
```

The comment above the function gives the reason it is safe to interpolate `type` directly:

> `// Can only be 'module' or a JS MIME type or an empty string.`

That does not match the check the value actually passes. The gate is `isJavascriptMimeType()`:

```ts
function isJavascriptMimeType(mimeType: string): boolean {
  return mimeType.split(';')[0] === 'text/javascript';
}
```

Only the part before the first `;` is compared — correctly, since that mirrors how a browser
matches a script's MIME essence — so a value such as `type="text/javascript;<parameters>"`
passes the gate and reaches `typeAttr` unchanged. `type` is validated for the purpose of
deciding whether a script should be dynamically loaded, and then embedded into a JavaScript
string literal as though that validation had also constrained its characters.

Two consequences follow from `index.html` content alone:

* a `'` in the value closes the string literal, so the rest of the attribute becomes
  statements in the loader source. The generated loader is hashed into the emitted CSP, so
  such statements become part of the policy's trusted script hash.
* a `</script>` in the value terminates the generated element, because the loader is written
  with `rewriter.emitRaw(...)`. The `.replaceAll('<', '\\u003c')` on the two neighbouring
  attributes exists to prevent exactly this.

## What is the new behavior?

`type` is encoded the same way as `integrity` and `crossOrigin`:

```ts
const typeAttr = JSON.stringify(s.type ?? '').replaceAll('<', '\\u003c');
```

Both branches of `createLoaderScript()` (Trusted Types enabled and disabled) share the same
`srcListFormatted`, so this single change covers both.

Two specs are added, one per case above. Existing specs that spell out the loader tuple are
updated for the quote style `JSON.stringify` produces (`''` becomes `""`).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

The only observable difference is the quote style of the `type` slot in the generated loader,
which is internal to the emitted script.

## Other information

This is a defense-in-depth change. I was not able to identify an attacker-controlled path to
the `type` attribute that does not already require control over the application's build input:
`autoCsp()` is reached only from `tools/esbuild/index-html-generator.ts`, once per build, over
`index.html`, and the `<script>` tags the CLI generates itself carry a literal `type="module"`
(`augment-index-html.ts`). Filing it as an ordinary fix for that reason.