### PR TITLE
perf(@angular/cli): skip eager yargs help message formatting during command execution

### DIFF
--- a/packages/angular/cli/src/command-builder/command-runner.ts
+++ b/packages/angular/cli/src/command-builder/command-runner.ts
@@ -102,10 +102,16 @@ export async function runCommand(args: string[], logger: logging.Logger): Promis
     addCommandModuleToYargs(CommandModule, context);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const usageInstance = (localYargs as any).getInternalMethods().getUsageInstance();
   if (jsonHelp) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const usageInstance = (localYargs as any).getInternalMethods().getUsageInstance();
     usageInstance.help = () => jsonHelpUsage(localYargs);
+  } else if (!help) {
+    // Yargs eagerly caches and formats the full command help (including table wrapping
+    // and Unicode string-width calculations via cliui) whenever a subcommand executes,
+    // in case the command fails. Because showHelpOnFail is disabled, this formatted text
+    // is never used. Skipping this work avoids non-trivial synchronous overhead during startup.
+    usageInstance.cacheHelpMessage = () => {};
   }
 
   // Add default command to support version option when no subcommand is specified


### PR DESCRIPTION
Whenever a subcommand is invoked, Yargs eagerly formats and caches the complete command help message via its internal cacheHelpMessage() method. This involves assembling layout tables with cliui, wrapping text with wrap-ansi, and evaluating Unicode string widths with string-width, even when the command succeeds and help output is never requested.

Because the Angular CLI explicitly configures showHelpOnFail(false) and handles errors via a custom failure handler, this cached help message is never consumed in either the success or failure paths. Overriding cacheHelpMessage to a no-op when neither --help nor --json-help is requested eliminates roughly 15ms to 20ms of synchronous formatting overhead from the CLI startup path.