### PR TITLE
fix(@angular/build): use chokidar watcher when followSymlinks is enabled

### DIFF
--- a/packages/angular/build/src/tools/esbuild/watcher.ts
+++ b/packages/angular/build/src/tools/esbuild/watcher.ts
@@ -252,7 +252,7 @@ class WatcherQueue {
 }
 
 export async function createWatcher(options?: WatcherOptions): Promise<BuildWatcher> {
-  if (options?.polling) {
+  if (options?.polling || options?.followSymlinks) {
     return createChokidarWatcher(options);
   }
 

--- a/packages/angular/build/src/tools/esbuild/watcher_spec.ts
+++ b/packages/angular/build/src/tools/esbuild/watcher_spec.ts
@@ -11,6 +11,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 import {
+  type BuildWatcher,
   ChangedFiles,
   createWatcher,
   getDirectoryPath,
@@ -481,6 +482,43 @@ describe('Watcher', () => {
       expect(emitted.some((f: string) => f.includes('bundle.js'))).toBeFalse();
 
       await watcher.close();
+    }, 10000);
+
+    it('should detect changes behind a directory symlink when followSymlinks is true', async () => {
+      const externalDir = fs.realpathSync(
+        fs.mkdtempSync(path.join(os.tmpdir(), 'watcher-external-')),
+      );
+      let watcher: BuildWatcher | undefined;
+
+      try {
+        const externalTargetFile = path.join(externalDir, 'index.ts');
+        fs.writeFileSync(externalTargetFile, 'export const a = 1;');
+
+        const symlinkDir = path.join(tempDir, 'symlinked-lib');
+        fs.symlinkSync(externalDir, symlinkDir, 'junction');
+
+        const symlinkedFile = path.join(symlinkDir, 'index.ts');
+
+        watcher = await createWatcher({
+          followSymlinks: true,
+          cwd: tempDir,
+        });
+
+        watcher.add(symlinkedFile);
+        await setTimeout(150);
+
+        const iterator = watcher[Symbol.asyncIterator]();
+        const nextPromise = iterator.next();
+
+        fs.writeFileSync(externalTargetFile, 'export const a = 2;');
+
+        const result = await nextPromise;
+        expect(result.done).toBeFalsy();
+        expect(result.value?.all.some((f: string) => f.includes('index.ts'))).toBeTrue();
+      } finally {
+        await watcher?.close();
+        fs.rmSync(externalDir, { recursive: true, force: true });
+      }
     }, 10000);
   });
 });


### PR DESCRIPTION
When `preserveSymlinks` is enabled in application build options, `followSymlinks: true` is passed to `createWatcher`.

With `@parcel/watcher`, native OS directory watchers (such as FSEvents, inotify, and ReadDirectoryChangesW) do not follow directory symlinks pointing outside the workspace root. Additionally, esbuild reports watch files under their symlinked workspace paths, preventing external directory watches from attaching and causing file modifications behind the symlink to be missed.

Since `chokidar` natively traverses directory symlinks and surfaces file change events relative to the watched root, `createWatcher` now falls back to Chokidar when `followSymlinks` is enabled. This restores watch rebuild detection for symlinked directories while preserving the performance benefits of `@parcel/watcher` for standard setups.

Closes #34039