### PR TITLE
perf(@angular/build): read rendered module length once per module in chunk optimizer

### DIFF
--- a/packages/angular/build/src/builders/application/chunk-optimizer.ts
+++ b/packages/angular/build/src/builders/application/chunk-optimizer.ts
@@ -113,9 +113,6 @@ function bundleOutputToEsbuildMetafile(
           continue;
         }
 
-        // Read the rendered length once per module. The value is a lazy getter on the bundler's
-        // rendered module object that transfers the entire module code from native memory on each
-        // access, which is prohibitively expensive when repeated for every input of a large chunk.
         const { renderedLength } = renderedModule;
 
         for (const [originalInputPath, originalInputInfo] of Object.entries(

--- a/packages/angular/build/src/builders/application/chunk-optimizer.ts
+++ b/packages/angular/build/src/builders/application/chunk-optimizer.ts
@@ -113,11 +113,16 @@ function bundleOutputToEsbuildMetafile(
           continue;
         }
 
+        // Read the rendered length once per module. The value is a lazy getter on the bundler's
+        // rendered module object that transfers the entire module code from native memory on each
+        // access, which is prohibitively expensive when repeated for every input of a large chunk.
+        const { renderedLength } = renderedModule;
+
         for (const [originalInputPath, originalInputInfo] of Object.entries(
           originalOutputEntry.inputs,
         )) {
           const proportion = originalInputInfo.bytesInOutput / totalOriginalBytesInModule;
-          const newBytesInOutput = Math.floor(renderedModule.renderedLength * proportion);
+          const newBytesInOutput = Math.floor(renderedLength * proportion);
 
           const existing = newOutputInputs[originalInputPath];
           if (existing) {

--- a/packages/angular/build/src/builders/application/chunk-optimizer.ts
+++ b/packages/angular/build/src/builders/application/chunk-optimizer.ts
@@ -113,8 +113,10 @@ function bundleOutputToEsbuildMetafile(
           continue;
         }
 
+        // Read once per module: in Rolldown, `renderedLength` is an uncached getter that
+        // copies the entire module code across the NAPI bridge on each access.
         const { renderedLength } = renderedModule;
-
+        
         for (const [originalInputPath, originalInputInfo] of Object.entries(
           originalOutputEntry.inputs,
         )) {


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

No test added: the change is a pure performance fix with no behavioral difference. The generated metafile is byte-identical before and after (verified by replaying `optimizeChunks` on a dumped esbuild result and comparing the serialized metafile and `initialFiles`). Happy to add a spec if you can point me at a suitable harness for `chunk-optimizer`.

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: performance

## What is the current behavior?

Issue Number: #34044

In `bundleOutputToEsbuildMetafile`, `renderedModule.renderedLength` is read inside the loop over each module's original inputs. On rolldown's rendered module object that property is a lazy getter (`bindingRenderedModule.code?.length`) which transfers the entire module code from native memory on every access. Because each "module" in the chunk optimizer is a whole esbuild output chunk, a 17 MB main chunk with 3,588 inputs performs 3,588 copies of a 17 MB string (~62 GB). On the application in the linked issue this is ~157 s out of a ~161 s `OPTIMIZE_CHUNKS` phase, while the rolldown bundling itself takes ~3 s. Rolldown also emits a misleading `[PLUGIN_TIMINGS]` warning about the `angular-bundle` plugin as a side effect.

## What is the new behavior?

The rendered length is read once per module before iterating its inputs. Measured on the same application and machine (production configuration, `sourceMap: true`):

| | Before | After |
|---|---|---|
| `DURATION[OPTIMIZE_CHUNKS]` | 179 s | 4 s |
| Total `ng build` | 234 s | 55 s |

Output files are byte-identical (same file list, same SHA-256 for every JS and CSS file).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

A follow-up on the rolldown side could cache `code` in `transformToRenderedModule`, but this hoist removes the cost regardless of the rolldown version. The `[PLUGIN_TIMINGS]` warning still fires after the fix because rolldown compares plugin time against a near-zero link stage when the inputs are a few hundred pre-bundled chunks; passing `checks: { pluginTimings: false }` to `rolldown()` in the optimizer would silence it, but that is left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
