### PR TITLE
feat(@angular/cli): add aube as supported package manager

### DIFF
--- a/packages/angular/cli/lib/config/workspace-schema.json
+++ b/packages/angular/cli/lib/config/workspace-schema.json
@@ -47,7 +47,7 @@
         "packageManager": {
           "description": "Specify which package manager tool to use.",
           "type": "string",
-          "enum": ["npm", "yarn", "pnpm", "bun"]
+          "enum": ["npm", "yarn", "pnpm", "bun", "aube"]
         },
         "warnings": {
           "description": "Control CLI specific console warnings",
@@ -101,7 +101,7 @@
         "packageManager": {
           "description": "Specify which package manager tool to use.",
           "type": "string",
-          "enum": ["npm", "yarn", "pnpm", "bun"]
+          "enum": ["npm", "yarn", "pnpm", "bun", "aube"]
         },
         "warnings": {
           "description": "Control CLI specific console warnings",

--- a/packages/angular/cli/src/package-managers/discovery_spec.ts
+++ b/packages/angular/cli/src/package-managers/discovery_spec.ts
@@ -108,4 +108,12 @@ describe('discover', () => {
     const result = await discover(host, '/project');
     expect(result).toBe('bun');
   });
+
+  it('should discover the aube lockfile', async () => {
+    const host = new MockHost({
+      '/project': ['aube-lock.yaml'],
+    });
+    const result = await discover(host, '/project');
+    expect(result).toBe('aube');
+  });
 });

--- a/packages/angular/cli/src/package-managers/package-manager-descriptor.ts
+++ b/packages/angular/cli/src/package-managers/package-manager-descriptor.ts
@@ -281,6 +281,31 @@ export const SUPPORTED_PACKAGE_MANAGERS = {
     },
     isNotFound: isKnownNotFound,
   },
+  aube: {
+    binary: 'aube',
+    lockfiles: ['aube-lock.yaml'],
+    addCommand: 'add',
+    installCommand: ['install'],
+    forceFlag: '--force',
+    saveExactFlag: '--save-exact',
+    saveTildeFlag: '--save-tilde',
+    saveDevFlag: '--save-dev',
+    noLockfileFlag: '', // Aube does not have a flag for this.
+    ignoreScriptsFlag: '--ignore-scripts',
+    configFiles: ['.npmrc'],
+    getRegistryOptions: (registry: string) => ({ args: ['--registry', registry] }),
+    versionCommand: ['--version'],
+    listDependenciesCommand: ['list', '--depth=0', '--json'],
+    getManifestCommand: ['view', '--json'],
+    viewCommandFieldArgFormatter: (fields) => [...fields],
+    outputParsers: {
+      listDependencies: parseNpmLikeDependencies,
+      getRegistryManifest: parseNpmLikeManifest,
+      getRegistryMetadata: parseNpmLikeMetadata,
+      getError: parseNpmLikeError,
+    },
+    isNotFound: isKnownNotFound,
+  },
   bun: {
     binary: 'bun',
     lockfiles: ['bun.lockb', 'bun.lock'],
@@ -347,6 +372,7 @@ export const SUPPORTED_PACKAGE_MANAGERS = {
 export const PACKAGE_MANAGER_PRECEDENCE: readonly PackageManagerName[] = [
   'pnpm',
   'yarn',
+  'aube',
   'bun',
   'npm',
 ];

--- a/packages/angular/create/src/index.ts
+++ b/packages/angular/create/src/index.ts
@@ -17,7 +17,7 @@ const hasPackageManagerArg = args.some((a) => a.startsWith('--package-manager'))
 if (!hasPackageManagerArg) {
   // Ex: yarn/1.22.18 npm/? node/v16.15.1 linux x64
   const packageManager = process.env['npm_config_user_agent']?.split('/')[0];
-  if (packageManager && ['npm', 'pnpm', 'yarn', 'bun'].includes(packageManager)) {
+  if (packageManager && ['npm', 'pnpm', 'yarn', 'bun', 'aube'].includes(packageManager)) {
     args.push('--package-manager', packageManager);
   }
 }

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -132,7 +132,7 @@
     "packageManager": {
       "description": "The package manager used to install dependencies.",
       "type": "string",
-      "enum": ["npm", "yarn", "pnpm", "bun"]
+      "enum": ["npm", "yarn", "pnpm", "bun", "aube"]
     },
     "standalone": {
       "description": "Creates an application based upon the standalone API, without NgModules.",

--- a/packages/schematics/angular/workspace/schema.json
+++ b/packages/schematics/angular/workspace/schema.json
@@ -40,7 +40,7 @@
     "packageManager": {
       "description": "The package manager to use for installing dependencies.",
       "type": "string",
-      "enum": ["npm", "yarn", "pnpm", "bun"],
+      "enum": ["npm", "yarn", "pnpm", "bun", "aube"],
       "$default": {
         "$source": "packageManager"
       }

--- a/tests/e2e/utils/packages.ts
+++ b/tests/e2e/utils/packages.ts
@@ -1,5 +1,5 @@
 import { getGlobalVariable } from './env';
-import { ProcessOutput, silentBun, silentNpm, silentPnpm, silentYarn } from './process';
+import { ProcessOutput, silentAube, silentBun, silentNpm, silentPnpm, silentYarn } from './process';
 
 export interface PkgInfo {
   readonly name: string;
@@ -7,7 +7,7 @@ export interface PkgInfo {
   readonly path: string;
 }
 
-export function getActivePackageManager(): 'npm' | 'yarn' | 'bun' | 'pnpm' {
+export function getActivePackageManager(): 'npm' | 'yarn' | 'bun' | 'pnpm' | 'aube' {
   return getGlobalVariable('package-manager');
 }
 
@@ -29,6 +29,9 @@ export async function installWorkspacePackages(options?: { force?: boolean }): P
     case 'bun':
       await silentBun('install');
       break;
+    case 'aube':
+      await silentAube('install');
+      break;
   }
 }
 
@@ -43,6 +46,8 @@ export function installPackage(specifier: string, registry?: string): Promise<Pr
       return silentBun('add', specifier, ...registryOption);
     case 'pnpm':
       return silentPnpm('add', specifier, ...registryOption);
+    case 'aube':
+      return silentAube('add', specifier, ...registryOption);
   }
 }
 
@@ -60,6 +65,9 @@ export async function uninstallPackage(name: string): Promise<void> {
         break;
       case 'pnpm':
         await silentPnpm('remove', name);
+        break;
+      case 'aube':
+        await silentAube('remove', name);
         break;
     }
   } catch (e) {

--- a/tests/e2e/utils/process.ts
+++ b/tests/e2e/utils/process.ts
@@ -411,6 +411,10 @@ export function silentBun(...args: string[]) {
   return _exec({ silent: true }, 'bun', args);
 }
 
+export function silentAube(...args: string[]) {
+  return _exec({ silent: true }, 'aube', args);
+}
+
 export function globalNpm(args: string[], env?: NodeJS.ProcessEnv) {
   if (!process.env.LEGACY_CLI_RUNNER) {
     throw new Error(


### PR DESCRIPTION
Add support for the [aube](https://aube.sh) package manager, a Rust-based Node.js package manager that is fully compatible with the npm ecosystem.

Aube is a drop-in replacement for npm/pnpm/yarn/bun that focuses on speed, automatic installs before script execution, and cross-project package deduplication via a content-addressable store.

### Key characteristics:
- **Binary:** `aube`
- **Lockfile:** `aube-lock.yaml`
- **Commands:** `aube add`, `aube install`, `aube view --json`, `aube list --json`
- **Config:** `.npmrc` (shared with npm/pnpm)
- **JSON output:** Mirrors npm/pnpm format, so existing `parseNpmLike*` parsers are reused

### Changes:
- Add `aube` descriptor to `SUPPORTED_PACKAGE_MANAGERS` in `package-manager-descriptor.ts`
- Add `aube` to `PACKAGE_MANAGER_PRECEDENCE`
- Update workspace schema JSON (`workspace-schema.json`) — both `cliOptions` and `cliGlobalOptions`
- Update `ng-new/schema.json` and `workspace/schema.json` schematics
- Update `@angular/create` to detect aube from `npm_config_user_agent`
- Add aube lockfile discovery test
- Add aube support to e2e test utilities

### Testing:
- All existing CLI unit tests pass (`bazel test //packages/angular/cli:test` — PASSED)
- Added discovery spec test for `aube-lock.yaml`
- Tested with a new workspace and the app works fine

Closes #34057 