### PR TITLE
build: set verifyDepsBeforeRun to warn in pnpm workspace configuration

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,3 +57,6 @@ allowBuilds:
   puppeteer: false
   utf-8-validate: false
   webdriver-manager: true
+
+# Workaround as the default 'install' causes problems during `pnpm ng-dev pr merge` as the lockfile is updated.
+verifyDepsBeforeRun: warn


### PR DESCRIPTION
The default 'install' setting causes unexpected lockfile updates during `pnpm ng-dev pr merge`. Setting it to `warn` prevents automatic dependency installation while still alerting if dependencies are out of sync.