### PR TITLE
fix(@angular/build): disable strictPort when port 0 is used in dev-server

### DIFF
--- a/packages/angular/build/src/builders/dev-server/options.ts
+++ b/packages/angular/build/src/builders/dev-server/options.ts
@@ -13,7 +13,12 @@ import { normalizeCacheOptions } from '../../utils/normalize-cache';
 import { ApplicationBuilderOptions } from '../application';
 import { Schema as DevServerOptions } from './schema';
 
-export type NormalizedDevServerOptions = Awaited<ReturnType<typeof normalizeOptions>>;
+export type NormalizedDevServerOptions = Omit<
+  Awaited<ReturnType<typeof normalizeOptions>>,
+  'strictPort'
+> & {
+  strictPort?: boolean;
+};
 
 /**
  * Normalize the user provided options by creating full paths for all path based options
@@ -122,6 +127,7 @@ export async function normalizeOptions(
     buildTarget,
     host: host ?? 'localhost',
     port,
+    strictPort: port !== 0,
     poll,
     open,
     verbose,

--- a/packages/angular/build/src/builders/dev-server/tests/behavior/build-errors_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/behavior/build-errors_spec.ts
@@ -38,8 +38,8 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
             expectNoLog(logs, 'Unexpected character "EOF"');
           },
         ],
-        { outputLogsOnFailure: false },
+        { outputLogsOnFailure: false, timeout: 60_000 },
       );
-    });
+    }, 90_000);
   });
 });

--- a/packages/angular/build/src/builders/dev-server/vite/server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite/server.ts
@@ -56,7 +56,7 @@ async function createServerConfig(
       ssrFiles,
     },
     port: serverOptions.port,
-    strictPort: true,
+    strictPort: serverOptions.strictPort ?? true,
     host: serverOptions.host,
     open: serverOptions.open,
     allowedHosts: serverOptions.allowedHosts,

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/serve-live-reload-proxies_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/serve-live-reload-proxies_spec.ts
@@ -101,10 +101,31 @@ async function createProxy(target: string, secure: boolean, ws = true): Promise<
     },
   }).listen(proxyPort);
 
+  server.on('error', () => {
+    // Ignore proxy connection errors that occur when the browser reloads or disconnects.
+  });
+
   return {
     server,
     url: `${secure ? 'https' : 'http'}://localhost:${proxyPort}`,
   };
+}
+
+async function waitForAppLiveReload(page: Page): Promise<void> {
+  const startTime = Date.now();
+  while (Date.now() - startTime < 30_000) {
+    try {
+      const text = await page.evaluate(() => document.querySelector('p')?.innerText);
+      if (text === 'app-live-reload') {
+        return;
+      }
+    } catch {
+      // Ignore execution context destruction errors during page navigation.
+    }
+    await setTimeoutPromise(100);
+  }
+
+  throw new Error('Timed out waiting for page to reload with updated text.');
 }
 
 async function goToPageAndWaitForWS(page: Page, url: string): Promise<void> {
@@ -203,8 +224,7 @@ describeServeBuilder(
             async ({ result }) => {
               expect(result?.success).toBeTrue();
 
-              // Wait for page to reload.
-              await setTimeoutPromise(500);
+              await waitForAppLiveReload(page);
 
               const innerText = await page.evaluate(() => document.querySelector('p').innerText);
               expect(innerText).toBe('app-live-reload');
@@ -238,8 +258,7 @@ describeServeBuilder(
                 async ({ result }) => {
                   expect(result?.success).toBeTrue();
 
-                  // Wait for page to reload.
-                  await setTimeoutPromise(500);
+                  await waitForAppLiveReload(page);
 
                   const innerText = await page.evaluate(
                     () => document.querySelector('p').innerText,
@@ -281,8 +300,7 @@ describeServeBuilder(
                 async ({ result }) => {
                   expect(result?.success).toBeTrue();
 
-                  // Wait for page to reload.
-                  await setTimeoutPromise(500);
+                  await waitForAppLiveReload(page);
 
                   const innerText = await page.evaluate(
                     () => document.querySelector('p').innerText,


### PR DESCRIPTION


This PR addresses flaky test failures identified in the dev-server test suites:

**`@angular/build` dev-server port collision**:
   - When `port: 0` is configured, an ephemeral port is requested. Previously `strictPort: true` was hardcoded in the Vite configuration, which caused dev-server restarts or rebuild error detection runs to fail if the ephemeral port was occupied before Vite bound to it.
   - Sets `strictPort: port !== 0` (falling back to an open port when `port: 0` is specified).

**`@angular-devkit/build-angular` live-reload proxy test flakiness**:
   - In `serve-live-reload-proxies_spec.ts`, the proxy HTTP server lacked an error handler, causing unhandled `ECONNRESET` errors when the headless browser disconnected or reloaded.
   - Replaced fixed `500ms` timeouts with a `waitForAppLiveReload` polling helper that tolerates execution context destructions during live-reload navigation.